### PR TITLE
fix: Generic HTTP header normalization (closes #25)

### DIFF
--- a/src/Http/Response/ResponseConverter.php
+++ b/src/Http/Response/ResponseConverter.php
@@ -40,25 +40,24 @@ final readonly class ResponseConverter
      */
     private function extractHeaders(SymfonyResponse $response): array
     {
-        $headers = $response->headers->all();
-
-        // Fix header names (lowercase to proper case)
-        $fixHeaders = [
-            'content-type' => 'Content-Type',
-            'connection' => 'Connection',
-            'transfer-encoding' => 'Transfer-Encoding',
-            'server' => 'Server',
-            'content-disposition' => 'Content-Disposition',
-            'last-modified' => 'Last-Modified',
-        ];
-
-        foreach ($fixHeaders as $lower => $proper) {
-            if (isset($headers[$lower])) {
-                $headers[$proper] = $headers[$lower];
-                unset($headers[$lower]);
-            }
+        $normalized = [];
+        foreach ($response->headers->all() as $name => $values) {
+            $normalized[$this->normalizeHeaderName($name)] = $values;
         }
 
-        return $headers;
+        return $normalized;
+    }
+
+    /**
+     * Normalizes a header name to proper case (e.g., "content-type" → "Content-Type").
+     *
+     * NOTE: ucfirst-based normalization has known limitations with acronyms:
+     * - "etag" → "Etag" (not "ETag"), "content-md5" → "Content-Md5" (not "Content-MD5")
+     * Per RFC 9110, HTTP header names are case-insensitive, so this is technically valid.
+     * This approach is still strictly better than the old hardcoded 6-header map.
+     */
+    private function normalizeHeaderName(string $name): string
+    {
+        return implode('-', array_map(ucfirst(...), explode('-', $name)));
     }
 }

--- a/tests/ResponseConverterTest.php
+++ b/tests/ResponseConverterTest.php
@@ -76,6 +76,8 @@ final class ResponseConverterTest extends TestCase
         $workermanResponse = $converter->convert($response, $this->connection);
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
+        $this->assertSame(['text/html'], $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame(['attachment'], $workermanResponse->getHeader('Content-Disposition'));
     }
 
     public function testConvertHandlesIterableStrategies(): void

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -801,11 +801,9 @@ final class SymfonyControllerTest extends TestCase
         $response = $controller($request, $this->connection);
 
         $this->assertInstanceOf(\Workerman\Protocols\Http\Response::class, $response);
-        // Symfony normalizes headers to lowercase, Workerman stores them as-is
-        // Content-Type is in FIX_HEADERS so it gets capitalized
+        // All headers are normalized to proper case (e.g., Content-Type, X-Custom-Header)
         $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
-        // X-Custom-Header is normalized to lowercase by Symfony
-        $this->assertSame(['custom-value'], $response->getHeader('x-custom-header'));
+        $this->assertSame(['custom-value'], $response->getHeader('X-Custom-Header'));
     }
 
     public function testResponseStatusCodeIsPreserved(): void
@@ -1024,8 +1022,8 @@ final class SymfonyControllerTest extends TestCase
         $this->assertSame($initialObLevel, ob_get_level(), 'OB level should remain unchanged after test');
         // Content-Type may have charset added by Symfony
         $this->assertStringContainsString('text/event-stream', $response->getHeader('Content-Type')[0] ?? '');
-        // Headers are normalized to lowercase by Symfony/Workerman
-        $this->assertSame(['true'], $response->getHeader('x-stream'));
+        // Headers are normalized to proper case
+        $this->assertSame(['true'], $response->getHeader('X-Stream'));
         $this->assertSame('streaming data', $response->rawBody());
     }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded 6-header `FIX_HEADERS` map with generic `normalizeHeaderName()` method
- All headers are now normalized to proper case (e.g., `cache-control` → `Cache-Control`, `x-custom-header` → `X-Custom-Header`)

## Changes

- `src/Http/Response/ResponseConverter.php:41-54` - New `extractHeaders()` and `normalizeHeaderName()` methods
- `tests/SymfonyControllerTest.php` - Updated 2 assertions to expect properly capitalized headers

## Verification

- ✅ 268 tests pass
- ✅ PHP CS Fixer: no issues
- ✅ PHPStan: no errors  
- ✅ Rector: no issues