### PR TITLE
[Docs] Document reload_strategy.memory in README (#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,18 @@ There are a few restart strategies that are implemented and can be enabled or di
    Reload all workers each time you change the files**.
  - **always**  
    Reload worker after each request.
-
+ - **memory**  
+   Reload worker when memory usage reaches a certain threshold. Three options are available:
+   `active` (default: `false`) toggles the strategy, `limit` (default: `134217728` — 128 MB) is the RSS threshold in bytes that triggers a worker reload, and `gc_limit` (default: `100663296` — 96 MB) runs `gc_collect_cycles()` preemptively before the reload check.
+   ```yaml
+   workerman:
+     reload_strategy:
+       memory:
+         active: true
+         limit: 268435456       # 256 MB
+         gc_limit: 201326592    # 192 MB
+   ```
+ 
 ** It is highly recommended to install the _php-inotify_ extension for file monitoring. Without it, monitoring will work in polling mode, which can be very cpu and disk intensive for large projects.
 
 See all available options for each strategy in the command output.


### PR DESCRIPTION
Closes #233

## Changes

Adds documentation for the `reload_strategy.memory` configuration option in the README, which was completely missing from the user-facing documentation despite being fully implemented in `ConfigurationTreeBuilder.php:248-268`.

### What was added

- **New entry** in the "Reload strategies" list for `memory` (after `always`)
- All three options documented inline: `active`, `limit`, `gc_limit` with defaults, units, and purpose
- **YAML example** block showing a practical configuration (256 MB limit / 192 MB gc_limit)
- Cross-referenced `gc_collect_cycles()` behavior from `MemoryRebootStrategy`

### Acceptance criteria

- [x] `README.md` "Reload strategies" section includes a `memory` subsection.
- [x] All three keys (`active`, `limit`, `gc_limit`) are documented with units and defaults.
- [x] A YAML example demonstrating the strategy is included.
- [x] No remaining contradiction between `ConfigurationTreeBuilder.php:248-268` and the README.