### PR TITLE
chore: release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2026-04-14
 
-### Added
+### Deprecated
 
-- Added `setHeader()` method to `Request` class ([#38](https://github.com/crazy-goat/workerman-bundle/issues/38))
-  - `withHeader()` is now deprecated (kept as alias for backward compatibility)
-  - Aligns with PSR-7 naming conventions where `with*` implies immutability
+- `Request::withHeader()` is deprecated ([#38](https://github.com/crazy-goat/workerman-bundle/issues/38))
+  - Use `setHeader()` instead
+  - `withHeader()` is kept as alias for backward compatibility
+
+### Added
 
 - Added `ServerWorker` SSL certificate validation for HTTPS/WSS servers ([#18](https://github.com/crazy-goat/workerman-bundle/issues/18))
   - Validates that `local_cert` and `local_pk` are provided for SSL transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2026-04-14
 
+### Added
+
+- Added `setHeader()` method to `Request` class ([#38](https://github.com/crazy-goat/workerman-bundle/issues/38))
+  - `withHeader()` is now deprecated (kept as alias for backward compatibility)
+  - Aligns with PSR-7 naming conventions where `with*` implies immutability
+
+- Added `ServerWorker` SSL certificate validation for HTTPS/WSS servers ([#18](https://github.com/crazy-goat/workerman-bundle/issues/18))
+  - Validates that `local_cert` and `local_pk` are provided for SSL transport
+  - Checks that certificate and key files are readable
+  - Throws clear `\InvalidArgumentException` messages instead of cryptic SSL errors
+
+### Fixed
+
+- **Critical**: Fixed `Middleware Pipeline` — closure capturing wrong request in middleware chain ([#21](https://github.com/crazy-goat/workerman-bundle/issues/21))
+  - Changed closure to use `$input` parameter instead of outer scope `$request`
+  - Request-modifying middleware now correctly affects subsequent middleware in the chain
+
+- Fixed `KernelFactory` — singleton kernel state reset between requests ([#22](https://github.com/crazy-goat/workerman-bundle/issues/22))
+  - Kernel now properly resets services between requests to prevent memory leaks
+  - Uses Symfony's `services_resetter` to reset services tagged with `kernel.reset`
+
+- Fixed `RequestConverter` — missing nested file handling ([#26](https://github.com/crazy-goat/workerman-bundle/issues/26))
+  - Forms with `files[0]`, `files[avatar]`, or `<input name="documents[]" multiple>` now work correctly
+  - Added recursive file processing for nested file arrays
+
+- Fixed `ResponseConverter` — generic HTTP header normalization ([#25](https://github.com/crazy-goat/workerman-bundle/issues/25))
+  - All headers are now properly normalized from lowercase to PascalCase
+  - Previously only 6 headers were normalized; now uses generic transformation
+
+- Fixed `Runner` — proper error handling for fork and cache warmup ([#23](https://github.com/crazy-goat/workerman-bundle/issues/23))
+  - `pcntl_fork()` error (`-1`) now throws exception instead of falling into indefinite wait
+  - Child process exit code properly reflects boot success/failure
+  - Parent process now detects cache warmup failures in forked child
+
 ### Changed
 
 - **Breaking**: `ResponseConverterStrategyInterface::convert()` now requires a `TcpConnection` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2026-04-14
 
 ### Changed
 

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -91,25 +91,25 @@ final readonly class ServerWorker
 
         if (!is_string($cert) || $cert === '') {
             throw new \InvalidArgumentException(
-                'SSL configuration requires "local_cert" option for HTTPS/WSS server.'
+                'SSL configuration requires "local_cert" option for HTTPS/WSS server.',
             );
         }
 
         if (!is_string($key) || $key === '') {
             throw new \InvalidArgumentException(
-                'SSL configuration requires "local_pk" option for HTTPS/WSS server.'
+                'SSL configuration requires "local_pk" option for HTTPS/WSS server.',
             );
         }
 
         if (!is_readable($cert)) {
             throw new \InvalidArgumentException(
-                sprintf('SSL certificate file is not readable: %s', $cert)
+                sprintf('SSL certificate file is not readable: %s', $cert),
             );
         }
 
         if (!is_readable($key)) {
             throw new \InvalidArgumentException(
-                sprintf('SSL private key file is not readable: %s', $key)
+                sprintf('SSL private key file is not readable: %s', $key),
             );
         }
 

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -34,7 +34,7 @@ final class ServerWorkerTest extends TestCase
     {
         $kernel = $this->createMock(KernelInterface::class);
         return new KernelFactory(
-            fn() => $kernel,
+            fn(): \PHPUnit\Framework\MockObject\MockObject => $kernel,
             [],
         );
     }

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -35,7 +35,7 @@ final class ServerWorkerTest extends TestCase
         $kernel = $this->createMock(KernelInterface::class);
         return new KernelFactory(
             fn() => $kernel,
-            []
+            [],
         );
     }
 
@@ -52,7 +52,7 @@ final class ServerWorkerTest extends TestCase
                 'name' => 'test-server',
                 'listen' => 'https://0.0.0.0:8443',
                 'local_pk' => $this->tempDir . '/key.pem',
-            ]
+            ],
         );
     }
 
@@ -69,7 +69,7 @@ final class ServerWorkerTest extends TestCase
                 'name' => 'test-server',
                 'listen' => 'https://0.0.0.0:8443',
                 'local_cert' => $this->tempDir . '/cert.pem',
-            ]
+            ],
         );
     }
 
@@ -87,7 +87,7 @@ final class ServerWorkerTest extends TestCase
                 'listen' => 'https://0.0.0.0:8443',
                 'local_cert' => '/nonexistent/cert.pem',
                 'local_pk' => $this->tempDir . '/key.pem',
-            ]
+            ],
         );
     }
 
@@ -105,7 +105,7 @@ final class ServerWorkerTest extends TestCase
                 'listen' => 'https://0.0.0.0:8443',
                 'local_cert' => $this->tempDir . '/cert.pem',
                 'local_pk' => '/nonexistent/key.pem',
-            ]
+            ],
         );
     }
 
@@ -125,7 +125,7 @@ final class ServerWorkerTest extends TestCase
                 'listen' => 'https://0.0.0.0:8443',
                 'local_cert' => $certFile,
                 'local_pk' => $keyFile,
-            ]
+            ],
         );
 
         $this->assertInstanceOf(ServerWorker::class, $serverWorker);
