### PR TITLE
fix: RequestConverter — Missing Nested File Handling (closes #26)

### DIFF
--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\DTO;
 
 use CrazyGoat\WorkermanBundle\Validator\FileUploadValidator;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
 final class RequestConverter
@@ -19,6 +20,9 @@ final class RequestConverter
 
         // Validate file structure to provide clearer error messages
         FileUploadValidator::validate($files);
+
+        // Convert Workerman's $_FILES-style arrays to UploadedFile objects
+        $files = self::processFiles($files);
 
         // Only populate POST bag for form-encoded content types
         // JSON and other content types should leave POST bag empty (like PHP-FPM)
@@ -84,5 +88,42 @@ final class RequestConverter
             $server,
             $content,
         );
+    }
+
+    /**
+     * Recursively convert Workerman's $_FILES-style arrays to UploadedFile objects.
+     *
+     * Workerman returns nested arrays for multiple file uploads (e.g., files[] or documents[0]),
+     * but Symfony's Request expects UploadedFile objects in the files ParameterBag.
+     *
+     * @param array<string, mixed> $files
+     *
+     * @return array<string, mixed>
+     */
+    private static function processFiles(array $files): array
+    {
+        $result = [];
+        foreach ($files as $key => $value) {
+            if (is_array($value)) {
+                // Check if this is a single file structure (has 'tmp_name' key)
+                if (array_key_exists('tmp_name', $value)) {
+                    $type = $value['type'] ?? 'application/octet-stream';
+                    $error = $value['error'] ?? \UPLOAD_ERR_OK;
+
+                    $result[$key] = new UploadedFile(
+                        $value['tmp_name'],
+                        $value['name'] ?? '',
+                        $type === '' ? 'application/octet-stream' : $type,
+                        $error,
+                        true, // test mode: files are already moved to temp dir by Workerman
+                    );
+                } else {
+                    // Nested array - recurse
+                    $result[$key] = self::processFiles($value);
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -78,6 +78,134 @@ final class RequestConverterTest extends TestCase
         $files = $symfonyRequest->files->get('files');
         $this->assertIsArray($files);
         $this->assertCount(2, $files);
+
+        // Each file should be an UploadedFile instance
+        foreach ($files as $file) {
+            $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $file);
+        }
+    }
+
+    public function testNestedFileArrayWithMultipleFiles(): void
+    {
+        $tmpFile1 = $this->createTempFile('content 1');
+        $tmpFile2 = $this->createTempFile('content 2');
+        $tmpFile3 = $this->createTempFile('content 3');
+
+        $buffer = "POST /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = $this->createRequestWithFiles($buffer, [
+            'documents' => [
+                [
+                    'name' => 'doc1.pdf',
+                    'tmp_name' => $tmpFile1,
+                    'type' => 'application/pdf',
+                    'size' => 9,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+                [
+                    'name' => 'doc2.pdf',
+                    'tmp_name' => $tmpFile2,
+                    'type' => 'application/pdf',
+                    'size' => 9,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+                [
+                    'name' => 'doc3.pdf',
+                    'tmp_name' => $tmpFile3,
+                    'type' => 'application/pdf',
+                    'size' => 9,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+            ],
+        ]);
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertTrue($symfonyRequest->files->has('documents'));
+        $documents = $symfonyRequest->files->get('documents');
+        $this->assertIsArray($documents);
+        $this->assertCount(3, $documents);
+
+        foreach ($documents as $index => $file) {
+            $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $file);
+            $this->assertSame('doc' . ($index + 1) . '.pdf', $file->getClientOriginalName());
+        }
+    }
+
+    public function testDeeplyNestedAssociativeFileArray(): void
+    {
+        $tmpFile1 = $this->createTempFile('avatar content');
+        $tmpFile2 = $this->createTempFile('resume content');
+
+        $buffer = "POST /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = $this->createRequestWithFiles($buffer, [
+            'user' => [
+                'avatar' => [
+                    'name' => 'avatar.png',
+                    'tmp_name' => $tmpFile1,
+                    'type' => 'image/png',
+                    'size' => 14,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+                'resume' => [
+                    'name' => 'resume.pdf',
+                    'tmp_name' => $tmpFile2,
+                    'type' => 'application/pdf',
+                    'size' => 16,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+            ],
+        ]);
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertTrue($symfonyRequest->files->has('user'));
+        $userFiles = $symfonyRequest->files->get('user');
+        $this->assertIsArray($userFiles);
+        $this->assertArrayHasKey('avatar', $userFiles);
+        $this->assertArrayHasKey('resume', $userFiles);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $userFiles['avatar']);
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $userFiles['resume']);
+        $this->assertSame('avatar.png', $userFiles['avatar']->getClientOriginalName());
+        $this->assertSame('resume.pdf', $userFiles['resume']->getClientOriginalName());
+    }
+
+    public function testMultipleFileInputsWithNumericKeys(): void
+    {
+        $tmpFile1 = $this->createTempFile('file 0 content');
+        $tmpFile2 = $this->createTempFile('file 1 content');
+
+        $buffer = "POST /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = $this->createRequestWithFiles($buffer, [
+            'files' => [
+                0 => [
+                    'name' => 'image0.png',
+                    'tmp_name' => $tmpFile1,
+                    'type' => 'image/png',
+                    'size' => 14,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+                1 => [
+                    'name' => 'image1.png',
+                    'tmp_name' => $tmpFile2,
+                    'type' => 'image/png',
+                    'size' => 14,
+                    'error' => \UPLOAD_ERR_OK,
+                ],
+            ],
+        ]);
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertTrue($symfonyRequest->files->has('files'));
+        $files = $symfonyRequest->files->get('files');
+        $this->assertIsArray($files);
+        $this->assertCount(2, $files);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $files[0]);
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\File\UploadedFile::class, $files[1]);
+        $this->assertSame('image0.png', $files[0]->getClientOriginalName());
+        $this->assertSame('image1.png', $files[1]->getClientOriginalName());
     }
 
     public function testNestedAssociativeFileArrayValidation(): void
@@ -484,7 +612,7 @@ final class RequestConverterTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, mixed>> $files
+     * @param array<string, array<string, mixed>|array<int, array<string, mixed>>> $files
      */
     private function createRequestWithFiles(string $buffer, array $files): Request
     {


### PR DESCRIPTION
## Problem

The `RequestConverter` previously only handled flat file uploads. HTML forms with nested file arrays (e.g., `files[]`, `documents[0]`, or `<input name="documents[]" multiple>`) would fail because Workerman returns nested arrays for multi-file forms, but the existing code assumed every array element directly contained `tmp_name`, `name`, and `type` keys.

## Solution

Added a recursive `processFiles()` method that properly parses nested file structures and converts them to `UploadedFile` objects for Symfony Request.

### Changes

- **`src/DTO/RequestConverter.php`**: Added `processFiles()` method that recursively converts `$_FILES`-style arrays to `UploadedFile` objects
- **`tests/RequestConverterTest.php`**: Added 3 new test cases:
  - `testNestedFileArrayWithMultipleFiles` — indexed file arrays
  - `testDeeplyNestedAssociativeFileArray` — nested associative structures
  - `testMultipleFileInputsWithNumericKeys` — files with numeric keys

All 268 tests pass, PHPStan/PHP-CS-Fixer/Rector clean.

Closes #26.