### PR TITLE
fix(Runner): check mkdir() return value to prevent silent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Runner::run()` — `mkdir()` return value now checked to prevent silent failures ([#151](https://github.com/crazy-goat/workerman-bundle/issues/151))
+  - Throws `\RuntimeException` with clear message when directory creation fails
+  - Double `is_dir()` check handles race condition between check and `mkdir()` call
+
 ## [0.14.0] - 2026-04-14
 
 ### Deprecated

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -107,8 +107,8 @@ final readonly class Runner implements RunnerInterface
         assert(is_int($stopTimeout));
         assert(is_int($maxPackageSize));
 
-        if (!is_dir($varRunDir = dirname($pidFile))) {
-            mkdir(directory: $varRunDir, recursive: true);
+        if (!is_dir($varRunDir = dirname($pidFile)) && !mkdir(directory: $varRunDir, recursive: true) && !is_dir($varRunDir)) {
+            throw new \RuntimeException(sprintf('Unable to create directory "%s".', $varRunDir));
         }
 
         TcpConnection::$defaultMaxPackageSize = $maxPackageSize;

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -108,7 +108,7 @@ final readonly class Runner implements RunnerInterface
         assert(is_int($maxPackageSize));
 
         if (!is_dir($varRunDir = dirname($pidFile)) && !mkdir(directory: $varRunDir, recursive: true) && !is_dir($varRunDir)) {
-            throw new \RuntimeException(sprintf('Unable to create directory "%s".', $varRunDir));
+            throw new \RuntimeException(\sprintf('Unable to create directory "%s".', $varRunDir));
         }
 
         TcpConnection::$defaultMaxPackageSize = $maxPackageSize;

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -74,6 +74,12 @@ final class RunnerTest extends TestCase
             $content,
             'Must have CACHE_WARMUP_TIMEOUT constant',
         );
+
+        $this->assertStringContainsString(
+            'Unable to create directory',
+            $content,
+            'Must throw when mkdir() fails to create var/run directory',
+        );
     }
 
     /**


### PR DESCRIPTION
Closes #151

Checks the return value of `mkdir()` in `Runner::run()` and throws a clear \RuntimeException on failure. The double `is_dir()` check handles the race condition where another process may create the directory between the initial check and the `mkdir()` call.