### PR TITLE
fix(ci): pin shivammathur/setup-php to commit SHA in tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
 
       - name: Validate composer.json
         run: composer validate --strict
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
## Summary

- Replace mutable tag `shivammathur/setup-php@v2` with a pinned commit SHA in `.github/workflows/tests.yaml`
- Prevents supply chain attacks via force-pushed tags
- Aligns with the pinning strategy already used in `release.yaml`

## Changes

| Location | Before | After |
|----------|--------|-------|
| `tests.yaml` line 15 (lint job) | `shivammathur/setup-php@v2` | `shivammathur/setup-php@accd6127` # v2.37.0 |
| `tests.yaml` line 85 (test job) | `shivammathur/setup-php@v2` | `shivammathur/setup-php@accd6127` # v2.37.0 |

Closes #149