### PR TITLE
fix(#34): TriggerFactory — Fragile Cron Expression Detection Heuristic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,19 @@
         "symfony/runtime": "^6.4|^7.0|^8.0",
         "workerman/workerman": "^5.0"
     },
+    "require": {
+        "php": "^8.2",
+        "ext-pcntl": "*",
+        "ext-posix": "*",
+        "league/mime-type-detection": "^1.13",
+        "psr/log": "^3.0",
+        "symfony/config": "^6.4|^7.0|^8.0",
+        "symfony/console": "^6.4|^7.0|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/http-kernel": "^6.4|^7.0|^8.0",
+        "symfony/runtime": "^6.4|^7.0|^8.0",
+        "workerman/workerman": "^5.0"
+    },
     "require-dev": {
         "dragonmantank/cron-expression": "^3.4",
         "guzzlehttp/guzzle": "^7.8",

--- a/composer.json
+++ b/composer.json
@@ -33,19 +33,6 @@
         "symfony/runtime": "^6.4|^7.0|^8.0",
         "workerman/workerman": "^5.0"
     },
-    "require": {
-        "php": "^8.2",
-        "ext-pcntl": "*",
-        "ext-posix": "*",
-        "league/mime-type-detection": "^1.13",
-        "psr/log": "^3.0",
-        "symfony/config": "^6.4|^7.0|^8.0",
-        "symfony/console": "^6.4|^7.0|^8.0",
-        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-        "symfony/http-kernel": "^6.4|^7.0|^8.0",
-        "symfony/runtime": "^6.4|^7.0|^8.0",
-        "workerman/workerman": "^5.0"
-    },
     "require-dev": {
         "dragonmantank/cron-expression": "^3.4",
         "guzzlehttp/guzzle": "^7.8",

--- a/docs/superpowers/plans/2026-04-14-triggerfactory-cron-detection-fix.md
+++ b/docs/superpowers/plans/2026-04-14-triggerfactory-cron-detection-fix.md
@@ -1,0 +1,117 @@
+# TriggerFactory Cron Expression Detection Fix - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix fragile cron expression detection in TriggerFactory by using CronExpression::isValidExpression()
+
+**Architecture:** Replace fragile heuristic (5 parts + contains '*') with library validation method. The library already handles all valid cron formats including aliases.
+
+**Tech Stack:** PHP 8.2, cron-expression library (dragonmantank/cron-expression), PHPUnit
+
+---
+
+## Task 1: Update TriggerFactory.php
+
+**Files:**
+- Modify: `src/Scheduler/Trigger/TriggerFactory.php:5-7`
+- Modify: `src/Scheduler/Trigger/TriggerFactory.php:37-42`
+
+- [ ] **Step 1: Add CronExpression import**
+
+Add after line 5 (namespace line):
+```php
+use Cron\CronExpression;
+```
+
+- [ ] **Step 2: Replace fragile cron detection with library validation**
+
+Replace lines 39-40:
+```php
+is_string($expression) && count(explode(' ', $expression)) === 5 && str_contains($expression, '*'),
+is_string($expression) && str_starts_with($expression, '@') => new CronExpressionTrigger($expression),
+```
+
+With:
+```php
+is_string($expression) && CronExpression::isValidExpression($expression) => new CronExpressionTrigger($expression),
+```
+
+- [ ] **Step 3: Run tests to verify changes**
+
+Run: `./vendor/bin/phpunit tests/TriggerFactoryTest.php -v`
+Expected: All tests pass (some may fail - see Task 2)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Scheduler/Trigger/TriggerFactory.php
+git commit -m "fix: use CronExpression::isValidExpression for robust cron detection"
+```
+
+---
+
+## Task 2: Update TriggerFactoryTest.php
+
+**Files:**
+- Modify: `tests/TriggerFactoryTest.php:114-128`
+- Modify: `tests/TriggerFactoryTest.php:131-137`
+
+- [ ] **Step 1: Add test case for cron without asterisks**
+
+Add to `cronExpressionProvider` array (after line 127):
+```php
+'daily at midnight on Monday (no asterisks)' => ['0 0 1 1 1'],
+```
+
+- [ ] **Step 2: Update testFivePartNonCronExpressionThrowsException**
+
+The test `'1 2 3 4 5'` previously expected exception, but `CronExpression::isValidExpression('1 2 3 4 5')` returns `true` (it's valid - means 1:02:03 on 4th day of 5th month).
+
+Replace `testFivePartNonCronExpressionThrowsException` with a test for a truly invalid expression:
+```php
+public function testFivePartNonCronExpressionThrowsException(): void
+{
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Invalid interval');
+
+    TriggerFactory::create('1 2 3 4 5 6');  // 6 parts - invalid
+}
+```
+
+- [ ] **Step 3: Run tests to verify all pass**
+
+Run: `./vendor/bin/phpunit tests/TriggerFactoryTest.php -v`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/TriggerFactoryTest.php
+git commit -m "test: add cron detection test cases and fix obsolete exception test"
+```
+
+---
+
+## Task 3: Final verification
+
+**Files:**
+- Run: Full test suite
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `./vendor/bin/phpunit`
+Expected: All tests pass
+
+- [ ] **Step 2: Run static analysis if available**
+
+Run: `./vendor/bin/phpstan analyse src/Scheduler/Trigger/TriggerFactory.php --level=max 2>/dev/null || echo "phpstan not configured"`
+
+---
+
+## Spec Coverage Check
+
+- [x] Replace fragile heuristic - Task 1
+- [x] Add CronExpression import - Task 1
+- [x] Test for cron without asterisks (0 0 1 1 1) - Task 2
+- [x] Remove obsolete test - Task 2
+- [x] Verify no regressions - Task 3

--- a/docs/superpowers/specs/2026-04-14-triggerfactory-cron-detection-design.md
+++ b/docs/superpowers/specs/2026-04-14-triggerfactory-cron-detection-design.md
@@ -1,0 +1,45 @@
+# TriggerFactory Cron Expression Detection Fix
+
+**Date:** 2026-04-14
+**Issue:** #34
+**Status:** Approved
+
+## Problem
+
+`TriggerFactory::create()` uses a fragile heuristic to detect cron expressions:
+
+```php
+is_string($expression) && count(explode(' ', $expression)) === 5 && str_contains($expression, '*')
+```
+
+This fails for valid cron expressions without asterisks, such as `0 0 1 1 1` (January 1st at midnight, on Monday).
+
+## Solution
+
+Replace the fragile heuristic with `CronExpression::isValidExpression()` from the `dragonmantank/cron-expression` library, which is already a dependency.
+
+### Changes
+
+**File:** `src/Scheduler/Trigger/TriggerFactory.php`
+
+1. Add import: `use Cron\CronExpression;`
+2. Replace lines 39-40 with single condition:
+   ```php
+   is_string($expression) && CronExpression::isValidExpression($expression) => new CronExpressionTrigger($expression),
+   ```
+
+The `str_starts_with($expression, '@')` check is no longer needed because `CronExpression::isValidExpression()` handles alias expressions (@daily, @hourly, etc.).
+
+### Test Updates
+
+**File:** `tests/TriggerFactoryTest.php`
+
+1. Add test case `0 0 1 1 1` to `cronExpressionProvider`
+2. Update `testFivePartNonCronExpressionThrowsException` - remove or adjust since `1 2 3 4 5` is now considered a valid cron expression by the library (which is correct - it's a valid cron expression for 1:02:03 on April 5th)
+
+## Verification
+
+Run existing tests to ensure no regressions:
+```bash
+./vendor/bin/phpunit tests/TriggerFactoryTest.php
+```

--- a/src/Scheduler/Trigger/TriggerFactory.php
+++ b/src/Scheduler/Trigger/TriggerFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Scheduler\Trigger;
 
+use Cron\CronExpression;
+
 final class TriggerFactory
 {
     /**
@@ -36,8 +38,7 @@ final class TriggerFactory
 
         $trigger = match (true) {
             $expression instanceof \DateTimeImmutable => new DateTimeTrigger($expression),
-            is_string($expression) && count(explode(' ', $expression)) === 5 && str_contains($expression, '*'),
-            is_string($expression) && str_starts_with($expression, '@') => new CronExpressionTrigger($expression),
+            is_string($expression) && CronExpression::isValidExpression($expression) => new CronExpressionTrigger($expression),
             default => new PeriodicalTrigger($expression),
         };
 

--- a/src/Scheduler/Trigger/TriggerFactory.php
+++ b/src/Scheduler/Trigger/TriggerFactory.php
@@ -38,7 +38,7 @@ final class TriggerFactory
 
         $trigger = match (true) {
             $expression instanceof \DateTimeImmutable => new DateTimeTrigger($expression),
-            is_string($expression) && CronExpression::isValidExpression($expression) => new CronExpressionTrigger($expression),
+            is_string($expression) && class_exists(CronExpression::class) && CronExpression::isValidExpression($expression) => new CronExpressionTrigger($expression),
             default => new PeriodicalTrigger($expression),
         };
 

--- a/tests/TriggerFactoryTest.php
+++ b/tests/TriggerFactoryTest.php
@@ -125,7 +125,7 @@ final class TriggerFactoryTest extends TestCase
             'with @weekly' => ['@weekly'],
             'with @daily' => ['@daily'],
             'with @hourly' => ['@hourly'],
-            'daily at midnight on Monday (no asterisks)' => ['0 0 1 1 1'],
+            'minute 0 hour 0 day 1 month 1 weekday Monday (no asterisks)' => ['0 0 1 1 1'],
         ];
     }
 
@@ -137,7 +137,7 @@ final class TriggerFactoryTest extends TestCase
         TriggerFactory::create('1 2 3 4 5 6');
     }
 
-    public function testExpressionWithAsterisksButNotFivePartsThrowsException(): void
+    public function testInvalidCronExpressionThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid interval');

--- a/tests/TriggerFactoryTest.php
+++ b/tests/TriggerFactoryTest.php
@@ -125,6 +125,7 @@ final class TriggerFactoryTest extends TestCase
             'with @weekly' => ['@weekly'],
             'with @daily' => ['@daily'],
             'with @hourly' => ['@hourly'],
+            'daily at midnight on Monday (no asterisks)' => ['0 0 1 1 1'],
         ];
     }
 
@@ -133,7 +134,7 @@ final class TriggerFactoryTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid interval');
 
-        TriggerFactory::create('1 2 3 4 5');
+        TriggerFactory::create('1 2 3 4 5 6');
     }
 
     public function testExpressionWithAsterisksButNotFivePartsThrowsException(): void


### PR DESCRIPTION
## Summary
- Replace fragile cron expression heuristic with `CronExpression::isValidExpression()`
- Add test case for cron expressions without asterisks (`0 0 1 1 1`)
- Add `class_exists` check for graceful handling when cron library not installed

## Test Plan
- [x] All 284 tests pass (11 skipped - normal)
- [x] PHPStan: No errors
- [x] CS Fixer: No issues

Closes #34