### PR TITLE
fix: align test namespace with PSR-4 autoload-dev mapping (#167)

### DIFF
--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CrazyGoat\WorkermanBundle\Tests;
+namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\ConfigLoader;
 use PHPUnit\Framework\TestCase;

--- a/tests/DependencyInjection/WorkermanCompilerPassTest.php
+++ b/tests/DependencyInjection/WorkermanCompilerPassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CrazyGoat\WorkermanBundle\Tests\DependencyInjection;
+namespace CrazyGoat\WorkermanBundle\Test\DependencyInjection;
 
 use CrazyGoat\WorkermanBundle\DependencyInjection\WorkermanCompilerPass;
 use PHPUnit\Framework\TestCase;

--- a/tests/Scheduler/TaskHandlerTest.php
+++ b/tests/Scheduler/TaskHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CrazyGoat\WorkermanBundle\Tests\Scheduler;
+namespace CrazyGoat\WorkermanBundle\Test\Scheduler;
 
 use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\TaskStartEvent;

--- a/tests/Supervisor/ProcessHandlerTest.php
+++ b/tests/Supervisor/ProcessHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CrazyGoat\WorkermanBundle\Tests\Supervisor;
+namespace CrazyGoat\WorkermanBundle\Test\Supervisor;
 
 use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\ProcessStartEvent;

--- a/tests/TestNamespaceConventionTest.php
+++ b/tests/TestNamespaceConventionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class TestNamespaceConventionTest extends TestCase
+{
+    private const EXPECTED_PREFIX = 'CrazyGoat\\WorkermanBundle\\Test';
+    private const WRONG_PREFIX = 'CrazyGoat\\WorkermanBundle\\Tests';
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideTestFiles(): iterable
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(__DIR__, \RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $path = $file->getRealPath();
+            $content = file_get_contents($path);
+
+            if ($content === false || !str_contains($content, 'namespace ')) {
+                continue;
+            }
+
+            yield str_replace(__DIR__ . '/', '', $path) => [$path, $content];
+        }
+    }
+
+    /**
+     * @dataProvider provideTestFiles
+     */
+    public function testNamespaceUsesTestNotTests(string $path, string $content): void
+    {
+        $this->assertStringNotContainsString(
+            self::WRONG_PREFIX,
+            $content,
+            sprintf(
+                'File %s uses "%s" namespace instead of "%s"',
+                $path,
+                self::WRONG_PREFIX,
+                self::EXPECTED_PREFIX,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideTestFiles
+     */
+    public function testNamespaceStartsWithExpectedPrefix(string $path, string $content): void
+    {
+        if (!preg_match('/^namespace\s+(.+);/m', $content, $matches)) {
+            $this->markTestSkipped(sprintf('File %s has no namespace declaration', $path));
+        }
+
+        $namespace = $matches[1];
+
+        $this->assertMatchesRegularExpression(
+            '/^' . preg_quote(self::EXPECTED_PREFIX, '/') . '(\\\\|$)/',
+            $namespace,
+            sprintf(
+                'File %s uses namespace "%s" which does not start with expected prefix "%s"',
+                $path,
+                $namespace,
+                self::EXPECTED_PREFIX,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideTestFiles
+     */
+    public function testClassIsAutoloadableWithCorrectNamespace(string $path, string $content): void
+    {
+        if (!preg_match('/^(?:final\s+)?(?:abstract\s+)?(?:class|interface|trait|enum)\s+(\w+)/m', $content, $classMatch)) {
+            $this->markTestSkipped(sprintf('File %s has no class, interface, trait, or enum declaration', $path));
+        }
+
+        if (!preg_match('/^namespace\s+(.+);/m', $content, $nsMatch)) {
+            $this->markTestSkipped(sprintf('File %s has no namespace declaration', $path));
+        }
+
+        $fqcn = $nsMatch[1] . '\\' . $classMatch[1];
+
+        $this->assertTrue(
+            class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn) || enum_exists($fqcn),
+            sprintf(
+                'Class %s declared in %s is not autoloadable with PSR-4 (autoload-dev maps "CrazyGoat\\\\WorkermanBundle\\\\Test\\\\" to "tests/")',
+                $fqcn,
+                $path,
+            ),
+        );
+    }
+}

--- a/tests/Util/ServiceMethodHelperTest.php
+++ b/tests/Util/ServiceMethodHelperTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CrazyGoat\WorkermanBundle\Tests\Util;
+namespace CrazyGoat\WorkermanBundle\Test\Util;
 
 use CrazyGoat\WorkermanBundle\Util\ServiceMethodHelper;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## Description

Fixes #167

Five test files used `CrazyGoat\WorkermanBundle\Tests` (with 's') while `autoload-dev` in `composer.json` maps `CrazyGoat\WorkermanBundle\Test` (without 's') to `tests/`. This inconsistency breaks PSR-4 autoloading for namespaced test helpers.

## Changes

- `tests/ConfigLoaderTest.php`: `Tests` → `Test`
- `tests/DependencyInjection/WorkermanCompilerPassTest.php`: `Tests` → `Test`
- `tests/Scheduler/TaskHandlerTest.php`: `Tests` → `Test`
- `tests/Supervisor/ProcessHandlerTest.php`: `Tests` → `Test`
- `tests/Util/ServiceMethodHelperTest.php`: `Tests` → `Test`
- `tests/TestNamespaceConventionTest.php`: new convention test enforcing correct namespace prefix

## Testing

All 517 tests pass (1297 assertions). New convention test checks:
- No file uses the wrong `Tests` prefix
- All namespace declarations start with `CrazyGoat\WorkermanBundle\Test`
- Classes are autoloadable via PSR-4