### PR TITLE
feat: rename Utils::reboot() to Utils::reload() with deprecated alias (#32)

### DIFF
--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -80,22 +80,22 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
             $connection->close();
         }
 
-        // Ensure terminate completes before reboot to avoid race conditions
+        // Ensure terminate completes before reload to avoid race conditions
         if ($this->rebootStrategy->shouldReboot()) {
             Timer::del($timerId);
             $this->terminateTimerId = null;
-            // Call terminate synchronously before reboot
+            // Call terminate synchronously before reload
             try {
                 $this->controller->terminateIfNeeded();
             } catch (\Throwable $e) {
                 error_log(sprintf(
-                    'Kernel termination failed during reboot: %s in %s:%d',
+                    'Kernel termination failed during reload: %s in %s:%d',
                     $e->getMessage(),
                     $e->getFile(),
                     $e->getLine(),
                 ));
             }
-            Utils::reboot();
+            Utils::reload();
         }
     }
 }

--- a/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
@@ -46,8 +46,8 @@ abstract class FileMonitorWatcher
         return false;
     }
 
-    final protected function reboot(): void
+    final protected function reload(): void
     {
-        Utils::reboot(rebootAllWorkers: true);
+        Utils::reload(reloadAllWorkers: true);
     }
 }

--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -9,12 +9,12 @@ use Workerman\Worker;
 
 final class InotifyMonitorWatcher extends FileMonitorWatcher
 {
-    private const REBOOT_DELAY = 0.33;
+    private const RELOAD_DELAY = 0.33;
     /** @var resource */
     private $fd;
     /** @var string[] */
     private array $pathByWd = [];
-    private \Closure|null $rebootCallback = null;
+    private \Closure|null $reloadCallback = null;
 
     public function start(): void
     {
@@ -48,7 +48,7 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
         if (function_exists('inotify_read')) {
             $events = \inotify_read($inotifyFd) ?: [];
 
-            if ($this->rebootCallback instanceof \Closure) {
+            if ($this->reloadCallback instanceof \Closure) {
                 return;
             }
 
@@ -67,12 +67,12 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
                     continue;
                 }
 
-                $this->rebootCallback = function (): void {
-                    $this->rebootCallback = null;
-                    $this->reboot();
+                $this->reloadCallback = function (): void {
+                    $this->reloadCallback = null;
+                    $this->reload();
                 };
 
-                $this->worker::$globalEvent?->delay(self::REBOOT_DELAY, $this->rebootCallback);
+                $this->worker::$globalEvent?->delay(self::RELOAD_DELAY, $this->reloadCallback);
 
                 return;
             }

--- a/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
@@ -44,7 +44,7 @@ final class PollingMonitorWatcher extends FileMonitorWatcher
 
                 if ($file->getFileInfo()->getMTime() > $this->lastMTime) {
                     $this->lastMTime = $file->getFileInfo()->getMTime();
-                    $this->reboot();
+                    $this->reload();
                     return;
                 }
             }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -45,9 +45,18 @@ final class Utils
         return \DIRECTORY_SEPARATOR !== '/';
     }
 
+    public static function reload(bool $reloadAllWorkers = false): void
+    {
+        posix_kill($reloadAllWorkers ? posix_getppid() : posix_getpid(), SIGUSR1);
+    }
+
+    /**
+     * @deprecated since 0.17.0, use Utils::reload() instead.
+     */
     public static function reboot(bool $rebootAllWorkers = false): void
     {
-        posix_kill($rebootAllWorkers ? posix_getppid() : posix_getpid(), SIGUSR1);
+        trigger_deprecation('crazy-goat/workerman-bundle', '0.17.0', 'Utils::reboot() is deprecated, use Utils::reload() instead.');
+        self::reload($rebootAllWorkers);
     }
 
     public static function clearOpcache(): void

--- a/tests/UtilsE2ETest.php
+++ b/tests/UtilsE2ETest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * E2E tests for Utils::reload().
+ *
+ * These tests verify that Utils::reload() actually sends a SIGUSR1 signal
+ * in a real subprocess context (not just within the same process).
+ */
+final class UtilsE2ETest extends TestCase
+{
+    private string $tempDir;
+    private string $autoloadPath;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            self::markTestSkipped('pcntl and posix extensions are required for this test.');
+        }
+
+        $this->tempDir = \sys_get_temp_dir() . '/workerman_e2e_' . \bin2hex(\random_bytes(4));
+        \mkdir($this->tempDir, 0700);
+        $autoloadPath = \realpath(__DIR__ . '/../vendor/autoload.php');
+        if ($autoloadPath === false) {
+            self::markTestSkipped('vendor/autoload.php not found.');
+        }
+        $this->autoloadPath = $autoloadPath;
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tempDir) && \is_dir($this->tempDir)) {
+            $files = \glob($this->tempDir . '/*.php');
+            if (\is_array($files)) {
+                \array_map(\unlink(...), $files);
+            }
+            \rmdir($this->tempDir);
+        }
+    }
+
+    public function testReloadSendsSigusr1ToChildProcess(): void
+    {
+        $scriptFile = $this->tempDir . '/test_reload.php';
+        \file_put_contents(
+            $scriptFile,
+            \sprintf(
+                <<<'PHP'
+<?php
+require %s;
+
+$signalReceived = false;
+pcntl_signal(SIGUSR1, function () use (&$signalReceived) {
+    $signalReceived = true;
+});
+
+\CrazyGoat\WorkermanBundle\Utils::reload();
+
+$start = microtime(true);
+while (!$signalReceived && (microtime(true) - $start) < 2) {
+    pcntl_signal_dispatch();
+    usleep(10000);
+}
+
+exit($signalReceived ? 0 : 1);
+PHP,
+                \var_export($this->autoloadPath, true),
+            ),
+        );
+
+        $exitCode = $this->runPhpScript($scriptFile);
+        self::assertSame(0, $exitCode, 'Utils::reload() should send SIGUSR1 in a subprocess.');
+    }
+
+    public function testDeprecatedRebootStillWorksInSubprocess(): void
+    {
+        $scriptFile = $this->tempDir . '/test_reboot_deprecated.php';
+        \file_put_contents(
+            $scriptFile,
+            \sprintf(
+                <<<'PHP'
+<?php
+require %s;
+
+$signalReceived = false;
+pcntl_signal(SIGUSR1, function () use (&$signalReceived) {
+    $signalReceived = true;
+});
+
+set_error_handler(function (int $errno, string $errstr) {
+    return $errno === E_USER_DEPRECATED;
+});
+
+\CrazyGoat\WorkermanBundle\Utils::reboot();
+restore_error_handler();
+
+$start = microtime(true);
+while (!$signalReceived && (microtime(true) - $start) < 2) {
+    pcntl_signal_dispatch();
+    usleep(10000);
+}
+
+exit($signalReceived ? 0 : 1);
+PHP,
+                \var_export($this->autoloadPath, true),
+            ),
+        );
+
+        $exitCode = $this->runPhpScript($scriptFile);
+        self::assertSame(0, $exitCode, 'Deprecated Utils::reboot() should still send SIGUSR1 in a subprocess.');
+    }
+
+    private function runPhpScript(string $scriptFile): int
+    {
+        $proc = \proc_open(
+            ['php', $scriptFile],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+        );
+
+        if (!\is_resource($proc)) {
+            $this->fail('Failed to start subprocess.');
+        }
+
+        \fclose($pipes[0]);
+        \stream_get_contents($pipes[1]);
+        \fclose($pipes[1]);
+        $stderr = \stream_get_contents($pipes[2]);
+        \fclose($pipes[2]);
+
+        $exitCode = \proc_close($proc);
+
+        if ($exitCode !== 0 && $stderr !== '' && $stderr !== false) {
+            \fwrite(\STDERR, "Subprocess stderr: " . $stderr);
+        }
+
+        return $exitCode;
+    }
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -70,11 +70,77 @@ final class UtilsTest extends TestCase
         new Utils();
     }
 
