### PR TITLE
Remove 8 permanently skipped tests from HttpRequestHandlerTest (#154)

### DIFF
--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -168,9 +168,6 @@ final class TestRebootStrategy implements RebootStrategyInterface
 
 /**
  * Tests for HttpRequestHandler initialization and configuration
- *
- * Note: Full request handling tests require Workerman running environment
- * due to Timer::add() usage. Those are covered by integration tests.
  */
 final class HttpRequestHandlerTest extends TestCase
 {
@@ -269,108 +266,4 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertTrue($this->rebootStrategy->shouldReboot);
     }
 
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testRequestProcessingSendsResponse(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running. ' .
-            'Run integration tests instead.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testHttp10ConnectionIsClosed(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testConnectionCloseHeaderClosesConnection(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testKeepAliveConnectionNotClosed(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testRebootTriggersSynchronousTerminate(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testKernelBootIsCalled(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testResponseContainsCorrectStatus(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
-
-    /**
-     * @requires extension pcntl
-     * @requires function pcntl_fork
-     * This test requires Workerman running environment
-     */
-    public function testResponseContainsBodyContent(): void
-    {
-        $this->markTestSkipped(
-            'This test requires Workerman running environment. ' .
-            'Timer::add() can only be used when Workerman is running.',
-        );
-    }
 }

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
-use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;


### PR DESCRIPTION
## Description

Removes 8 test methods from `HttpRequestHandlerTest` that were permanently marked as skipped with `$this->markTestSkipped()`. These tests have never executed and only inflate test metrics while providing false confidence.

## Changes

- Removed 8 permanently skipped test methods:
  - `testRequestProcessingSendsResponse`
  - `testHttp10ConnectionIsClosed`
  - `testConnectionCloseHeaderClosesConnection`
  - `testKeepAliveConnectionNotClosed`
  - `testRebootTriggersSynchronousTerminate`
  - `testKernelBootIsCalled`
  - `testResponseContainsCorrectStatus`
  - `testResponseContainsBodyContent`
- Removed unused `Request` import
- Updated class docblock

## Verification

- All 8 method names have zero references elsewhere in the codebase
- Full test suite: 334 tests, 1038 assertions, 2 skipped (pre-existing skips from other files)
- PHP CS Fixer, PHPStan, Rector all pass

Closes #154