### PR TITLE
[Code Quality] Consolidate BinaryFileResponseStrategy reflection helpers into dedicated class (#223)

### DIFF
--- a/src/Http/Response/Strategy/BinaryFileResponseReflector.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseReflector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Http\Response\Strategy;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class BinaryFileResponseReflector
+{
+    /**
+     * @var array<class-string, array<string, \ReflectionProperty|null>>
+     */
+    private static array $propertyCache = [];
+
+    public function getTempFileObject(BinaryFileResponse $response): ?\SplTempFileObject
+    {
+        $value = $this->resolvePropertyValue($response, 'tempFileObject');
+
+        return $value instanceof \SplTempFileObject ? $value : null;
+    }
+
+    public function getOffset(BinaryFileResponse $response): ?int
+    {
+        return $this->resolvePropertyValue($response, 'offset');
+    }
+
+    public function getMaxlen(BinaryFileResponse $response): ?int
+    {
+        return $this->resolvePropertyValue($response, 'maxlen');
+    }
+
+    public function getDeleteFileAfterSend(BinaryFileResponse $response): ?bool
+    {
+        return $this->resolvePropertyValue($response, 'deleteFileAfterSend');
+    }
+
+    private function resolvePropertyValue(BinaryFileResponse $response, string $name): mixed
+    {
+        $property = $this->resolveProperty($response, $name);
+
+        return $property?->getValue($response);
+    }
+
+    private function resolveProperty(BinaryFileResponse $response, string $name): ?\ReflectionProperty
+    {
+        $class = $response::class;
+
+        if (!isset(self::$propertyCache[$class][$name])) {
+            try {
+                $reflection = new \ReflectionClass($response);
+                $property = $reflection->getProperty($name);
+                self::$propertyCache[$class][$name] = $property;
+            } catch (\ReflectionException) {
+                self::$propertyCache[$class][$name] = null;
+            }
+        }
+
+        return self::$propertyCache[$class][$name];
+    }
+}

--- a/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
@@ -15,9 +15,17 @@ use Workerman\Protocols\Http\Response as WorkermanResponse;
  *
  * This handles file downloads properly by using Workerman's native withFile()
  * method, which efficiently streams files without loading them into memory.
+ *
+ * @see BinaryFileResponse         Depends on private fields: tempFileObject, offset, maxlen, deleteFileAfterSend
+ * @see BinaryFileResponseReflector
  */
 final readonly class BinaryFileResponseStrategy implements ResponseConverterStrategyInterface
 {
+    public function __construct(
+        private BinaryFileResponseReflector $reflector = new BinaryFileResponseReflector(),
+    ) {
+    }
+
     public function supports(SymfonyResponse $response): bool
     {
         return $response instanceof BinaryFileResponse;
@@ -31,10 +39,7 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
             $headers,
         );
 
-        // Handle SplTempFileObject (in-memory files) - read directly to body
-        // SplTempFileObject stores data in memory (default max 2MB, configurable via $max_memory)
-        // For larger data, use regular files on disk instead of SplTempFileObject
-        $tempFileObject = $this->getTempFileObject($response);
+        $tempFileObject = $this->reflector->getTempFileObject($response);
         if ($tempFileObject instanceof \SplTempFileObject) {
             $tempFileObject->rewind();
             $content = '';
@@ -46,13 +51,11 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
             return $workermanResponse;
         }
 
-        // Regular file - use Workerman's efficient file streaming
         $file = $response->getFile();
-        $offset = $this->getPrivateProperty($response, 'offset');
-        $maxlen = $this->getPrivateProperty($response, 'maxlen');
-        $deleteFileAfterSend = $this->getPrivateProperty($response, 'deleteFileAfterSend');
+        $offset = $this->reflector->getOffset($response);
+        $maxlen = $this->reflector->getMaxlen($response);
+        $deleteFileAfterSend = $this->reflector->getDeleteFileAfterSend($response);
 
-        // If file should be deleted after send, stream it and register cleanup on connection close
         if ($deleteFileAfterSend === true) {
             $filePath = $file->getPathname();
 
@@ -78,40 +81,5 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
                 @unlink($filePath);
             }
         };
-    }
-
-    /**
-     * Get the temp file object from BinaryFileResponse if it exists.
-     * Uses reflection to access private property with graceful fallback.
-     */
-    private function getTempFileObject(BinaryFileResponse $response): ?\SplTempFileObject
-    {
-        try {
-            $reflection = new \ReflectionClass($response);
-            $property = $reflection->getProperty('tempFileObject');
-            $value = $property->getValue($response);
-
-            return $value instanceof \SplTempFileObject ? $value : null;
-        } catch (\ReflectionException) {
-            // Property doesn't exist in this Symfony version, assume no temp file
-            return null;
-        }
-    }
-
-    /**
-     * Get a private property value from BinaryFileResponse.
-     * Uses reflection with graceful fallback if property doesn't exist.
-     */
-    private function getPrivateProperty(BinaryFileResponse $response, string $propertyName): mixed
-    {
-        try {
-            $reflection = new \ReflectionClass($response);
-            $property = $reflection->getProperty($propertyName);
-
-            return $property->getValue($response);
-        } catch (\ReflectionException) {
-            // Property doesn't exist in this Symfony version, return null
-            return null;
-        }
     }
 }

