### PR TITLE
Add setHeader() method, keep withHeader() as alias

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -6,7 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Http;
 
 class Request extends \Workerman\Protocols\Http\Request
 {
-    public function withHeader(string $name, string $value): self
+    public function setHeader(string $name, string $value): self
     {
         if (!isset($this->data['headers'])) {
             $this->parseHeaders();
@@ -16,5 +16,10 @@ class Request extends \Workerman\Protocols\Http\Request
         $this->data['headers'][$name] = $value;
 
         return $this;
+    }
+
+    public function withHeader(string $name, string $value): self
+    {
+        return $this->setHeader($name, $value);
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -18,6 +18,9 @@ class Request extends \Workerman\Protocols\Http\Request
         return $this;
     }
 
+    /**
+     * @deprecated Use setHeader() instead. This method is kept for backward compatibility.
+     */
     public function withHeader(string $name, string $value): self
     {
         return $this->setHeader($name, $value);


### PR DESCRIPTION
## Summary
- Add `setHeader()` method as the proper name for mutating operation
- Keep `withHeader()` as deprecated alias for backward compatibility

Fixes #38