@@ -147,7 +147,7 @@ final class ServerWorkerTest extends TestCase
                 'listen' => 'wss://0.0.0.0:8443',
                 'local_cert' => $certFile,
                 'local_pk' => $keyFile,
-            ]
+            ],
         );
 
         $this->assertInstanceOf(ServerWorker::class, $serverWorker);
@@ -161,12 +161,12 @@ final class ServerWorkerTest extends TestCase
         if ($privkey === false) {
             throw new \RuntimeException('Failed to generate private key');
         }
-        
+
         $cert = \openssl_csr_new($dn, $privkey, ['digest_alg' => 'sha256']);
         if ($cert === false || $cert === true) {
             throw new \RuntimeException('Failed to generate CSR');
         }
-        
+
         $x509 = \openssl_csr_sign($cert, null, $privkey, 365);
         if ($x509 === false) {
             throw new \RuntimeException('Failed to sign certificate');
@@ -175,7 +175,7 @@ final class ServerWorkerTest extends TestCase
         if (!\openssl_pkey_export_to_file($privkey, $keyFile)) {
             throw new \RuntimeException('Failed to export private key');
         }
-        
+
         if (!\openssl_x509_export_to_file($x509, $certFile)) {
             throw new \RuntimeException('Failed to export certificate');
         }


### PR DESCRIPTION
## Release 0.14.0 - Milestone 1 Complete

### Summary

Milestone 1 "Critical Fixes & Stability" is complete. This release includes all HIGH priority bug fixes, security improvements, and HTTP correctness fixes.

### Changes

#### Deprecated
- `#38` - `Request::withHeader()` deprecated, use `setHeader()` instead

#### Added
- `#18` - `ServerWorker` SSL certificate validation for HTTPS/WSS servers

#### Fixed
- `#21` - **Critical**: Middleware Pipeline closure capturing wrong request
- `#22` - `KernelFactory` singleton kernel state reset between requests
- `#26` - `RequestConverter` missing nested file handling
- `#25` - `ResponseConverter` generic HTTP header normalization
- `#23` - `Runner` proper error handling for fork and cache warmup

#### Changed
- `#104` - `BinaryFileResponseStrategy` connection-aware temp file cleanup
- `#68` - `RequestConverter` multipart/form-data returns empty content (PHP-FPM behavior)
- `#27` - `StreamedBinaryFileResponse` simplified chunking logic

### Closed Issues

Closes milestone #1