### PR TITLE
Fix phpunit.xml schema version to match installed PHPUnit 10.5

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         bootstrap="tests/App/bootstrap.php"
         backupGlobals="false"
         colors="true"


### PR DESCRIPTION
## Description

Fixes #162

Updates the PHPUnit XSD schema reference in `phpunit.xml` from `https://schema.phpunit.de/10.2/phpunit.xsd` to the local vendor path (`vendor/phpunit/phpunit/phpunit.xsd`).

### Why

- `composer.json` requires `^10.4` but the schema was pinned to 10.2
- Installed PHPUnit is 10.5.63 — the local schema always matches the installed version
- Using `vendor/` path works offline and never goes out of sync

### Testing

- `vendor/bin/phpunit` passes: 364 tests, 1140 assertions
- All pre-push hooks (php-cs-fixer, phpstan, rector) pass
- No code changes — configuration only