### PR TITLE
fix: resolve StaticFilesMiddleware path traversal

### DIFF
--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -12,7 +12,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
 {
     private string $rootRealPath;
 
-    public function __construct(private string $rootDirectory)
+    public function __construct(string $rootDirectory)
     {
         $resolved = realpath($rootDirectory);
         if ($resolved === false) {
@@ -35,13 +35,19 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
 
     private function getPublicPathFile(Request $request): string|false
     {
-        $resolved = realpath($this->rootDirectory . $request->path());
+        $path = $request->path();
+
+        if (str_contains($path, "\0") || str_contains($path, '%00') || str_contains($path, '\\')) {
+            return false;
+        }
+
+        $resolved = realpath($this->rootRealPath . DIRECTORY_SEPARATOR . ltrim($path, '/'));
 
         if ($resolved === false) {
             return false;
         }
 
-        if (!str_starts_with($resolved, $this->rootRealPath . DIRECTORY_SEPARATOR)) {
+        if (!str_starts_with($resolved . DIRECTORY_SEPARATOR, $this->rootRealPath . DIRECTORY_SEPARATOR)) {
             return false;
         }
 

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -34,6 +34,146 @@ final class StaticFilesMiddlewareTest extends TestCase
     }
 
     /**
+     * @dataProvider invalidCharacterProvider
+     */
+    public function testInvalidCharactersPassToNext(string $path): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+        $request = $this->createRequest($path);
+        $called = false;
+        $next = function (Request $req) use (&$called): Response {
+            $called = true;
+            return new Response(200);
+        };
+
+        $response = $middleware($request, $next);
+
+        $this->assertTrue($called, "Next should be called for invalid path: $path");
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidCharacterProvider(): array
+    {
+        return [
+            'NUL byte in path' => ["/test.txt\0"],
+            'URL-encoded NUL prefix' => ['/%00/../etc/passwd'],
+            'backslash in path' => ['/..\\test.txt'],
+            'encoded backslash in path' => ['/%5C/../etc/passwd'],
+        ];
+    }
+
+    public function testPrefixCollisionBlocked(): void
+    {
+        $siblingDir = dirname($this->rootDirectory) . '/public-other';
+        @mkdir($siblingDir, 0777, true);
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+            $request = $this->createRequest('/../public-other/test.txt');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(200);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertTrue($called, 'Next should be called for prefix collision path');
+            $this->assertEquals(200, $response->getStatusCode());
+        } finally {
+            if (is_dir($siblingDir)) {
+                rmdir($siblingDir);
+            }
+        }
+    }
+
+    public function testSymlinkEscapingBlocked(): void
+    {
+        $targetDir = __DIR__ . '/data/outside';
+        $linkPath = $this->rootDirectory . '/escape_link';
+
+        try {
+            if (!is_dir($targetDir)) {
+                mkdir($targetDir, 0777, true);
+            }
+            file_put_contents($targetDir . '/secret.txt', 'secret content');
+
+            if (!file_exists($linkPath)) {
+                symlink($targetDir, $linkPath);
+            }
+
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+            $request = $this->createRequest('/escape_link/secret.txt');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(200);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertTrue($called, 'Next should be called for symlink escaping path');
+            $this->assertEquals(200, $response->getStatusCode());
+        } finally {
+            if (file_exists($linkPath)) {
+                unlink($linkPath);
+            }
+            if (file_exists($targetDir . '/secret.txt')) {
+                unlink($targetDir . '/secret.txt');
+            }
+            if (is_dir($targetDir)) {
+                rmdir($targetDir);
+            }
+        }
+    }
+
+    public function testSymlinkInsideRootAllowed(): void
+    {
+        $linkPath = $this->rootDirectory . '/linked';
+        $subDir = $this->rootDirectory . '/subdir';
+
+        try {
+            if (!is_dir($subDir)) {
+                mkdir($subDir, 0777, true);
+            }
+            file_put_contents($subDir . '/linked_file.txt', 'linked content');
+
+            if (!file_exists($linkPath)) {
+                symlink($subDir, $linkPath);
+            }
+
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+            $request = $this->createRequest('/linked/linked_file.txt');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should not be called for symlink inside root');
+        } finally {
+            if (file_exists($linkPath)) {
+                unlink($linkPath);
+            }
+            if (file_exists($subDir . '/linked_file.txt')) {
+                unlink($subDir . '/linked_file.txt');
+            }
+            if (is_dir($subDir)) {
+                rmdir($subDir);
+            }
+        }
+    }
+
+    /**
      * @dataProvider pathTraversalProvider
      */
     public function testPathTraversalBlocked(string $path): void


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in `StaticFilesMiddleware` where the unresolved `rootDirectory` was used for path join while the containment check compared against the resolved `rootRealPath`. When the configured root directory contains symlinks, the join resolves differently than the containment check, enabling path traversal.

## Changes

### src/Middleware/StaticFilesMiddleware.php
- Use `rootRealPath` (resolved) instead of `rootDirectory` (unresolved) in the path join
- Reject request paths containing NUL bytes, URL-encoded NUL (`%00`), or backslashes
- Append trailing separator to both sides of containment check to prevent prefix collisions (e.g. `/srv/static-evil` vs `/srv/static`)

### tests/StaticFilesMiddlewareTest.php
- Added `testInvalidCharactersPassToNext` — NUL, %00, backslash, %5C rejection
- Added `testPrefixCollisionBlocked` — sibling directory overlap
- Added `testSymlinkEscapingBlocked` — symlink pointing outside root
- Added `testSymlinkInsideRootAllowed` — symlink inside root still served

## Fixes

Closes #226