--- a/tests/Strategy/BinaryFileResponseReflectorTest.php
+++ b/tests/Strategy/BinaryFileResponseReflectorTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Strategy;
+
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\BinaryFileResponseReflector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class BinaryFileResponseReflectorTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        $this->testFile = sys_get_temp_dir() . '/test_reflector_' . uniqid() . '.txt';
+        file_put_contents($this->testFile, 'Hello World from binary file!');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+    }
+
+    public function testGetTempFileObjectReturnsNullWhenNotSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $this->assertNull($reflector->getTempFileObject($response));
+    }
+
+    public function testGetTempFileObjectReturnsObjectWhenSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $tempFile = new \SplTempFileObject();
+        $tempFile->fwrite('Temp content');
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('tempFileObject');
+        $property->setValue($response, $tempFile);
+
+        $result = $reflector->getTempFileObject($response);
+        $this->assertInstanceOf(\SplTempFileObject::class, $result);
+        $result->rewind();
+        $this->assertSame('Temp content', $result->fread(1024));
+    }
+
+    public function testGetOffsetReturnsDefaultValueWhenNotSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $this->assertSame(0, $reflector->getOffset($response));
+    }
+
+    public function testGetOffsetReturnsIntWhenSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('offset');
+        $property->setValue($response, 42);
+
+        $this->assertSame(42, $reflector->getOffset($response));
+    }
+
+    public function testGetMaxlenReturnsDefaultValueWhenNotSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $this->assertSame(-1, $reflector->getMaxlen($response));
+    }
+
+    public function testGetMaxlenReturnsIntWhenSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('maxlen');
+        $property->setValue($response, 100);
+
+        $this->assertSame(100, $reflector->getMaxlen($response));
+    }
+
+    public function testGetDeleteFileAfterSendReturnsDefaultValueWhenNotSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $this->assertFalse($reflector->getDeleteFileAfterSend($response));
+    }
+
+    public function testGetDeleteFileAfterSendReturnsBoolWhenSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($response, true);
+
+        $this->assertTrue($reflector->getDeleteFileAfterSend($response));
+    }
+
+    public function testGetDeleteFileAfterSendReturnsFalseWhenSet(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($response, false);
+
+        $this->assertFalse($reflector->getDeleteFileAfterSend($response));
+    }
+
+    public function testPropertyCacheIsUsedOnSubsequentCalls(): void
+    {
+        $reflector = new BinaryFileResponseReflector();
+        $response = new BinaryFileResponse($this->testFile);
+
+        $reflection = new \ReflectionClass($response);
+        $offsetProperty = $reflection->getProperty('offset');
+        $offsetProperty->setValue($response, 10);
+
+        $this->assertSame(10, $reflector->getOffset($response));
+        $this->assertSame(10, $reflector->getOffset($response));
+
+        // Verify a second instance also returns cached result
+        $reflector2 = new BinaryFileResponseReflector();
+        $this->assertSame(10, $reflector2->getOffset($response));
+    }
+}


### PR DESCRIPTION
## Description

Consolidates the two near-identical reflection helpers (`getTempFileObject()` and `getPrivateProperty()`) in `BinaryFileResponseStrategy` into a single dedicated `BinaryFileResponseReflector` collaborator.

## Changes

- **New:** `src/Http/Response/Strategy/BinaryFileResponseReflector.php` — type-safe accessors for private `BinaryFileResponse` properties with static `ReflectionProperty` caching
- **Modified:** `src/Http/Response/Strategy/BinaryFileResponseStrategy.php` — removed `getTempFileObject()`/`getPrivateProperty()`, delegates to `BinaryFileResponseReflector` via constructor injection
- **New:** `tests/Strategy/BinaryFileResponseReflectorTest.php` — covers all four typed accessors and caching behavior

## Why

- Eliminates duplication: two near-identical reflection helpers
- Caches `ReflectionProperty` instances statically: no `new ReflectionClass()` on the hot path after first resolution
- Documents Symfony private fields the strategy depends on at class level
- Isolates reflection concerns to one class — if Symfony renames/removes private fields, the break is confined

## Acceptance criteria

- [x] Exactly one reflection helper used by `BinaryFileResponseStrategy` → `BinaryFileResponseReflector`
- [x] Symfony private properties documented at class level
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change observable

Closes #223