### PR TITLE
fix: improve cache warmup error messages with exit codes and signal details (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved cache warmup error messages to include exit codes, signal numbers, and status details ([#129](https://github.com/crazy-goat/workerman-bundle/issues/129))
+
 ## [0.17.0] - 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.17.0] - 2026-05-19
 
 ### Added

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -83,9 +83,7 @@ final readonly class Runner implements RunnerInterface
                 // SIGKILL (9) = success (child killed itself after successful boot)
                 // SIGTERM (15) = error (child killed itself after exception)
                 if ($signal === \SIGTERM) {
-                    throw new \RuntimeException(\sprintf(
-                        'Cache warmup failed in forked process (child signaled failure via SIGTERM)',
-                    ));
+                    throw new \RuntimeException('Cache warmup failed in forked process (child signaled failure via SIGTERM)');
                 }
                 if ($signal !== \SIGKILL) {
                     throw new \RuntimeException(\sprintf(

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -74,19 +74,30 @@ final readonly class Runner implements RunnerInterface
 
             if (!\pcntl_wifexited($status)) {
                 if (!\pcntl_wifsignaled($status)) {
-                    throw new \RuntimeException('Cache warmup failed in forked process');
+                    throw new \RuntimeException(\sprintf(
+                        'Cache warmup failed in forked process (unexpected status: %d)',
+                        $status,
+                    ));
                 }
                 $signal = \pcntl_wtermsig($status);
                 // SIGKILL (9) = success (child killed itself after successful boot)
                 // SIGTERM (15) = error (child killed itself after exception)
                 if ($signal === \SIGTERM) {
-                    throw new \RuntimeException('Cache warmup failed in forked process');
+                    throw new \RuntimeException(\sprintf(
+                        'Cache warmup failed in forked process (child signaled failure via SIGTERM)',
+                    ));
                 }
                 if ($signal !== \SIGKILL) {
-                    throw new \RuntimeException('Cache warmup failed in forked process');
+                    throw new \RuntimeException(\sprintf(
+                        'Cache warmup failed in forked process (killed by unexpected signal %d)',
+                        $signal,
+                    ));
                 }
             } elseif (\pcntl_wexitstatus($status) !== 0) {
-                throw new \RuntimeException('Cache warmup failed in forked process');
+                throw new \RuntimeException(\sprintf(
+                    'Cache warmup failed in forked process (exit code %d)',
+                    \pcntl_wexitstatus($status),
+                ));
             }
         }
 

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -46,9 +46,27 @@ final class RunnerTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "throw new \RuntimeException('Cache warmup failed in forked process')",
+            'Cache warmup failed in forked process (exit code',
             $content,
-            'Must throw when child exits with non-zero code',
+            'Must throw with exit code when child exits with non-zero code',
+        );
+
+        $this->assertStringContainsString(
+            'Cache warmup failed in forked process (child signaled failure via SIGTERM)',
+            $content,
+            'Must throw with SIGTERM-specific message when child signals failure',
+        );
+
+        $this->assertStringContainsString(
+            'Cache warmup failed in forked process (killed by unexpected signal',
+            $content,
+            'Must throw with signal number when child is killed by unexpected signal',
+        );
+
+        $this->assertStringContainsString(
+            'Cache warmup failed in forked process (unexpected status',
+            $content,
+            'Must throw with unexpected status when child neither exited nor signaled',
         );
 
         $this->assertStringContainsString(


### PR DESCRIPTION
## Description

Improves diagnostic value of cache warmup failure exceptions in `Runner.php` by differentiating the four possible failure modes:

| Condition | Old Message | New Message |
|-----------|-------------|-------------|
| Child neither exited nor signaled | `Cache warmup failed in forked process` | `Cache warmup failed in forked process (unexpected status: %d)` |
| Child signaled failure via SIGTERM | `Cache warmup failed in forked process` | `Cache warmup failed in forked process (child signaled failure via SIGTERM)` |
| Child killed by unexpected signal | `Cache warmup failed in forked process` | `Cache warmup failed in forked process (killed by unexpected signal %d)` |
| Child exited with non-zero code | `Cache warmup failed in forked process` | `Cache warmup failed in forked process (exit code %d)` |

## Changes

- `src/Runner.php`: Updated four exception throw sites to include contextual diagnostic information
- `tests/RunnerTest.php`: Updated structural assertions to match new message patterns
- `CHANGELOG.md`: Added entry for the fix

Closes #129