### PR TITLE
refactor: extract magic string '+10 year' to class constant in PeriodicalTrigger (#156)

### DIFF
--- a/src/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Scheduler/Trigger/PeriodicalTrigger.php
@@ -8,6 +8,8 @@ use CrazyGoat\WorkermanBundle\Exception\InvalidTriggerException;
 
 final class PeriodicalTrigger implements TriggerInterface
 {
+    private const MAX_SCHEDULE_HORIZON = '+10 year';
+
     private \DateInterval $interval;
     private string $description;
 
@@ -35,7 +37,7 @@ final class PeriodicalTrigger implements TriggerInterface
 
     public function getNextRunDate(\DateTimeImmutable $now): \DateTimeImmutable|null
     {
-        $period = new \DatePeriod($now, $this->interval, $now->modify('+10 year'));
+        $period = new \DatePeriod($now, $this->interval, $now->modify(self::MAX_SCHEDULE_HORIZON));
         /** @var \Iterator<\DateTimeImmutable> $iterator */
         $iterator = $period->getIterator();
         $iterator->next();

--- a/tests/PeriodicalTriggerTest.php
+++ b/tests/PeriodicalTriggerTest.php
@@ -133,4 +133,13 @@ final class PeriodicalTriggerTest extends TestCase
             '1 week' => ['+1 week', '2024-01-22 12:00:00'],
         ];
     }
+
+    public function testMaxScheduleHorizonConstantIsDefined(): void
+    {
+        $reflection = new \ReflectionClass(PeriodicalTrigger::class);
+        $constant = $reflection->getReflectionConstant('MAX_SCHEDULE_HORIZON');
+        $this->assertInstanceOf(\ReflectionClassConstant::class, $constant);
+        $this->assertTrue($constant->isPrivate());
+        $this->assertSame('+10 year', $constant->getValue());
+    }
 }


### PR DESCRIPTION
## Description

Extract the magic string `'+10 year'` used as upper bound for `DatePeriod` iteration into a private class constant `MAX_SCHEDULE_HORIZON` with a descriptive name.

Closes #156

## Changes

- `src/Scheduler/Trigger/PeriodicalTrigger.php`: Added `private const MAX_SCHEDULE_HORIZON = '+10 year'`, replaced inline usage with `self::MAX_SCHEDULE_HORIZON`
- `tests/PeriodicalTriggerTest.php`: Added `testMaxScheduleHorizonConstantIsDefined` — verifies constant existence, private visibility, and value

## Checklist

- [x] PHPUnit all green (374 tests, 0 failures)
- [x] PHPStan no errors
- [x] CS Fixer clean
- [x] Rector clean
- [x] Code review completed