### PR TITLE
Add pre-push git hook to run composer lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,25 @@ All pull requests must pass the following checks before merging:
 
 ## Development Workflow
 
+### Pre-Push Hook
+
+A pre-push git hook is automatically installed via Composer's post-install scripts. It runs `composer lint` before each push to catch issues early.
+
+**To skip the hook** (for emergency pushes):
+```bash
+git push --no-verify
+```
+
+**To manually reinstall the hook**:
+```bash
+php bin/install-git-hook.php
+```
+
+**To remove the hook**:
+```bash
+rm .git/hooks/pre-push
+```
+
 ### Before Submitting a PR
 
 1. Run linting locally:

--- a/bin/install-git-hook.php
+++ b/bin/install-git-hook.php
@@ -1,11 +1,9 @@
-#!/usr/bin/env php
 <?php
 
 $hookContent = <<<'HOOK'
 #!/bin/bash
 echo "Running pre-push lint checks..."
 composer lint
-exit $?
 HOOK;
 
 $gitHookDir = __DIR__ . '/../.git/hooks';

--- a/bin/install-git-hook.php
+++ b/bin/install-git-hook.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+
+$hookContent = <<<'HOOK'
+#!/bin/bash
+echo "Running pre-push lint checks..."
+composer lint
+exit $?
+HOOK;
+
+$gitHookDir = __DIR__ . '/../.git/hooks';
+$prePushPath = $gitHookDir . '/pre-push';
+
+if (!is_dir($gitHookDir)) {
+    echo "Error: .git/hooks directory not found\n";
+    exit(1);
+}
+
+if (file_put_contents($prePushPath, $hookContent) === false) {
+    echo "Error: Failed to write pre-push hook\n";
+    exit(1);
+}
+
+chmod($prePushPath, 0755);
+echo "Git pre-push hook installed successfully\n";

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,12 @@
             "vendor/bin/php-cs-fixer fix -v --dry-run",
             "vendor/bin/phpstan",
             "vendor/bin/rector process --dry-run"
+        ],
+        "post-install-cmd": [
+            "php bin/install-git-hook.php"
+        ],
+        "post-update-cmd": [
+            "php bin/install-git-hook.php"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Added `bin/install-git-hook.php` - script that installs the git hook
- Added `post-install-cmd` and `post-update-cmd` in composer.json
- Hook runs `composer lint` before each push

## Resolves
#136