### PR TITLE
fix: remove FPM-specific no-op calls from StreamedBinaryFileResponse (#160)

### DIFF
--- a/src/Protocol/Http/Response/StreamedBinaryFileResponse.php
+++ b/src/Protocol/Http/Response/StreamedBinaryFileResponse.php
@@ -26,8 +26,6 @@ class StreamedBinaryFileResponse extends BinaryFileResponse implements StreamRes
                 $file = new \SplFileObject($this->file->getPathname(), 'r');
             }
 
-            ignore_user_abort(true);
-
             if (0 !== $this->offset) {
                 $file->fseek($this->offset);
             }
@@ -40,9 +38,6 @@ class StreamedBinaryFileResponse extends BinaryFileResponse implements StreamRes
                     break;
                 }
                 yield $data;
-                if (connection_aborted() !== 0) {
-                    break;
-                }
                 if (0 < $length) {
                     $length -= strlen($data);
                 }

--- a/src/Worker/SupervisorWorker.php
+++ b/src/Worker/SupervisorWorker.php
@@ -22,7 +22,7 @@ readonly class SupervisorWorker
                 continue;
             }
 
-            if ($serviceConfig['processes'] !== null && $serviceConfig['processes'] <= 0) {
+            if (isset($serviceConfig['processes']) && $serviceConfig['processes'] <= 0) {
                 continue;
             }
 

--- a/tests/App/ResponseTestController.php
+++ b/tests/App/ResponseTestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test\App;
 
+use CrazyGoat\WorkermanBundle\Protocol\Http\Response\StreamedBinaryFileResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -56,6 +57,16 @@ final class ResponseTestController extends AbstractController
         $property->setValue($response, true);
 
         return $response;
+    }
+
+    #[Route('/response_test_streamed_binary', name: 'app_response_test_streamed_binary')]
+    public function streamedBinaryFileResponse(): StreamedBinaryFileResponse
+    {
+        $testFile = __DIR__ . '/../fixtures/test_download.txt';
+
+        return new StreamedBinaryFileResponse($testFile, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
     }
 
     #[Route('/response_test_temp_file', name: 'app_response_test_temp_file')]

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -101,6 +101,17 @@ final class ResponseTest extends KernelTestCase
         // File should be deleted after download (handled by strategy)
     }
 
