### PR TITLE
fix: remove unnecessary array_map calls and simplify data flow in WorkermanCompilerPass

### DIFF
--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -21,12 +21,14 @@ final class WorkermanCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $tasks = array_map(fn(array $a) => $a[0], $container->findTaggedServiceIds('workerman.task'));
-        $processes = array_map(fn(array $a) => $a[0], $container->findTaggedServiceIds('workerman.process'));
-        $rebootStrategies = array_map(fn(array $a) => $a[0], $container->findTaggedServiceIds('workerman.reboot_strategy'));
-        $responseConverterStrategiesTagged = $container->findTaggedServiceIds('workerman.response_converter.strategy');
-        uasort($responseConverterStrategiesTagged, fn(array $a, array $b): int => ($b[0]['priority'] ?? 0) <=> ($a[0]['priority'] ?? 0));
-        $responseConverterStrategies = array_map(fn(array $a) => $a[0], $responseConverterStrategiesTagged);
+        $tasksTagged = $container->findTaggedServiceIds('workerman.task');
+        $processesTagged = $container->findTaggedServiceIds('workerman.process');
+        $rebootStrategies = $container->findTaggedServiceIds('workerman.reboot_strategy');
+        $responseConverterStrategies = $container->findTaggedServiceIds('workerman.response_converter.strategy');
+        uasort($responseConverterStrategies, fn(array $a, array $b): int => ($b[0]['priority'] ?? 0) <=> ($a[0]['priority'] ?? 0));
+
+        $tasks = array_map(fn(array $a): array => $a[0], $tasksTagged);
+        $processes = array_map(fn(array $a): array => $a[0], $processesTagged);
 
         $container
             ->getDefinition('workerman.config_loader')
@@ -88,7 +90,7 @@ final class WorkermanCompilerPass implements CompilerPassInterface
     /**
      * Creates a Reference map from tagged services for ServiceLocator registration.
      *
-     * @param array<string, array<string, mixed>> $taggedServices Output from findTaggedServiceIds()
+     * @param array<string, mixed> $taggedServices Associative array keyed by service IDs (values ignored, only keys used)
      *
      * @return array<string, Reference> Service id => Reference mapping
      */

--- a/tests/DependencyInjection/WorkermanCompilerPassTest.php
+++ b/tests/DependencyInjection/WorkermanCompilerPassTest.php
@@ -180,4 +180,46 @@ final class WorkermanCompilerPassTest extends TestCase
         $this->assertSame('service.a', (string) $references['service.a']);
         $this->assertSame('service.b', (string) $references['service.b']);
     }
+
+    public function testReferenceMapUsesOnlyServiceIdsNotTagAttributes(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->container->register('service.one', \stdClass::class)
+            ->addTag('workerman.task', ['priority' => 10, 'env' => 'prod']);
+        $this->container->register('service.two', \stdClass::class)
+            ->addTag('workerman.task', ['priority' => 20, 'env' => 'dev']);
+
+        $this->compilerPass->process($this->container);
+
+        $taskLocator = $this->container->getDefinition('workerman.task_locator');
+        $args = $taskLocator->getArguments();
+        $references = $args[0];
+
+        $this->assertCount(2, $references);
+        $this->assertArrayHasKey('service.one', $references);
+        $this->assertArrayHasKey('service.two', $references);
+        $this->assertSame('service.one', (string) $references['service.one']);
+        $this->assertSame('service.two', (string) $references['service.two']);
+    }
+
+    public function testRebootStrategyReferenceMapUsesOnlyServiceIds(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->container->register('strategy.a', \stdClass::class)
+            ->addTag('workerman.reboot_strategy');
+        $this->container->register('strategy.b', \stdClass::class)
+            ->addTag('workerman.reboot_strategy');
+
+        $this->compilerPass->process($this->container);
+
+        $rebootStrategy = $this->container->getDefinition('workerman.reboot_strategy');
+        $args = $rebootStrategy->getArguments();
+        $references = $args[0];
+
+        $this->assertCount(2, $references);
+        $this->assertArrayHasKey('strategy.a', $references);
+        $this->assertArrayHasKey('strategy.b', $references);
+    }
 }


### PR DESCRIPTION
## Description

Removes unnecessary `array_map` transformations in `WorkermanCompilerPass` that were confusing data flow.

### Changes

1. **``** — removed unnecessary `array_map($a[0])` since this variable only flows through `referenceMap()` which uses only array keys
2. **``** — merged the two-variable pattern (`*Tagged` + `array_map`) into a single variable; `uasort` + `referenceMap()` both work correctly on the raw `findTaggedServiceIds()` result
3. **`` / ``** — kept the `array_map` (they need flattened tag attributes for `ConfigLoader` → `SchedulerWorker`/ `SupervisorWorker`), but renamed intermediate variables to clarify the data flow
4. **`referenceMap()` phpdoc** — corrected `@param` type from `array<string, array<string, mixed>>` to `array<string, mixed>` since only array keys are consumed

### Tests

- Added `testReferenceMapUsesOnlyServiceIdsNotTagAttributes`: verifies task locator references ignore tag attribute values
- Added `testRebootStrategyReferenceMapUsesOnlyServiceIds`: verifies reboot strategy references are built from service IDs only

Closes #24