### PR TITLE
Prepare CHANGELOG for v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added test helper methods in `RequestConverterTest` for temp file cleanup and request creation ([#88](https://github.com/crazy-goat/workerman-bundle/issues/88))
-  - Added `setUp()`/`tearDown()` for automatic temp file cleanup
+  - Added `tearDown()` for automatic temp file cleanup
   - Added `createTempFile()` helper method
   - Added `createRequestWithFiles()` helper method
   - Reduces test boilerplate and improves readability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added test helper methods in `RequestConverterTest` for temp file cleanup and request creation ([#88](https://github.com/crazy-goat/workerman-bundle/issues/88))
+  - Added `setUp()`/`tearDown()` for automatic temp file cleanup
+  - Added `createTempFile()` helper method
+  - Added `createRequestWithFiles()` helper method
+  - Reduces test boilerplate and improves readability
+
 - Added `QUERY_STRING` to server bag in `RequestConverter` ([#66](https://github.com/crazy-goat/workerman-bundle/issues/66))
   - Enables `$request->server->get('QUERY_STRING')` to return query string
   - Enables Symfony's `getQueryString()` to work correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-05
+
 ### Added
 
 - Added test helper methods in `RequestConverterTest` for temp file cleanup and request creation ([#88](https://github.com/crazy-goat/workerman-bundle/issues/88))

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -26,6 +26,7 @@ final class RequestConverterTest extends TestCase
 
         parent::tearDown();
     }
+
     public function testValidFileStructureIsAccepted(): void
     {
         $buffer = $this->createMultipartRequest(
@@ -424,7 +425,9 @@ final class RequestConverterTest extends TestCase
         if ($tmpFile === false) {
             throw new \RuntimeException('Failed to create temp file');
         }
-        file_put_contents($tmpFile, $content);
+        if (file_put_contents($tmpFile, $content) === false) {
+            throw new \RuntimeException('Failed to write to temp file');
+        }
         $this->tempFiles[] = $tmpFile;
 
         return $tmpFile;
@@ -437,6 +440,8 @@ final class RequestConverterTest extends TestCase
     {
         $rawRequest = new Request($buffer);
 
+        // Workerman's Request does not expose a public API for file injection.
+        // Reflection is required to simulate malformed file uploads for testing.
         $reflection = new \ReflectionClass($rawRequest);
         $dataProperty = $reflection->getProperty('data');
         $dataProperty->setValue($rawRequest, ['files' => $files]);

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -14,6 +14,18 @@ use PHPUnit\Framework\TestCase;
  */
 final class RequestConverterTest extends TestCase
 {
+    /** @var string[] */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
     public function testValidFileStructureIsAccepted(): void
     {
         $buffer = $this->createMultipartRequest(
@@ -116,37 +128,17 @@ final class RequestConverterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('missing required field');
 
-        // Create a temp file so Workerman doesn't clear our files array
-        $tmpFile = tempnam(sys_get_temp_dir(), 'test_');
-        file_put_contents($tmpFile, 'test content');
+        $tmpFile = $this->createTempFile('test content');
 
         $buffer = "POST /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $rawRequest = new Request($buffer);
-
-        // Manually inject malformed file data (missing required fields) but with valid tmp_name
-        // so Workerman's file() method doesn't clear it
-        $reflection = new \ReflectionClass($rawRequest);
-        $dataProperty = $reflection->getProperty('data');
-        $dataProperty->setValue($rawRequest, [
-            'files' => [
-                'malformed_file' => [
-                    'name' => 'test.txt',
-                    'tmp_name' => $tmpFile,
-                    // Missing 'type', 'size', 'error' - should trigger validation error
-                ],
+        $rawRequest = $this->createRequestWithFiles($buffer, [
+            'malformed_file' => [
+                'name' => 'test.txt',
+                'tmp_name' => $tmpFile,
             ],
         ]);
 
-        try {
-            // This should throw InvalidArgumentException
-            RequestConverter::toSymfonyRequest($rawRequest);
-            // If we get here, delete the file
-            unlink($tmpFile);
-        } catch (InvalidArgumentException $e) {
-            // Exception thrown as expected, clean up
-            unlink($tmpFile);
-            throw $e;
-        }
+        RequestConverter::toSymfonyRequest($rawRequest);
     }
 
     public function testHeadersAreAvailableInServerBag(): void
@@ -424,5 +416,31 @@ final class RequestConverterTest extends TestCase
         $buffer .= "\r\n";
 
         return $buffer . $body;
+    }
+
+    private function createTempFile(string $content = 'test'): string
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test_');
+        if ($tmpFile === false) {
+            throw new \RuntimeException('Failed to create temp file');
+        }
+        file_put_contents($tmpFile, $content);
+        $this->tempFiles[] = $tmpFile;
+
+        return $tmpFile;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $files
+     */
+    private function createRequestWithFiles(string $buffer, array $files): Request
+    {
+        $rawRequest = new Request($buffer);
+
+        $reflection = new \ReflectionClass($rawRequest);
+        $dataProperty = $reflection->getProperty('data');
+        $dataProperty->setValue($rawRequest, ['files' => $files]);
+
+        return $rawRequest;
     }
 }


### PR DESCRIPTION
## Summary
- Update CHANGELOG to release v0.13.0 with all unreleased changes
- Adds version header `[0.13.0] - 2026-04-05` while keeping `[Unreleased]` section

## Changes included in v0.13.0
- Test helper methods in RequestConverterTest (#88)
- QUERY_STRING support in RequestConverter (#66)
- REQUEST_TIME and REQUEST_TIME_FLOAT support (#67)
- SERVER_PORT and SERVER_NAME support (#65)
- E2E tests for StreamedResponse (#69)
- E2E tests for HTTPS detection (#64)
- SERVER_PROTOCOL E2E test (#60)
- Priority-based strategy ordering enforced in compiler pass