+    public function testStreamedBinaryFileResponse(): void
+    {
+        $client = new Client(['http_errors' => false]);
+
+        $response = $client->request('GET', 'http://127.0.0.1:8888/response_test_streamed_binary');
+
+        $this->assertContains($response->getStatusCode(), [200, 206]);
+        $this->assertStringContainsString('Test file download content', (string) $response->getBody());
+        $this->assertStringContainsString('text/plain', $response->getHeaderLine('content-type'));
+    }
+
     public function testBinaryFileResponseWithTempFileObject(): void
     {
         $client = new Client(['http_errors' => false]);

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use CrazyGoat\WorkermanBundle\Protocol\Http\Response\StreamedBinaryFileResponse;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class StreamedBinaryFileResponseTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        $this->testFile = sys_get_temp_dir() . '/test_streamed_binary_' . uniqid() . '.txt';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+    }
+
+    public function testStreamContentReturnsGenerator(): void
+    {
+        file_put_contents($this->testFile, 'test content');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $generator = $response->streamContent();
+
+        $this->assertInstanceOf(\Generator::class, $generator);
+    }
+
+    public function testStreamContentReturnsEarlyForUnsuccessfulResponse(): void
+    {
+        file_put_contents($this->testFile, 'test content');
+        $response = new StreamedBinaryFileResponse($this->testFile, Response::HTTP_NOT_FOUND);
+
+        $generator = $response->streamContent();
+
+        $this->assertInstanceOf(\Generator::class, $generator);
+        $this->assertSame($response, $generator->getReturn());
+    }
+
+    public function testStreamContentReturnsEarlyWhenMaxlenIsZero(): void
+    {
+        file_put_contents($this->testFile, 'test content');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $maxlenProperty = $reflection->getProperty('maxlen');
+        $maxlenProperty->setValue($response, 0);
+
+        $generator = $response->streamContent();
+
+        $this->assertInstanceOf(\Generator::class, $generator);
+        $this->assertSame($response, $generator->getReturn());
+    }
+
+    public function testStreamContentYieldsFullFileContent(): void
+    {
+        $content = 'Hello World from streamed binary file!';
+        file_put_contents($this->testFile, $content);
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame($content, $output);
+    }
+
+    public function testStreamContentRespectsOffset(): void
+    {
+        $content = 'Hello World from streamed binary file!';
+        file_put_contents($this->testFile, $content);
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $offsetProperty = $reflection->getProperty('offset');
+        $offsetProperty->setValue($response, 6);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame('World from streamed binary file!', $output);
+    }
+
+    public function testStreamContentRespectsMaxlen(): void
+    {
+        $content = 'Hello World from streamed binary file!';
+        file_put_contents($this->testFile, $content);
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $maxlenProperty = $reflection->getProperty('maxlen');
+        $maxlenProperty->setValue($response, 13);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame('Hello World f', $output);
+    }
+
+    public function testStreamContentHandlesLargeFile(): void
+    {
+        $content = str_repeat('A', 100000);
+        file_put_contents($this->testFile, $content);
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame(100000, strlen($output));
+        $this->assertSame($content, $output);
+    }
+
+    public function testStreamContentWithSplTempFileObject(): void
+    {
+        $content = 'Temp file object content for streaming';
+        $tempFile = new \SplTempFileObject();
+        $tempFile->fwrite($content);
+
+        $dummyFile = sys_get_temp_dir() . '/dummy_' . uniqid() . '.txt';
+        file_put_contents($dummyFile, 'dummy');
+        $response = new StreamedBinaryFileResponse($dummyFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('tempFileObject');
+        $property->setValue($response, $tempFile);
+        unlink($dummyFile);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame($content, $output);
+    }
+
+    public function testStreamContentDoesNotDeleteSplTempFileObjectInFinally(): void
+    {
+        $tempFile = new \SplTempFileObject();
+        $tempFile->fwrite('content');
+
+        $dummyFile = sys_get_temp_dir() . '/dummy_' . uniqid() . '.txt';
+        file_put_contents($dummyFile, 'dummy');
+        $response = new StreamedBinaryFileResponse($dummyFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('tempFileObject');
+        $property->setValue($response, $tempFile);
+        $deleteProperty = $reflection->getProperty('deleteFileAfterSend');
+        $deleteProperty->setValue($response, true);
+        unlink($dummyFile);
+
+        $generator = $response->streamContent();
+
+        foreach ($generator as $chunk) {
+            // consume generator
+        }
+
+        $tempFile->rewind();
+        $this->assertSame('content', $tempFile->fread(1024));
+    }
+
+    public function testStreamContentDeletesFileWhenDeleteFileAfterSendIsTrue(): void
+    {
+        file_put_contents($this->testFile, 'delete me after stream');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($response, true);
+
+        $this->assertFileExists($this->testFile);
+
+        $generator = $response->streamContent();
+
+        foreach ($generator as $chunk) {
+            // consume generator
+        }
+
+        $this->assertFileDoesNotExist($this->testFile);
+    }
+
+    public function testStreamContentDoesNotDeleteFileWhenDeleteFileAfterSendIsFalse(): void
+    {
+        file_put_contents($this->testFile, 'do not delete me');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $this->assertFileExists($this->testFile);
+
+        $generator = $response->streamContent();
+
+        foreach ($generator as $chunk) {
+            // consume generator
+        }
+
+        $this->assertFileExists($this->testFile);
+    }
+
+    public function testStreamContentReturnsResponseAsReturnValue(): void
+    {
+        file_put_contents($this->testFile, 'test');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $generator = $response->streamContent();
+
+        foreach ($generator as $chunk) {
+            // consume generator
+        }
+
+        $this->assertSame($response, $generator->getReturn());
+    }
+
+    public function testStreamContentYieldsEmptyForEmptyFile(): void
+    {
+        file_put_contents($this->testFile, '');
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $generator = $response->streamContent();
+        $output = '';
+
+        foreach ($generator as $chunk) {
+            $output .= $chunk;
+        }
+
+        $this->assertSame('', $output);
+    }
+
+    public function testStreamContentWorksWithChunkSize(): void
+    {
+        $content = 'AB';
+        file_put_contents($this->testFile, $content);
+        $response = new StreamedBinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $chunkSizeProperty = $reflection->getProperty('chunkSize');
+        $chunkSizeProperty->setValue($response, 1);
+
+        $generator = $response->streamContent();
+        $chunks = [];
+
+        foreach ($generator as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertSame('A', $chunks[0]);
+        $this->assertSame('B', $chunks[1]);
+        $this->assertSame($content, implode('', $chunks));
+    }
+}


### PR DESCRIPTION
## Description

Fixes #160 — removes `ignore_user_abort()` and `connection_aborted()` from `StreamedBinaryFileResponse::streamContent()`.

These are PHP-FPM-specific functions that have **no effect** in Workerman's event-driven architecture:
- `ignore_user_abort(true)` — always a no-op in Workerman
- `connection_aborted()` — always returns `0` in Workerman, creating dead code

## Changes

1. **`src/Protocol/Http/Response/StreamedBinaryFileResponse.php`** — removed `ignore_user_abort()` call and `connection_aborted()` check
2. **`tests/StreamedBinaryFileResponseTest.php`** — 14 unit tests covering `streamContent()` generator (offset, maxlen, chunk size, SplTempFileObject, delete-after-send, edge cases)
3. **`tests/App/ResponseTestController.php`** + **`tests/ResponseTest.php`** — e2e test for `StreamedBinaryFileResponse` HTTP endpoint
4. **`src/Worker/SupervisorWorker.php`** — fixed pre-existing undefined array key warning (prevents test server from starting cleanly)

## Testing

- ✅ 373 tests pass (1144 assertions)
- ✅ 14 new unit tests
- ✅ 1 new e2e test
- ✅ PHP CS Fixer
- ✅ PHPStan
- ✅ Rector