### PR TITLE
fix: make Runner source path configurable instead of hardcoded (#130)

### DIFF
--- a/tests/Fixtures/runner_test_runner.php
+++ b/tests/Fixtures/runner_test_runner.php
@@ -7,7 +7,7 @@
  * shutdown functions, and other PHPUnit state that interferes with
  * pcntl_fork() + exit() behavior.
  *
- * Usage: php runner_test_runner.php <test_name>
+ * Usage: php runner_test_runner.php <test_name> [source_file]
  *
  * Exit codes:
  *   0 = test passed
@@ -21,11 +21,12 @@ declare(strict_types=1);
 /** @var list<string> $argv */
 
 if ($argc < 2) {
-    fwrite(STDERR, "Usage: php runner_test_runner.php <test_name>\n");
+    fwrite(STDERR, "Usage: php runner_test_runner.php <test_name> [source_file]\n");
     exit(2);
 }
 
 $testName = $argv[1];
+define('RUNNER_SOURCE_FILE', $argv[2] ?? dirname(__DIR__) . '/src/Runner.php');
 
 function fail(string $message): never
 {
@@ -68,8 +69,7 @@ match ($testName) {
  */
 function testForkFailure(): void
 {
-    $sourceFile = dirname(__DIR__) . '/src/Runner.php';
-    $content = file_get_contents($sourceFile);
+    $content = file_get_contents(RUNNER_SOURCE_FILE);
     if ($content === false) {
         fail('Cannot read Runner.php');
     }

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -21,13 +21,14 @@ use PHPUnit\Framework\TestCase;
 final class RunnerTest extends TestCase
 {
     private const RUNNER_SCRIPT = __DIR__ . '/Fixtures/runner_test_runner.php';
+    private const RUNNER_SOURCE = __DIR__ . '/../src/Runner.php';
 
     /**
      * Structural test: verify Runner source uses correct error handling pattern.
      */
     public function testRunnerUsesCorrectForkErrorHandling(): void
     {
-        $sourceFile = dirname(__DIR__) . '/src/Runner.php';
+        $sourceFile = self::RUNNER_SOURCE;
         $this->assertFileExists($sourceFile);
 
         $content = file_get_contents($sourceFile);
@@ -117,7 +118,7 @@ final class RunnerTest extends TestCase
      */
     public function testCacheWarmupTimeoutDefaultsTo30(): void
     {
-        $sourceFile = dirname(__DIR__) . '/src/Runner.php';
+        $sourceFile = self::RUNNER_SOURCE;
         $this->assertFileExists($sourceFile);
 
         $content = file_get_contents($sourceFile);
@@ -240,6 +241,7 @@ final class RunnerTest extends TestCase
                 '-d', 'extension=posix',
                 self::RUNNER_SCRIPT,
                 $testName,
+                self::RUNNER_SOURCE,
             ],
             $descriptors,
             $pipes,


### PR DESCRIPTION
## Description

Fixes #130

Makes the Runner source file path configurable instead of hardcoded in two places:

1. **tests/RunnerTest.php** - Added `RUNNER_SOURCE` constant using `__DIR__`-based path, used in both structural tests and passed to the isolated test fixture.

2. **tests/Fixtures/runner_test_runner.php** - Accepts the source file path as an optional 3rd CLI argument (`[source_file]`), with backward-compatible fallback to the original hardcoded path.

## Changes

- `tests/RunnerTest.php`: Added `RUNNER_SOURCE` constant, updated structural tests and `runIsolatedTest()` to use/pass it
- `tests/Fixtures/runner_test_runner.php`: Accept optional `source_file` argument, use it in `testForkFailure()`

## Testing

- ✅ All 530 tests pass (0 failures, 4 pre-existing skips)
- ✅ Both structural tests and behavioral (fork) tests verified