### PR TITLE
[Docs] Add docs/README.md index page for user-facing documentation (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,5 @@ $ php -d phar.readonly=0 bin/console workerman:build:bin --help
 ```
 
 See [docs/build-packaging.md](docs/build-packaging.md) for full documentation, build configuration options, and known limitations.
+
+For an overview of all documentation files, see [docs/](docs/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory contains documentation for the WorkermanBundle.
+
+## Index
+
+- [build-packaging.md](build-packaging.md) — PHAR and standalone binary packaging
+
+All other user-facing documentation is in the [main README](../README.md).


### PR DESCRIPTION
## Summary

Adds a documentation index page at `docs/README.md` to serve as an entry point for the `docs/` folder, and links to it from the main `README.md`.

Closes #244

## Changes

- **docs/README.md** (new): Index page listing user-facing documentation files
- **README.md**: Added link to `docs/` for an overview of documentation files

## Acceptance criteria

- [x] `docs/` contains an index file listing every user-facing document
- [x] The repo `README.md` links to the docs index
- [x] `docs/superpowers/` is not advertised as user documentation
- [x] No remaining ambiguity about which files in `docs/` are intended for users