### PR TITLE
[Docs] Use unprivileged port in README quick-start example (#245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ bin/console config:dump-reference workerman
 workerman:
   servers:
     - name: 'Symfony webserver'
-      listen: http://0.0.0.0:80
+      listen: http://127.0.0.1:8080
       processes: 4
 
   reload_strategy:
@@ -59,6 +59,10 @@ workerman:
     file_monitor:
       active: true
 ```
+
+> **Note:** The example above binds an unprivileged port (`8080`) so it works without `sudo`.  
+> To bind a port below 1024 (e.g. `80` or `443`) you must run the process as **root** or grant the `CAP_NET_BIND_SERVICE` capability on Linux.  
+> In production, consider using the `user` and `group` config keys to drop privileges after binding, or front with a reverse proxy (e.g. nginx, Caddy).
 
 ### Start application
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ workerman:
       active: true
 ```
 
-> **Note:** The example above binds an unprivileged port (`8080`) so it works without `sudo`.  
-> To bind a port below 1024 (e.g. `80` or `443`) you must run the process as **root** or grant the `CAP_NET_BIND_SERVICE` capability on Linux.  
+> **Note:** The example above binds an unprivileged port (`8080`) so it works without `sudo`.
+>
+> To bind a port below 1024 (e.g. `80` or `443`) you must run the process as **root** or grant the `CAP_NET_BIND_SERVICE` capability on Linux.
+>
 > In production, consider using the `user` and `group` config keys to drop privileges after binding, or front with a reverse proxy (e.g. nginx, Caddy).
 
 ### Start application


### PR DESCRIPTION
## Description

Changes the quick-start example in README.md from `listen: http://0.0.0.0:80` to `listen: http://127.0.0.1:8080` so it works without `sudo` on a fresh Symfony skeleton.

## Changes

- `README.md`: Changed port 80 → 8080 and address 0.0.0.0 → 127.0.0.1 in the YAML example
- `README.md`: Added a note block explaining unprivileged ports vs privileged ports and production alternatives

## Acceptance criteria

- [x] The README quick-start binds an unprivileged port by default.
- [x] A short note explains how to bind a privileged port (root or `setcap`).
- [x] Copy-pasting the example on a fresh Symfony app starts the server without permission errors.
- [x] No remaining contradiction between the quick-start example and the platform's port-binding rules.

Closes #245
