### PR TITLE
[Performance] Batch-load all ReflectionProperty instances in one ReflectionClass pass (#222)

### DIFF
--- a/src/Http/Response/Strategy/BinaryFileResponseReflector.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseReflector.php
@@ -13,6 +13,9 @@ final class BinaryFileResponseReflector
      */
     private static array $propertyCache = [];
 
+    /** @var list<string> */
+    private const TARGET_PROPERTIES = ['tempFileObject', 'offset', 'maxlen', 'deleteFileAfterSend'];
+
     public function getTempFileObject(BinaryFileResponse $response): ?\SplTempFileObject
     {
         $value = $this->resolvePropertyValue($response, 'tempFileObject');
@@ -35,27 +38,38 @@ final class BinaryFileResponseReflector
         return $this->resolvePropertyValue($response, 'deleteFileAfterSend');
     }
 
-    private function resolvePropertyValue(BinaryFileResponse $response, string $name): mixed
+    public static function resetCache(): void
     {
-        $property = $this->resolveProperty($response, $name);
-
-        return $property?->getValue($response);
+        self::$propertyCache = [];
     }
 
-    private function resolveProperty(BinaryFileResponse $response, string $name): ?\ReflectionProperty
+    private function resolvePropertyValue(BinaryFileResponse $response, string $name): mixed
     {
         $class = $response::class;
+        $this->ensurePropertiesCached($class);
 
-        if (!isset(self::$propertyCache[$class][$name])) {
+        return self::$propertyCache[$class][$name]?->getValue($response);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function ensurePropertiesCached(string $class): void
+    {
+        if (isset(self::$propertyCache[$class])) {
+            return;
+        }
+
+        self::$propertyCache[$class] = [];
+
+        $reflection = new \ReflectionClass($class);
+
+        foreach (self::TARGET_PROPERTIES as $name) {
             try {
-                $reflection = new \ReflectionClass($response);
-                $property = $reflection->getProperty($name);
-                self::$propertyCache[$class][$name] = $property;
+                self::$propertyCache[$class][$name] = $reflection->getProperty($name);
             } catch (\ReflectionException) {
                 self::$propertyCache[$class][$name] = null;
             }
         }
-
-        return self::$propertyCache[$class][$name];
     }
 }


### PR DESCRIPTION
## Description

Closes #222

BinaryFileResponseReflector previously resolved each private property lazily with its own `ReflectionClass` instantiation, creating up to 4 `ReflectionClass` objects on the first request per unique response class.

Now all target properties (`tempFileObject`, `offset`, `maxlen`, `deleteFileAfterSend`) are resolved in a single `ReflectionClass` pass via `ensurePropertiesCached()`, reducing `ReflectionClass` allocations from up to 4 to exactly 1 per unique class across the entire process lifetime.

### Changes

- Extracted target property names into a `TARGET_PROPERTIES` constant
- Replaced per-property lazy caching with eager batch caching (`ensurePropertiesCached`)
- Added `resetCache()` static method for test isolation

### Verification

- [x] All 692 PHPUnit tests pass
- [x] PHP CS Fixer passes
- [x] PHPStan passes (no errors)
- [x] Rector passes

### Benchmark results

Existing tests pass. No behavioural change observable — the same `ReflectionProperty` instances are cached and reused. On the first request for a given response class, `ReflectionClass` is instantiated once instead of up to 4 times.