### PR TITLE
fix: validate dynamic method calls in ProcessHandler and TaskHandler (#153)

### DIFF
--- a/src/Scheduler/TaskHandler.php
+++ b/src/Scheduler/TaskHandler.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Scheduler;
 
 use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\TaskStartEvent;
+use CrazyGoat\WorkermanBundle\Util\ServiceMethodHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -19,13 +20,18 @@ final readonly class TaskHandler
 
     public function __invoke(string $service, string $taskName): void
     {
-        [$serviceName, $method] = explode('::', $service, 2);
+        [$serviceName, $method] = ServiceMethodHelper::split($service);
         $service = $this->locator->get($serviceName);
         assert(is_object($service));
 
         $this->eventDispatcher->dispatch(new TaskStartEvent($service::class, $taskName));
 
         try {
+            if (!method_exists($service, $method)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Method "%s" does not exist on service "%s" (class "%s").', $method, $serviceName, $service::class),
+                );
+            }
             $service->$method();
         } catch (\Throwable $e) {
             $this->eventDispatcher->dispatch(new TaskErrorEvent($e, $service::class, $taskName));

--- a/src/Supervisor/ProcessHandler.php
+++ b/src/Supervisor/ProcessHandler.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Supervisor;
 
 use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\ProcessStartEvent;
+use CrazyGoat\WorkermanBundle\Util\ServiceMethodHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -19,13 +20,18 @@ final readonly class ProcessHandler
 
     public function __invoke(string $service, string $processName): void
     {
-        [$serviceName, $method] = explode('::', $service, 2);
+        [$serviceName, $method] = ServiceMethodHelper::split($service);
         $service = $this->locator->get($serviceName);
         assert(is_object($service));
 
         $this->eventDispatcher->dispatch(new ProcessStartEvent($service::class, $processName));
 
         try {
+            if (!method_exists($service, $method)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Method "%s" does not exist on service "%s" (class "%s").', $method, $serviceName, $service::class),
+                );
+            }
             $service->$method();
         } catch (\Throwable $e) {
             $this->eventDispatcher->dispatch(new ProcessErrorEvent($e, $service::class, $processName));

--- a/src/Util/ServiceMethodHelper.php
+++ b/src/Util/ServiceMethodHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Util;
+
+/**
+ * @internal
+ */
+final class ServiceMethodHelper
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Validate and split a service method string into service ID and method name.
+     *
+     * Expected format: "serviceId::methodName"
+     *
+     * @return array{string, string} [serviceId, methodName]
+     */
+    public static function split(string $service): array
+    {
+        $parts = explode('::', $service, 2);
+        if (\count($parts) !== 2 || $parts[0] === '' || $parts[1] === '') {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid service method format "%s". Expected "serviceId::methodName".', $service),
+            );
+        }
+
+        return [$parts[0], $parts[1]];
+    }
+}

--- a/tests/Scheduler/TaskHandlerTest.php
+++ b/tests/Scheduler/TaskHandlerTest.php
@@ -69,7 +69,7 @@ final class TaskHandlerTest extends TestCase
     public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
     {
         $service = new class {
-            public function execute(): void
+            public function execute(): never
             {
                 throw new \RuntimeException('Task failed');
             }

--- a/tests/Scheduler/TaskHandlerTest.php
+++ b/tests/Scheduler/TaskHandlerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Tests\Scheduler;
+
+use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
+use CrazyGoat\WorkermanBundle\Event\TaskStartEvent;
+use CrazyGoat\WorkermanBundle\Scheduler\TaskHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class TaskHandlerTest extends TestCase
+{
+    public function testInvokeDispatchesStartEventAndCallsServiceMethod(): void
+    {
+        $service = new class {
+            public bool $called = false;
+
+            public function execute(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_task_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(TaskStartEvent::class));
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_task_service::execute', 'test_task');
+
+        $this->assertTrue($service->called);
+    }
+
+    public function testInvokeDispatchesErrorEventWhenMethodDoesNotExist(): void
+    {
+        $service = new class {
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_task_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) {
+                static $callCount = 0;
+                ++$callCount;
+                if ($callCount === 1) {
+                    $this->assertInstanceOf(TaskStartEvent::class, $event);
+                } elseif ($callCount === 2) {
+                    $this->assertInstanceOf(TaskErrorEvent::class, $event);
+                }
+
+                return $event;
+            });
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_task_service::nonexistent', 'test_task');
+        // Should not throw - error is caught by try-catch and dispatched as event
+    }
+
+    public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
+    {
+        $service = new class {
+            public function execute(): void
+            {
+                throw new \RuntimeException('Task failed');
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_task_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) {
+                static $callCount = 0;
+                ++$callCount;
+                if ($callCount === 1) {
+                    $this->assertInstanceOf(TaskStartEvent::class, $event);
+                } elseif ($callCount === 2) {
+                    $this->assertInstanceOf(TaskErrorEvent::class, $event);
+                    $this->assertInstanceOf(\RuntimeException::class, $event->getError());
+                    $this->assertSame('Task failed', $event->getError()->getMessage());
+                }
+
+                return $event;
+            });
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_task_service::execute', 'test_task');
+    }
+
+    /** @dataProvider provideInvalidServiceStrings */
+    public function testInvokeThrowsExceptionOnInvalidFormat(string $input): void
+    {
+        $locator = $this->createMock(ContainerInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid service method format');
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke($input, 'test_task');
+    }
+
+    /** @return iterable<array{string}> */
+    public static function provideInvalidServiceStrings(): iterable
+    {
+        yield 'missing separator' => ['JustAService'];
+        yield 'empty service ID' => ['::method'];
+        yield 'empty method name' => ['service::'];
+        yield 'empty string' => [''];
+    }
+}

--- a/tests/Supervisor/ProcessHandlerTest.php
+++ b/tests/Supervisor/ProcessHandlerTest.php
@@ -69,7 +69,7 @@ final class ProcessHandlerTest extends TestCase
     public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
     {
         $service = new class {
-            public function run(): void
+            public function run(): never
             {
                 throw new \RuntimeException('Something went wrong');
             }

--- a/tests/Supervisor/ProcessHandlerTest.php
+++ b/tests/Supervisor/ProcessHandlerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Tests\Supervisor;
+
+use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
+use CrazyGoat\WorkermanBundle\Event\ProcessStartEvent;
+use CrazyGoat\WorkermanBundle\Supervisor\ProcessHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class ProcessHandlerTest extends TestCase
+{
+    public function testInvokeDispatchesStartEventAndCallsServiceMethod(): void
+    {
+        $service = new class {
+            public bool $called = false;
+
+            public function run(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ProcessStartEvent::class));
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_service::run', 'test_process');
+
+        $this->assertTrue($service->called);
+    }
+
+    public function testInvokeDispatchesErrorEventWhenMethodDoesNotExist(): void
+    {
+        $service = new class {
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) {
+                static $callCount = 0;
+                ++$callCount;
+                if ($callCount === 1) {
+                    $this->assertInstanceOf(ProcessStartEvent::class, $event);
+                } elseif ($callCount === 2) {
+                    $this->assertInstanceOf(ProcessErrorEvent::class, $event);
+                }
+
+                return $event;
+            });
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_service::nonexistent', 'test_process');
+        // Should not throw - error is caught by try-catch and dispatched as event
+    }
+
+    public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
+    {
+        $service = new class {
+            public function run(): void
+            {
+                throw new \RuntimeException('Something went wrong');
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_service')->willReturn($service);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) {
+                static $callCount = 0;
+                ++$callCount;
+                if ($callCount === 1) {
+                    $this->assertInstanceOf(ProcessStartEvent::class, $event);
+                } elseif ($callCount === 2) {
+                    $this->assertInstanceOf(ProcessErrorEvent::class, $event);
+                    $this->assertInstanceOf(\RuntimeException::class, $event->getError());
+                    $this->assertSame('Something went wrong', $event->getError()->getMessage());
+                }
+
+                return $event;
+            });
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke('my_service::run', 'test_process');
+    }
+
+    /** @dataProvider provideInvalidServiceStrings */
+    public function testInvokeThrowsExceptionOnInvalidFormat(string $input): void
+    {
+        $locator = $this->createMock(ContainerInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid service method format');
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke($input, 'test_process');
+    }
+
+    /** @return iterable<array{string}> */
+    public static function provideInvalidServiceStrings(): iterable
+    {
+        yield 'missing separator' => ['JustAService'];
+        yield 'empty service ID' => ['::method'];
+        yield 'empty method name' => ['service::'];
+        yield 'empty string' => [''];
+    }
+}

--- a/tests/Util/ServiceMethodHelperTest.php
+++ b/tests/Util/ServiceMethodHelperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Tests\Util;
+
+use CrazyGoat\WorkermanBundle\Util\ServiceMethodHelper;
+use PHPUnit\Framework\TestCase;
+
+final class ServiceMethodHelperTest extends TestCase
+{
+    /** @dataProvider provideValidServiceStrings */
+    public function testSplitReturnsServiceIdAndMethod(string $input, string $expectedServiceId, string $expectedMethod): void
+    {
+        [$serviceId, $method] = ServiceMethodHelper::split($input);
+
+        $this->assertSame($expectedServiceId, $serviceId);
+        $this->assertSame($expectedMethod, $method);
+    }
+
+    /** @return iterable<array{string, string, string}> */
+    public static function provideValidServiceStrings(): iterable
+    {
+        yield 'simple service and method' => ['App\Service::handle', 'App\Service', 'handle'];
+        yield 'service with dots' => ['app.my_service::execute', 'app.my_service', 'execute'];
+        yield 'method with underscore' => ['SomeService::my_method', 'SomeService', 'my_method'];
+    }
+
+    /** @dataProvider provideInvalidServiceStrings */
+    public function testSplitThrowsExceptionOnInvalidFormat(string $input, string $expectedMessage): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        ServiceMethodHelper::split($input);
+    }
+
+    /** @return iterable<array{string, string}> */
+    public static function provideInvalidServiceStrings(): iterable
+    {
+        yield 'missing separator' => [
+            'JustAService',
+            'Invalid service method format "JustAService". Expected "serviceId::methodName".',
+        ];
+        yield 'empty service ID' => [
+            '::method',
+            'Invalid service method format "::method". Expected "serviceId::methodName".',
+        ];
+        yield 'empty method name' => [
+            'service::',
+            'Invalid service method format "service::". Expected "serviceId::methodName".',
+        ];
+        yield 'empty string' => [
+            '',
+            'Invalid service method format "". Expected "serviceId::methodName".',
+        ];
+        yield 'only separator' => [
+            '::',
+            'Invalid service method format "::". Expected "serviceId::methodName".',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fix #153 — ProcessHandler and TaskHandler now validate the service method format and check method existence before dynamic invocation, preventing worker crashes with clear error messages.

## Changes

### Shared helper (src/Util/ServiceMethodHelper.php)
- New ServiceMethodHelper::split() validates the serviceId::methodName format and returns [serviceId, method]
- Throws InvalidArgumentException on malformed input (missing ::, empty parts)

### ProcessHandler & TaskHandler
- Format validation stays outside try block (fail-fast on config errors)
- Method existence check (method_exists()) moved inside try block — caught by catch (Throwable) and dispatched as error event instead of crashing the worker
- Runtime exceptions from the service method continue to be caught gracefully

### Tests added (22 total)
- ServiceMethodHelperTest: valid formats, invalid formats (5 variants)
- ProcessHandlerTest: success, missing method, runtime exception, invalid format
- TaskHandlerTest: success, missing method, runtime exception, invalid format
