### PR TITLE
[Docs] Document that servers.listen is effectively required and list supported URI schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ workerman:
 >
 > In production, consider using the `user` and `group` config keys to drop privileges after binding, or front with a reverse proxy (e.g. nginx, Caddy).
 
+> **`listen` is effectively required.** Omitting it creates a worker that does not accept connections — no traffic reaches your application.
+> Supported URI schemes: `http://`, `https://`, `ws://` (WebSocket), `wss://` (WebSocket over SSL), `tcp://` (raw TCP).
+
 ### Start application
 
 Using the Symfony console command:


### PR DESCRIPTION
## Description

Closes #232

Documents that `servers[].listen` is effectively required (omitting it silently no-ops the server) and lists the supported URI schemes: `http://`, `https://`, `ws://`, `wss://`, `tcp://`.

### Acceptance criteria

- [x] README.md contains a paragraph stating `listen` must be set and listing the URI schemes.
- [x] The example block remains runnable; copy-paste produces a working server.
- [x] No remaining contradiction between README and ConfigurationTreeBuilder.