### PR TITLE
fix(SchedulerWorker): log exceptions in child process instead of swallowing

### DIFF
--- a/src/Worker/SchedulerWorker.php
+++ b/src/Worker/SchedulerWorker.php
@@ -154,12 +154,14 @@ final class SchedulerWorker
                 ($this->handler)($service, $taskName);
             } catch (\Throwable $e) {
                 $this->worker->log(sprintf(
-                    '%s Task "%s" failed: %s in %s:%d',
+                    '%s Task "%s" failed: [%s] %s in %s:%d\nStack trace:\n%s',
                     $this->worker->name,
                     $taskName,
+                    $e::class,
                     $e->getMessage(),
                     $e->getFile(),
                     $e->getLine(),
+                    $e->getTraceAsString(),
                 ));
                 $childExitCode = 1;
             } finally {

--- a/src/Worker/SchedulerWorker.php
+++ b/src/Worker/SchedulerWorker.php
@@ -152,7 +152,15 @@ final class SchedulerWorker
             $childExitCode = 0;
             try {
                 ($this->handler)($service, $taskName);
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->worker->log(sprintf(
+                    '%s Task "%s" failed: %s in %s:%d',
+                    $this->worker->name,
+                    $taskName,
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine(),
+                ));
                 $childExitCode = 1;
             } finally {
                 // Release lock, cleanup and exit

--- a/tests/SchedulerWorkerSigchldTest.php
+++ b/tests/SchedulerWorkerSigchldTest.php
@@ -88,6 +88,49 @@ final class SchedulerWorkerSigchldTest extends TestCase
     }
 
     /**
+     * Structural test: verify SchedulerWorker logs exceptions in child process.
+     * This is a regression safety net for Issue #157 — if someone removes the
+     * exception logging or reverts to silently swallowing exceptions, this test
+     * catches it immediately.
+     */
+    public function testSchedulerWorkerLogsExceptionsInChildProcess(): void
+    {
+        $sourceFile = dirname(__DIR__) . '/src/Worker/SchedulerWorker.php';
+        $this->assertFileExists($sourceFile);
+
+        $content = file_get_contents($sourceFile);
+        $this->assertNotFalse($content);
+
+        // Verify the catch block captures the exception variable
+        $this->assertStringContainsString(
+            'catch (\Throwable $e)',
+            $content,
+            'Catch block must capture exception variable for logging (Issue #157)',
+        );
+
+        // Verify the exception is logged via Worker::log()
+        $this->assertStringContainsString(
+            '$this->worker->log(sprintf(',
+            $content,
+            'Exception must be logged via Worker::log() in child process (Issue #157)',
+        );
+
+        // Verify the log message includes exception type
+        $this->assertStringContainsString(
+            '$e::class',
+            $content,
+            'Log message must include exception type for quick identification (Issue #157)',
+        );
+
+        // Verify the log message includes stack trace
+        $this->assertStringContainsString(
+            '$e->getTraceAsString()',
+            $content,
+            'Log message must include stack trace for full diagnostic information (Issue #157)',
+        );
+    }
+
+    /**
      * Run a SIGCHLD test in an isolated PHP process to avoid PHPUnit
      * state inheritance issues with pcntl_fork().
      *


### PR DESCRIPTION
## Summary

- Fixes #157
- When a scheduled task throws an exception in a forked child process, the exception was silently swallowed
- Now the exception is logged via `Worker::log()` before exiting, providing diagnostic information

## Changes

**Before:**
```php
} catch (\Throwable) {
    $childExitCode = 1;
}
```

**After:**
```php
} catch (\Throwable $e) {
    $this->worker->log(sprintf(
        '%s Task "%s" failed: %s in %s:%d',
        $this->worker->name,
        $taskName,
        $e->getMessage(),
        $e->getFile(),
        $e->getLine(),
    ));
    $childExitCode = 1;
}
```

## Testing

- ✅ All SchedulerWorker tests pass (5 tests)
- ✅ PHPStan passes (with `--memory-limit=256M`)
- ✅ PHP CS Fixer passes