### PR TITLE
refactor: inject SymfonyController via DI into HttpRequestHandler

### DIFF
--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\DependencyInjection;
 
 use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
+use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\StackRebootStrategy;
 use CrazyGoat\WorkermanBundle\Scheduler\TaskHandler;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessHandler;
@@ -51,13 +52,20 @@ final class WorkermanCompilerPass implements CompilerPassInterface
             ->setArguments([$this->referenceMap($responseConverterStrategies)]);
 
         $container
+            ->register('workerman.symfony_controller', SymfonyController::class)
+            ->setArguments([
+                new Reference(KernelInterface::class),
+                new Reference('workerman.response_converter'),
+            ]);
+
+        $container->setAlias(SymfonyController::class, 'workerman.symfony_controller');
+
+        $container
             ->register('workerman.http_request_handler', HttpRequestHandler::class)
             ->setPublic(true)
             ->setArguments([
-                new Reference(KernelInterface::class),
+                new Reference('workerman.symfony_controller'),
                 new Reference('workerman.reboot_strategy'),
-                new Reference('workerman.response_converter'),
-                [],
             ]);
 
         $container

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Http;
 
-use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Utils;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
 use Workerman\Timer;
@@ -19,15 +17,12 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
 {
     /** @var MiddlewareInterface[] */
     private array $middlewares = [];
-    private readonly SymfonyController $controller;
     private ?int $terminateTimerId = null;
 
     public function __construct(
-        private readonly KernelInterface         $kernel,
-        private readonly RebootStrategyInterface $rebootStrategy,
-        private readonly ResponseConverter       $responseConverter,
+        private readonly SymfonyController         $controller,
+        private readonly RebootStrategyInterface   $rebootStrategy,
     ) {
-        $this->controller = new SymfonyController($this->kernel, $this->responseConverter);
     }
 
     public function withMiddlewares(MiddlewareInterface ...$middlewares): self

--- a/tests/DependencyInjection/WorkermanCompilerPassTest.php
+++ b/tests/DependencyInjection/WorkermanCompilerPassTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\WorkermanBundle\DependencyInjection\WorkermanCompilerPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 final class WorkermanCompilerPassTest extends TestCase
 {
@@ -114,6 +115,31 @@ final class WorkermanCompilerPassTest extends TestCase
 
         $httpRequestHandler = $this->container->getDefinition('workerman.http_request_handler');
         $this->assertTrue($httpRequestHandler->isPublic());
+    }
+
+    public function testRegistersSymfonyControllerService(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->compilerPass->process($this->container);
+
+        $this->assertTrue($this->container->has('workerman.symfony_controller'));
+    }
+
+    public function testSymfonyControllerReceivesCorrectDependencies(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->compilerPass->process($this->container);
+
+        $definition = $this->container->getDefinition('workerman.symfony_controller');
+        $args = $definition->getArguments();
+
+        $this->assertCount(2, $args);
+        $this->assertInstanceOf(Reference::class, $args[0]);
+        $this->assertSame(KernelInterface::class, (string) $args[0]);
+        $this->assertInstanceOf(Reference::class, $args[1]);
+        $this->assertSame('workerman.response_converter', (string) $args[1]);
     }
 
     public function testTaskAndProcessHandlersArePublic(): void

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Test\App\TestMiddleware;
 use PHPUnit\Framework\TestCase;
@@ -181,8 +182,8 @@ final class HttpRequestHandlerTest extends TestCase
     {
         $this->kernel = new HttpHandlerTestKernel();
         $this->rebootStrategy = new TestRebootStrategy();
-        $responseConverter = new ResponseConverter([new DefaultResponseStrategy()]);
-        $this->handler = new HttpRequestHandler($this->kernel, $this->rebootStrategy, $responseConverter);
+        $controller = new SymfonyController($this->kernel, new ResponseConverter([new DefaultResponseStrategy()]));
+        $this->handler = new HttpRequestHandler($controller, $this->rebootStrategy);
     }
 
     public function testHandlerInitializesCorrectly(): void
@@ -245,9 +246,19 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertSame($this->handler, $result);
     }
 
-    public function testKernelIsSetCorrectly(): void
+    public function testKernelIsNotBootedBeforeRequest(): void
     {
         $this->assertFalse($this->kernel->bootCalled);
+    }
+
+    public function testSymfonyControllerIsInjectedViaConstructor(): void
+    {
+        $controller = new SymfonyController($this->kernel, new ResponseConverter([new DefaultResponseStrategy()]));
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+
+        $reflection = new \ReflectionClass($handler);
+        $controllerProperty = $reflection->getProperty('controller');
+        $this->assertSame($controller, $controllerProperty->getValue($handler));
     }
 
     public function testRebootStrategyIsSetCorrectly(): void

--- a/tests/ServicesAutowiringTest.php
+++ b/tests/ServicesAutowiringTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
+use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Scheduler\TaskHandler;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessHandler;
 use Psr\Container\ContainerInterface;
@@ -19,6 +20,7 @@ final class ServicesAutowiringTest extends KernelTestCase
         $this->assertInstanceOf(ContainerInterface::class, $container->get('workerman.process_locator'));
         $this->assertInstanceOf(ContainerInterface::class, $container->get('workerman.task_locator'));
         $this->assertInstanceOf(HttpRequestHandler::class, $container->get('workerman.http_request_handler'));
+        $this->assertInstanceOf(SymfonyController::class, $container->get('workerman.symfony_controller'));
         $this->assertInstanceOf(TaskHandler::class, $container->get('workerman.task_handler'));
         $this->assertInstanceOf(ProcessHandler::class, $container->get('workerman.process_handler'));
     }


### PR DESCRIPTION
Closes #158

## Summary

`HttpRequestHandler` previously created `SymfonyController` internally via `new SymfonyController(...)`, bypassing Symfony's DI container. This made testing harder and prevented decorating/swapping the controller.

## Changes

- `HttpRequestHandler` now accepts `SymfonyController$controller` via constructor injection
- `WorkermanCompilerPass` registers `workerman.symfony_controller` service and sets an autowiring alias
- Removed unused `KernelInterface` and `ResponseConverter` dependencies from `HttpRequestHandler`
- Updated tests: compiler pass registration tests, handler constructor test, autowiring integration test

## BC Note

`HttpRequestHandler` constructor signature changed from 3 params (`KernelInterface$kernel, RebootStrategyInterface $rebootStrategy, ResponseConverter $responseConverter`) to 2 params (`SymfonyController$controller, RebootStrategyInterface $rebootStrategy`). The class is `final` and all in-repo callers have been updated.