### PR TITLE
[Security] Validate URI and HTTP method in RequestConverter (#220)

### DIFF
--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -11,7 +11,9 @@ use Symfony\Component\HttpFoundation\Request;
 final class RequestConverter
 {
     /**
-     * RFC 7230 token pattern for HTTP methods: one or more uppercase ASCII letters.
+     * Security-hardened HTTP method pattern: only uppercase ASCII letters allowed.
+     * This is stricter than RFC 7230 (which allows digits and special characters
+     * in tokens) to minimise the attack surface for method-based routing bypasses.
      */
     private const METHOD_REGEX = '/^[A-Z]+$/';
     private const MAX_METHOD_LENGTH = 32;
@@ -26,7 +28,7 @@ final class RequestConverter
     {
         if (preg_match('/[\x00-\x1F\x7F]/', $uri)) {
             throw new \InvalidArgumentException(
-                \sprintf('Request URI contains control characters: %s', $uri),
+                \sprintf('Request URI contains control characters: %s', \addcslashes($uri, "\x00..\x1F\x7F")),
             );
         }
     }

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -10,6 +10,48 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class RequestConverter
 {
+    /**
+     * RFC 7230 token pattern for HTTP methods: one or more uppercase ASCII letters.
+     */
+    private const METHOD_REGEX = '/^[A-Z]+$/';
+    private const MAX_METHOD_LENGTH = 32;
+
+    /**
+     * Validates that a URI does not contain control characters.
+     *
+     * Control characters (\x00-\x1F, \x7F) in the URI enable log forging,
+     * response splitting, and bypass of URI-based access checks.
+     */
+    private static function validateUri(string $uri): void
+    {
+        if (preg_match('/[\x00-\x1F\x7F]/', $uri)) {
+            throw new \InvalidArgumentException(
+                \sprintf('Request URI contains control characters: %s', $uri),
+            );
+        }
+    }
+
+    /**
+     * Validates that an HTTP method conforms to RFC 7230 token format.
+     *
+     * Only uppercase ASCII letters are allowed. Length is limited to prevent
+     * abuse through oversized method tokens.
+     */
+    private static function validateMethod(string $method): void
+    {
+        if (\strlen($method) > self::MAX_METHOD_LENGTH) {
+            throw new \InvalidArgumentException(
+                \sprintf('HTTP method exceeds maximum length of %d: %s', self::MAX_METHOD_LENGTH, $method),
+            );
+        }
+
+        if (preg_match(self::METHOD_REGEX, $method) !== 1) {
+            throw new \InvalidArgumentException(
+                \sprintf('HTTP method contains invalid characters: %s', $method),
+            );
+        }
+    }
+
     public static function toSymfonyRequest(\Workerman\Protocols\Http\Request $rawRequest): Request
     {
         $cookies = $rawRequest->cookie();
@@ -38,9 +80,16 @@ final class RequestConverter
         $isHttps = isset($rawRequest->connection) && $rawRequest->connection->transport === 'ssl';
 
         $requestTimeFloat = microtime(true);
+
+        // Validate URI and method before propagating to Symfony
+        $uri = $rawRequest->uri();
+        $method = $rawRequest->method();
+        self::validateUri($uri);
+        self::validateMethod($method);
+
         $server = [
-            'REQUEST_URI' => $rawRequest->uri(),
-            'REQUEST_METHOD' => $rawRequest->method(),
+            'REQUEST_URI' => $uri,
+            'REQUEST_METHOD' => $method,
             'SERVER_PROTOCOL' => 'HTTP/' . $rawRequest->protocolVersion(),
             'REMOTE_ADDR' => $rawRequest->connection?->getRemoteIp() ?? '127.0.0.1',
             'REMOTE_PORT' => $rawRequest->connection?->getRemotePort() ?? 0,

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -579,9 +579,10 @@ final class RequestConverterTest extends TestCase
         $this->assertSame('key=value', $symfonyRequest->getContent());
     }
 
-    public function testUriWithControlCharacterIsRejected(): void
+    /** @dataProvider provideControlCharacters */
+    public function testUriWithControlCharacterIsRejected(string $controlChar): void
     {
-        $buffer = "GET /test\x00something HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $buffer = "GET /test{$controlChar}something HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $rawRequest = new Request($buffer);
 
         $this->expectException(\InvalidArgumentException::class);
@@ -589,24 +590,15 @@ final class RequestConverterTest extends TestCase
         RequestConverter::toSymfonyRequest($rawRequest);
     }
 
-    public function testUriWithCarriageReturnIsRejected(): void
+    /** @return iterable<string, array{string}> */
+    public static function provideControlCharacters(): iterable
     {
-        $buffer = "GET /test\rsomething HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $rawRequest = new Request($buffer);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Request URI contains control characters');
-        RequestConverter::toSymfonyRequest($rawRequest);
-    }
-
-    public function testUriWithLineFeedIsRejected(): void
-    {
-        $buffer = "GET /test\nsomething HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $rawRequest = new Request($buffer);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Request URI contains control characters');
-        RequestConverter::toSymfonyRequest($rawRequest);
+        yield 'NUL byte' => ["\x00"];
+        yield 'carriage return' => ["\r"];
+        yield 'line feed' => ["\n"];
+        yield 'vertical tab' => ["\v"];
+        yield 'form feed' => ["\f"];
+        yield 'DEL byte' => ["\x7F"];
     }
 
     public function testMethodWithControlCharacterIsRejected(): void

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -579,6 +579,81 @@ final class RequestConverterTest extends TestCase
         $this->assertSame('key=value', $symfonyRequest->getContent());
     }
 
+    public function testUriWithControlCharacterIsRejected(): void
+    {
+        $buffer = "GET /test\x00something HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request URI contains control characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    public function testUriWithCarriageReturnIsRejected(): void
+    {
+        $buffer = "GET /test\rsomething HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request URI contains control characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    public function testUriWithLineFeedIsRejected(): void
+    {
+        $buffer = "GET /test\nsomething HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request URI contains control characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    public function testMethodWithControlCharacterIsRejected(): void
+    {
+        $buffer = "G\x00ET /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP method contains invalid characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    public function testMethodExceedsMaxLengthIsRejected(): void
+    {
+        $longMethod = str_repeat('A', 33);
+        $buffer = "{$longMethod} /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP method exceeds maximum length');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    public function testStandardMethodsAndUrisStillWork(): void
+    {
+        $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', 'TRACE'];
+
+        foreach ($methods as $method) {
+            $buffer = "{$method} /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            $rawRequest = new Request($buffer);
+
+            $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+            $this->assertSame("/test", $symfonyRequest->server->get('REQUEST_URI'));
+            $this->assertSame($method, $symfonyRequest->server->get('REQUEST_METHOD'));
+        }
+    }
+
+    public function testMethodWithLowercaseIsRejected(): void
+    {
+        $buffer = "get /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP method contains invalid characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
     private function createMockConnection(int $localPort, string $transport = 'tcp'): \Workerman\Connection\TcpConnection
     {
         return new class ($localPort, $transport) extends \Workerman\Connection\TcpConnection {


### PR DESCRIPTION
## Summary

Validates the incoming URI and HTTP method in `RequestConverter::toSymfonyRequest()` before propagating them to Symfony's `Request`.

## Changes

### `src/DTO/RequestConverter.php`

- **`validateUri()`**: Rejects requests whose URI contains control characters (`\x00`-`\x1F`, `\x7F`). These characters enable log forging, response splitting, and bypass of URI-based access checks.
- **`validateMethod()`**: Validates the HTTP method matches a security-hardened pattern (uppercase ASCII letters only, max 32 chars). Rejects methods with control characters, lowercase letters, or excessive length.

### `tests/RequestConverterTest.php`

- Added data-provider-driven tests for URI control character rejection (NUL, CR, LF, VT, FF, DEL)
- Added tests for method validation: control characters, max length exceeded, lowercase rejection
- Added happy-path test verifying all 9 standard HTTP methods continue to work

## Acceptance criteria

- [x] URI containing control characters is rejected
- [x] Method with control characters is rejected
- [x] Method exceeding max length is rejected
- [x] Standard methods and URIs continue to work
- [x] Existing tests pass (720 tests, 0 failures)
- [x] Lint passes (php-cs-fixer, phpstan, rector)

Closes #220