-    public function testReboot(): void
+    public function testReloadSendsSigusr1(): void
     {
-        $this->markTestSkipped(
-            'Utils::reboot() sends POSIX signals and requires a running Workerman process. ' .
-            'Cannot be tested in unit test context — requires integration test.',
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl and posix extensions are required for this test.');
+        }
+
+        $signalReceived = false;
+        \pcntl_signal(SIGUSR1, static function () use (&$signalReceived): void {
+            $signalReceived = true;
+        });
+
+        try {
+            Utils::reload();
+            \pcntl_signal_dispatch();
+            $this->assertTrue($signalReceived, 'reload() should send SIGUSR1 signal.');
+        } finally {
+            \pcntl_signal(SIGUSR1, SIG_DFL);
+        }
+    }
+
+    public function testDeprecatedRebootTriggersDeprecation(): void
+    {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl and posix extensions are required for this test.');
+        }
+
+        \pcntl_signal(SIGUSR1, static fn(): null => null);
+
+        $deprecationTriggered = false;
+        \set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecationTriggered): bool {
+                if ($errno === \E_USER_DEPRECATED && \str_contains($errstr, 'Utils::reboot() is deprecated')) {
+                    $deprecationTriggered = true;
+
+                    return true;
+                }
+
+                return false;
+            },
         );
+
+        try {
+            Utils::reboot();
+            \pcntl_signal_dispatch();
+            $this->assertTrue($deprecationTriggered, 'reboot() should trigger a deprecation notice.');
+        } finally {
+            \restore_error_handler();
+            \pcntl_signal(SIGUSR1, SIG_DFL);
+        }
+    }
+
+    public function testDeprecatedRebootDelegatesToReload(): void
+    {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl and posix extensions are required for this test.');
+        }
+
+        $signalReceived = false;
+        \pcntl_signal(SIGUSR1, static function () use (&$signalReceived): void {
+            $signalReceived = true;
+        });
+
+        \set_error_handler(static fn(int $errno): bool => $errno === \E_USER_DEPRECATED);
+
+        try {
+            Utils::reboot();
+            \pcntl_signal_dispatch();
+            $this->assertTrue($signalReceived, 'reboot() should delegate to reload() and send SIGUSR1.');
+        } finally {
+            \restore_error_handler();
+            \pcntl_signal(SIGUSR1, SIG_DFL);
+        }
     }
 }


### PR DESCRIPTION
## Description

Renames `Utils::reboot()` to `Utils::reload()` because "reload" accurately reflects the Workerman SIGUSR1 signal behavior (graceful worker restart), whereas "reboot" is misleading.

### Changes

- **src/Utils.php**: Rename `reboot()` → `reload()`. Add deprecated `reboot()` alias that calls `reload()` and triggers a deprecation notice.
- **src/Http/HttpRequestHandler.php**: Update call site + comments.
- **src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php**: Rename `reboot()` → `reload()`.
- **src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php**: Rename `REBOOT_DELAY` → `RELOAD_DELAY`, `` → ``.
- **src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php**: Update call site.
- **tests/UtilsTest.php**: Add unit tests with pcntl signal handler verification.
- **tests/UtilsE2ETest.php**: Add E2E tests with subprocess signal delivery.

### Backward Compatibility

`Utils::reboot()` is preserved as a deprecated alias with `@deprecated` annotation and `trigger_deprecation()` notice. It will be removed in a future major version.

Closes #32