### PR TITLE
fix: close proc_open pipes to prevent file descriptor leak (#170)

### DIFF
--- a/tests/App/bootstrap.php
+++ b/tests/App/bootstrap.php
@@ -20,7 +20,15 @@ function workerman_create_console_command(string $command): string
 function workerman_start(): void
 {
     $descriptor = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-    \proc_open(\workerman_create_command('start -d'), $descriptor, $pipes);
+    $process = \proc_open(\workerman_create_command('start -d'), $descriptor, $pipes);
+
+    if (\is_resource($process)) {
+        foreach ($pipes as $pipe) {
+            \fclose($pipe);
+        }
+        \proc_close($process);
+    }
+
     \usleep(500_000);
 }
 

--- a/tests/ProcOpenPipeCleanupTest.php
+++ b/tests/ProcOpenPipeCleanupTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for proc_open pipe cleanup in bootstrap.php and WorkermanCommandTest.php.
+ *
+ * Issue #170: tests/App/bootstrap.php: proc_open pipes not closed - file descriptor leak.
+ *
+ * Structural tests verify the source code contains the expected pipe cleanup
+ * pattern as a regression safety net.
+ */
+final class ProcOpenPipeCleanupTest extends TestCase
+{
+    public function testBootstrapClosesProcOpenPipes(): void
+    {
+        $sourceFile = dirname(__DIR__) . '/tests/App/bootstrap.php';
+        $this->assertFileExists($sourceFile);
+
+        $content = file_get_contents($sourceFile);
+        $this->assertNotFalse($content);
+
+        $this->assertStringContainsString(
+            '\fclose($pipe)',
+            $content,
+            'bootstrap.php must close proc_open pipes to prevent file descriptor leak',
+        );
+
+        $this->assertStringContainsString(
+            '\proc_close($process)',
+            $content,
+            'bootstrap.php must close the process handle after proc_open',
+        );
+
+        $this->assertStringContainsString(
+            '\is_resource($process)',
+            $content,
+            'bootstrap.php must check proc_open result before using pipes',
+        );
+    }
+
+    public function testWorkermanCommandClosesProcOpenPipes(): void
+    {
+        $sourceFile = dirname(__DIR__) . '/tests/WorkermanCommandTest.php';
+        $this->assertFileExists($sourceFile);
+
+        $content = file_get_contents($sourceFile);
+        $this->assertNotFalse($content);
+
+        $this->assertStringContainsString(
+            '\fclose($pipe)',
+            $content,
+            'WorkermanCommandTest must close proc_open pipes to prevent file descriptor leak',
+        );
+
+        $this->assertStringContainsString(
+            '\proc_close($process)',
+            $content,
+            'WorkermanCommandTest must close the process handle after proc_open',
+        );
+
+        $this->assertStringContainsString(
+            '\is_resource($process)',
+            $content,
+            'WorkermanCommandTest must check proc_open result before using pipes',
+        );
+    }
+}

--- a/tests/WorkermanCommandTest.php
+++ b/tests/WorkermanCommandTest.php
@@ -60,7 +60,15 @@ final class WorkermanCommandTest extends KernelTestCase
 
         // Restart via index.php (Runtime path — works with proc_open).
         $descriptor = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-        \proc_open(\workerman_create_command('start -d'), $descriptor, $pipes);
+        $process = \proc_open(\workerman_create_command('start -d'), $descriptor, $pipes);
+
+        if (\is_resource($process)) {
+            foreach ($pipes as $pipe) {
+                \fclose($pipe);
+            }
+            \proc_close($process);
+        }
+
         \usleep(500_000);
 
         // Server should be back up.


### PR DESCRIPTION
## Description

Fixes #170

Both `tests/App/bootstrap.php` and `tests/WorkermanCommandTest.php` called `proc_open()` but never closed the resulting pipes or the process handle. This leaked file descriptors for the lifetime of the process.

## Changes

- `tests/App/bootstrap.php`: Store `proc_open` result, close all pipes via `fclose`, close the process handle via `proc_close`, guarded by `is_resource` check
- `tests/WorkermanCommandTest.php`: Same fix applied (same pattern)
- `tests/ProcOpenPipeCleanupTest.php`: New structural regression test verifying the cleanup pattern exists in both files

## Testing

- `composer test`: 364 tests, all pass
- `composer lint`: php-cs-fixer + phpstan + rector all pass
- New structural tests (2 tests, 10 assertions) pass

Closes #170