### PR TITLE
fix: StreamedBinaryFileResponse — Incorrect Chunking Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Files remain accessible via `$request->files` as before
   - **Migration**: If your code relies on reading raw multipart body via `getContent()`, you'll need to adapt it
 
+- `StreamedBinaryFileResponse::streamContent()` simplified chunking logic
+  - Removed redundant inner while loop that was effectively a no-op
+  - Fixed length calculation to use actual data length (`strlen($data)`) instead of requested bytes (`$read`)
+  - Fixes incorrect chunk count for files where fread() returns fewer bytes than requested
+  - Fixes (#27)
+
 ## [0.13.0] - 2026-04-05
 
 ### Added

--- a/src/Protocol/Http/Response/StreamedBinaryFileResponse.php
+++ b/src/Protocol/Http/Response/StreamedBinaryFileResponse.php
@@ -34,20 +34,17 @@ class StreamedBinaryFileResponse extends BinaryFileResponse implements StreamRes
 
             $length = $this->maxlen;
             while ($length && !$file->eof()) {
-                $read = $length > $this->chunkSize || 0 > $length ? $this->chunkSize : $length;
-
-                if (false === $data = $file->fread($read)) {
+                $read = ($length > $this->chunkSize || 0 > $length) ? $this->chunkSize : $length;
+                $data = $file->fread($read);
+                if ($data === false || $data === '') {
                     break;
                 }
-                while ('' !== $data) {
-                    yield $data;
-                    if (connection_aborted() !== 0) {
-                        break 2;
-                    }
-                    if (0 < $length) {
-                        $length -= $read;
-                    }
-                    $data = substr($data, $read);
+                yield $data;
+                if (connection_aborted() !== 0) {
+                    break;
+                }
+                if (0 < $length) {
+                    $length -= strlen($data);
                 }
             }
         } finally {


### PR DESCRIPTION
## Summary

Fixes incorrect chunking logic in `StreamedBinaryFileResponse` by simplifying the inner while loop that was unnecessarily complex and had a bug where `$length` was decremented by `$read` instead of actual data length.

## Changes

- Simplified the chunking logic in `src/Protocol/Http/Response/StreamedBinaryFileResponse.php:36-52`
- Removed redundant inner `while ('' !== $data)` loop that only executed once in most cases
- Fixed length calculation: uses `strlen($data)` instead of `$read` because `fread()` may return fewer bytes than requested
- Added explicit check for empty string (`$data === ''`) alongside the existing `false` check for more robust handling
- Changed `break 2` to single `break` since we're now only using one loop level

## Why

The original code had two issues:
1. The inner loop was effectively a no-op - `substr($data, $read)` when `$read >= strlen($data)` returns empty string, causing the loop to execute exactly once
2. `$length -= $read` was incorrect - should use actual data length since `fread()` can return fewer bytes than requested

## Testing

- All 261 existing tests pass
- Static analysis (phpstan, php-cs-fixer, rector) passes

Closes #27