### PR TITLE
docs: improve WorkermanCompilerPass::referenceMap() PHPDoc

### DIFF
--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -78,9 +78,11 @@ final class WorkermanCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param string[] $taggedServices
+     * Creates a Reference map from tagged services for ServiceLocator registration.
      *
-     * @return Reference[]
+     * @param array<string, array<string, mixed>> $taggedServices Output from findTaggedServiceIds()
+     *
+     * @return array<string, Reference> Service id => Reference mapping
      */
     private function referenceMap(array $taggedServices): array
     {


### PR DESCRIPTION
Closes #146.

Replaces the minimal `@param string[] $taggedServices` / `@return Reference[]` PHPDoc on `WorkermanCompilerPass::referenceMap()` with a description that names the method's purpose and tightens the types:

- `@param array<string, array<string, mixed>> $taggedServices` matches the shape Symfony's `ContainerBuilder::findTaggedServiceIds()` returns (the actual callers pass its output in directly, see `WorkermanCompilerPass::process()`).
- `@return array<string, Reference>` reflects that the map is keyed by service id, not a positional list.

No behaviour change.
