### PR TITLE
feat(ConfigLoader): add validation for complete configuration before warmUp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor/
 var/
 .vscode/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Require conversation resolution before merging
   - No approval count required (solo dev project)
 
+### Added
+
+- Added validation in `ConfigLoader::warmUp()` to ensure all config sections are set before caching ([#35](https://github.com/crazy-goat/workerman-bundle/issues/35))
+  - New `ConfigSection` enum with cases: WORKERMAN, PROCESS, SCHEDULER
+  - Throws `LogicException` with descriptive message when any section is missing
+  - Prevents incomplete configuration from being cached
+
+### Changed
+
+- **Breaking**: Config cache format changed from numeric indices to string keys ([#35](https://github.com/crazy-goat/workerman-bundle/issues/35))
+  - **Old format:** `[0 => ..., 1 => ..., 2 => ...]`
+  - **New format:** `['workerman' => ..., 'process' => ..., 'scheduler' => ...]`
+  - Uses `ConfigSection` enum values as keys for clarity and type safety
+  - **Migration**: Clear cache after upgrade: `rm -rf var/cache/*`
+
 ## [0.14.0] - 2026-04-14
 
 ### Deprecated

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -29,6 +29,26 @@ final class ConfigLoader implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
+        if (!isset($this->config[0], $this->config[1], $this->config[2])) {
+            $missingSections = [];
+            if (!isset($this->config[0])) {
+                $missingSections[] = 'workerman';
+            }
+            if (!isset($this->config[1])) {
+                $missingSections[] = 'process';
+            }
+            if (!isset($this->config[2])) {
+                $missingSections[] = 'scheduler';
+            }
+
+            throw new \LogicException(
+                sprintf(
+                    'All config sections must be set before warming up. Missing: %s',
+                    implode(', ', $missingSections),
+                ),
+            );
+        }
+
         $resources = is_file($this->yamlConfigFilePath) ? [new FileResource($this->yamlConfigFilePath)] : [];
         $this->cache->write(sprintf('<?php return %s;', var_export($this->config, true)), $resources);
 

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -29,18 +29,14 @@ final class ConfigLoader implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
-        if (!isset($this->config[0], $this->config[1], $this->config[2])) {
-            $missingSections = [];
-            if (!isset($this->config[0])) {
-                $missingSections[] = 'workerman';
+        $missingSections = [];
+        foreach (ConfigSection::cases() as $section) {
+            if (!isset($this->config[$section->value])) {
+                $missingSections[] = $section->value;
             }
-            if (!isset($this->config[1])) {
-                $missingSections[] = 'process';
-            }
-            if (!isset($this->config[2])) {
-                $missingSections[] = 'scheduler';
-            }
+        }
 
+        if ($missingSections !== []) {
             throw new \LogicException(
                 sprintf(
                     'All config sections must be set before warming up. Missing: %s',
@@ -60,7 +56,7 @@ final class ConfigLoader implements CacheWarmerInterface
         return $this->cache->isFresh();
     }
 
-    /** @return array<int, mixed[]> */
+    /** @return array<string, mixed[]> */
     private function getConfig(): array
     {
         return $this->config ??= require $this->cache->getPath();
@@ -69,36 +65,36 @@ final class ConfigLoader implements CacheWarmerInterface
     /** @param mixed[] $config */
     public function setWorkermanConfig(array $config): void
     {
-        $this->config[0] = $config;
+        $this->config[ConfigSection::WORKERMAN->value] = $config;
     }
 
     /** @param mixed[] $config */
     public function setProcessConfig(array $config): void
     {
-        $this->config[1] = $config;
+        $this->config[ConfigSection::PROCESS->value] = $config;
     }
 
     /** @param mixed[] $config */
     public function setSchedulerConfig(array $config): void
     {
-        $this->config[2] = $config;
+        $this->config[ConfigSection::SCHEDULER->value] = $config;
     }
 
     /** @return mixed[] */
     public function getWorkermanConfig(): array
     {
-        return $this->getConfig()[0];
+        return $this->getConfig()[ConfigSection::WORKERMAN->value];
     }
 
     /** @return mixed[] */
     public function getProcessConfig(): array
     {
-        return $this->getConfig()[1];
+        return $this->getConfig()[ConfigSection::PROCESS->value];
     }
 
     /** @return mixed[] */
     public function getSchedulerConfig(): array
     {
-        return $this->getConfig()[2];
+        return $this->getConfig()[ConfigSection::SCHEDULER->value];
     }
 }

--- a/src/ConfigSection.php
+++ b/src/ConfigSection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle;
+
+enum ConfigSection: string
+{
+    case WORKERMAN = 'workerman';
+    case PROCESS = 'process';
+    case SCHEDULER = 'scheduler';
+}

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Tests;
+
+use CrazyGoat\WorkermanBundle\ConfigLoader;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigLoaderTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/config-loader-test-' . uniqid();
+        mkdir($this->tempDir . '/config/packages', 0777, true);
+        mkdir($this->tempDir . '/cache', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+
+        rmdir($dir);
+    }
+
+    public function testWarmUpThrowsExceptionWhenWorkermanConfigIsMissing(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Set only process and scheduler config
+        $loader->setProcessConfig(['some' => 'process']);
+        $loader->setSchedulerConfig(['some' => 'scheduler']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('All config sections must be set before warming up. Missing: workerman');
+
+        $loader->warmUp($this->tempDir . '/cache');
+    }
+
+    public function testWarmUpThrowsExceptionWhenProcessConfigIsMissing(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Set only workerman and scheduler config
+        $loader->setWorkermanConfig(['some' => 'workerman']);
+        $loader->setSchedulerConfig(['some' => 'scheduler']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('All config sections must be set before warming up. Missing: process');
+
+        $loader->warmUp($this->tempDir . '/cache');
+    }
+
+    public function testWarmUpThrowsExceptionWhenSchedulerConfigIsMissing(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Set only workerman and process config
+        $loader->setWorkermanConfig(['some' => 'workerman']);
+        $loader->setProcessConfig(['some' => 'process']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('All config sections must be set before warming up. Missing: scheduler');
+
+        $loader->warmUp($this->tempDir . '/cache');
+    }
+
+    public function testWarmUpThrowsExceptionWithMultipleMissingSections(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Set only workerman config
+        $loader->setWorkermanConfig(['some' => 'workerman']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('All config sections must be set before warming up. Missing: process, scheduler');
+
+        $loader->warmUp($this->tempDir . '/cache');
+    }
+
+    public function testWarmUpThrowsExceptionWhenNoConfigIsSet(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Don't set any config
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('All config sections must be set before warming up. Missing: workerman, process, scheduler');
+
+        $loader->warmUp($this->tempDir . '/cache');
+    }
+
+    public function testWarmUpSucceedsWithAllConfigSectionsSet(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        // Set all config sections
+        $loader->setWorkermanConfig(['server' => ['listen' => 'http://0.0.0.0:8080']]);
+        $loader->setProcessConfig(['processes' => []]);
+        $loader->setSchedulerConfig(['schedules' => []]);
+
+        // Should not throw exception
+        $result = $loader->warmUp($this->tempDir . '/cache');
+
+        // Verify cache was created
+        $this->assertFileExists($this->tempDir . '/cache/workerman/config.cache.php');
+        $this->assertSame([], $result);
+
+        // Verify config can be loaded back
+        $loadedConfig = require $this->tempDir . '/cache/workerman/config.cache.php';
+        $this->assertArrayHasKey(0, $loadedConfig);
+        $this->assertArrayHasKey(1, $loadedConfig);
+        $this->assertArrayHasKey(2, $loadedConfig);
+        $this->assertSame(['server' => ['listen' => 'http://0.0.0.0:8080']], $loadedConfig[0]);
+        $this->assertSame(['processes' => []], $loadedConfig[1]);
+        $this->assertSame(['schedules' => []], $loadedConfig[2]);
+    }
+
+    public function testGetWorkermanConfigReturnsCorrectSection(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $workermanConfig = ['server' => ['listen' => 'http://0.0.0.0:8080']];
+        $loader->setWorkermanConfig($workermanConfig);
+        $loader->setProcessConfig(['processes' => []]);
+        $loader->setSchedulerConfig(['schedules' => []]);
+        $loader->warmUp($this->tempDir . '/cache');
+
+        $this->assertSame($workermanConfig, $loader->getWorkermanConfig());
+    }
+
+    public function testGetProcessConfigReturnsCorrectSection(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $processConfig = ['processes' => [['name' => 'test']]];
+        $loader->setWorkermanConfig(['server' => []]);
+        $loader->setProcessConfig($processConfig);
+        $loader->setSchedulerConfig(['schedules' => []]);
+        $loader->warmUp($this->tempDir . '/cache');
+
+        $this->assertSame($processConfig, $loader->getProcessConfig());
+    }
+
+    public function testGetSchedulerConfigReturnsCorrectSection(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $schedulerConfig = ['schedules' => [['name' => 'test']]];
+        $loader->setWorkermanConfig(['server' => []]);
+        $loader->setProcessConfig(['processes' => []]);
+        $loader->setSchedulerConfig($schedulerConfig);
+        $loader->warmUp($this->tempDir . '/cache');
+
+        $this->assertSame($schedulerConfig, $loader->getSchedulerConfig());
+    }
+}

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -130,12 +130,12 @@ final class ConfigLoaderTest extends TestCase
 
         // Verify config can be loaded back
         $loadedConfig = require $this->tempDir . '/cache/workerman/config.cache.php';
-        $this->assertArrayHasKey(0, $loadedConfig);
-        $this->assertArrayHasKey(1, $loadedConfig);
-        $this->assertArrayHasKey(2, $loadedConfig);
-        $this->assertSame(['server' => ['listen' => 'http://0.0.0.0:8080']], $loadedConfig[0]);
-        $this->assertSame(['processes' => []], $loadedConfig[1]);
-        $this->assertSame(['schedules' => []], $loadedConfig[2]);
+        $this->assertArrayHasKey('workerman', $loadedConfig);
+        $this->assertArrayHasKey('process', $loadedConfig);
+        $this->assertArrayHasKey('scheduler', $loadedConfig);
+        $this->assertSame(['server' => ['listen' => 'http://0.0.0.0:8080']], $loadedConfig['workerman']);
+        $this->assertSame(['processes' => []], $loadedConfig['process']);
+        $this->assertSame(['schedules' => []], $loadedConfig['scheduler']);
     }
 
     public function testGetWorkermanConfigReturnsCorrectSection(): void
@@ -146,7 +146,6 @@ final class ConfigLoaderTest extends TestCase
         $loader->setWorkermanConfig($workermanConfig);
         $loader->setProcessConfig(['processes' => []]);
         $loader->setSchedulerConfig(['schedules' => []]);
-        $loader->warmUp($this->tempDir . '/cache');
 
         $this->assertSame($workermanConfig, $loader->getWorkermanConfig());
     }
@@ -159,7 +158,6 @@ final class ConfigLoaderTest extends TestCase
         $loader->setWorkermanConfig(['server' => []]);
         $loader->setProcessConfig($processConfig);
         $loader->setSchedulerConfig(['schedules' => []]);
-        $loader->warmUp($this->tempDir . '/cache');
 
         $this->assertSame($processConfig, $loader->getProcessConfig());
     }
@@ -172,7 +170,6 @@ final class ConfigLoaderTest extends TestCase
         $loader->setWorkermanConfig(['server' => []]);
         $loader->setProcessConfig(['processes' => []]);
         $loader->setSchedulerConfig($schedulerConfig);
-        $loader->warmUp($this->tempDir . '/cache');
 
         $this->assertSame($schedulerConfig, $loader->getSchedulerConfig());
     }


### PR DESCRIPTION
## Summary

Add validation in `warmUp()` method to ensure all three config sections (workerman, process, scheduler) are set before writing to cache.

## Problem

In the `ConfigLoader` class, the `$config` property is populated by three separate setter calls. If the `warmUp()` method is called before all three sections are set, the saved configuration will be incomplete. There is no validation that all three sections have been set.

## Changes

### src/ConfigSection.php (new file)
- Add enum `ConfigSection` with cases: WORKERMAN, PROCESS, SCHEDULER
- Uses string values for clarity

### src/ConfigLoader.php
- Add validation in `warmUp()` method using `ConfigSection` enum
- Throws `LogicException` with descriptive message when any config section is missing
- Lists all missing sections (e.g., "Missing: process, scheduler")
- Refactored to use `ConfigSection` enum instead of magic numbers

### tests/ConfigLoaderTest.php (new file)
- 9 comprehensive tests covering:
  - Missing workerman config
  - Missing process config
  - Missing scheduler config
  - Multiple missing sections
  - All sections missing
  - Complete configuration (success case)
  - Getter methods validation

## Testing

Unit tests pass:
```
PHPUnit 10.5.63
OK (9 tests, 21 assertions)
```

## BREAKING CHANGE

Cache format changed from numeric indices to string keys:
- **Old format:** `[0 => ..., 1 => ..., 2 => ...]`
- **New format:** `['workerman' => ..., 'process' => ..., 'scheduler' => ...]`

Existing cache must be cleared after upgrade:
```bash
rm -rf var/cache/*
```

Closes #35