### PR TITLE
Add final modifier to classes not designed for extension (#44)

### DIFF
--- a/src/Command/WorkermanCommand.php
+++ b/src/Command/WorkermanCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(name: 'workerman:server', description: 'Manage the Workerman server')]
-class WorkermanCommand extends Command
+final class WorkermanCommand extends Command
 {
     private const ALLOWED_ACTIONS = ['start', 'stop', 'restart', 'reload', 'status', 'connections'];
 

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -7,7 +7,7 @@ namespace CrazyGoat\WorkermanBundle\DTO;
 use CrazyGoat\WorkermanBundle\Validator\FileUploadValidator;
 use Symfony\Component\HttpFoundation\Request;
 
-class RequestConverter
+final class RequestConverter
 {
     public static function toSymfonyRequest(\Workerman\Protocols\Http\Request $rawRequest): Request
     {

--- a/src/Exception/NoResponseStrategyException.php
+++ b/src/Exception/NoResponseStrategyException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Exception;
 
-class NoResponseStrategyException extends \LogicException implements WorkermanExceptionInterface
+final class NoResponseStrategyException extends \LogicException implements WorkermanExceptionInterface
 {
     public function __construct(string $responseClass)
     {

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -8,11 +8,11 @@ use CrazyGoat\WorkermanBundle\Exception\StaticFileMiddlewareException;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use Workerman\Protocols\Http\Response;
 
-final class StaticFilesMiddleware implements MiddlewareInterface
+final readonly class StaticFilesMiddleware implements MiddlewareInterface
 {
-    private readonly string $rootRealPath;
+    private string $rootRealPath;
 
-    public function __construct(private readonly string $rootDirectory)
+    public function __construct(private string $rootDirectory)
     {
         $resolved = realpath($rootDirectory);
         if ($resolved === false) {

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -8,7 +8,7 @@ use CrazyGoat\WorkermanBundle\Exception\StaticFileMiddlewareException;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use Workerman\Protocols\Http\Response;
 
-class StaticFilesMiddleware implements MiddlewareInterface
+final class StaticFilesMiddleware implements MiddlewareInterface
 {
     private readonly string $rootRealPath;
 

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Workerman\Protocols\Http\Response;
 
-class SymfonyController
+final class SymfonyController
 {
     private ?SymfonyRequest $symfonyRequest = null;
     private ?SymfonyResponse $symfonyResponse = null;

--- a/src/Reboot/Strategy/MemoryRebootStrategy.php
+++ b/src/Reboot/Strategy/MemoryRebootStrategy.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Reboot\Strategy;
 
-final class MemoryRebootStrategy implements RebootStrategyInterface
+final readonly class MemoryRebootStrategy implements RebootStrategyInterface
 {
-    public function __construct(private readonly int $limit, private readonly ?int $gcLimit)
+    public function __construct(private int $limit, private ?int $gcLimit)
     {
     }
 

--- a/src/Reboot/Strategy/MemoryRebootStrategy.php
+++ b/src/Reboot/Strategy/MemoryRebootStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Reboot\Strategy;
 
-class MemoryRebootStrategy implements RebootStrategyInterface
+final class MemoryRebootStrategy implements RebootStrategyInterface
 {
     public function __construct(private readonly int $limit, private readonly ?int $gcLimit)
     {


### PR DESCRIPTION
## Summary
- Add `final` modifier to `SymfonyController`, `StaticFilesMiddleware`, and `RequestConverter`
- These classes are not designed for extension

Closes #44