### PR TITLE
[Security] Cookie header merged with comma allows cookie smuggling (#217)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,48 @@
+# Security
+
+## Header Injection Protection
+
+The `RequestConverter` applies security hardening when propagating HTTP headers from Workerman to Symfony:
+
+### Cookie Header (RFC 6265)
+
+When multiple `Cookie` header lines are present in the request, values are joined with `; ` as required by RFC 6265, rather than the standard HTTP `, ` separator. This prevents cookie smuggling where a `,` byte in a cookie value could be misinterpreted as a separator between cookies.
+
+**Before (vulnerable):**
+```
+Cookie: session=abc123
+Cookie: token=xyz789
+→ HTTP_COOKIE: "session=abc123, token=xyz789"
+→ Cookies parsed as one cookie: session=abc123, token=xyz789
+```
+
+**After (hardened):**
+```
+Cookie: session=abc123
+Cookie: token=xyz789
+→ HTTP_COOKIE: "session=abc123; token=xyz789"
+→ Cookies correctly parsed as two cookies: session=abc123, token=xyz789
+```
+
+### Duplicate Sensitive Headers
+
+Duplicate `Host`, `Content-Length`, and `Authorization` headers are suspicious and may indicate request smuggling or header injection attacks. Only the first value of each is propagated to Symfony; subsequent values are silently discarded.
+
+- **Host**: Prevents Host-header poisoning attacks
+- **Content-Length**: Prevents request smuggling via conflicting Content-Length values
+- **Authorization**: Prevents authorization header injection
+
+### Control Character Rejection
+
+Header values containing control characters (`\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F`, `\x7F`) are rejected with an `\InvalidArgumentException`. This prevents:
+
+- HTTP response splitting via CR/LF injection in header values
+- Log forging via control characters in custom headers
+- Protocol-level attacks through malformed header values
+
+### Request URI and Method Validation
+
+The `RequestConverter` also validates:
+
+- **URI**: Control characters in the request URI are rejected (defense against log forging and URI-based access bypass)
+- **Method**: Only uppercase ASCII letters are allowed (stricter than RFC 7230 to minimise routing bypass attacks), with a maximum length of 32 characters

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -57,7 +57,6 @@ final class RequestConverter
 
     public static function toSymfonyRequest(\Workerman\Protocols\Http\Request $rawRequest): Request
     {
-        $cookies = $rawRequest->cookie();
         $query = $rawRequest->get();
         // IMPORTANT: Get files BEFORE post() because parsePost() clears the files array
         $files = $rawRequest->file() ?? [];
@@ -75,9 +74,6 @@ final class RequestConverter
         $isFormUrlEncoded = str_starts_with($contentType, 'application/x-www-form-urlencoded');
         $isMultipart = str_starts_with($contentType, 'multipart/form-data');
         $isFormData = $isFormUrlEncoded || $isMultipart;
-
-        // Build server bag with HTTP_* headers (CGI convention)
-        $headers = $rawRequest->header() ?? [];
 
         // Detect HTTPS from Workerman's SSL transport (configured via https:// listen address)
         $isHttps = isset($rawRequest->connection) && $rawRequest->connection->transport === 'ssl';
@@ -107,11 +103,74 @@ final class RequestConverter
             $server['HTTPS'] = 'on';
         }
 
-        // Convert headers to HTTP_* format for ServerBag
-        foreach ($headers as $name => $value) {
-            $key = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
-            // Handle repeated headers (Workerman returns arrays for multiple values)
-            $server[$key] = is_array($value) ? implode(', ', $value) : $value;
+        // Build server headers from raw HTTP with security hardening
+        $server = self::buildServerHeaders($rawRequest, $server);
+
+        // For multipart requests, pass empty content to match PHP-FPM behavior
+        // (php://input is not available for multipart - body is consumed during $_POST/$_FILES parsing)
+        $content = $isMultipart ? '' : $rawRequest->rawBody();
+
+        return new Request(
+            is_array($query) ? $query : [],
+            $isFormData && is_array($post) ? $post : [],
+            [],
+            self::parseCookiesFromServerBag($server),
+            $files,
+            $server,
+            $content,
+        );
+    }
+
+    /**
+     * Build server headers from Workerman request with security hardening.
+     *
+     * Uses Workerman's parsed headers as the base (includes middleware-added headers),
+     * and only falls back to raw header parsing to detect duplicate header values
+     * for special handling:
+     *
+     * - Cookie: multiple header values joined with '; ' per RFC 6265
+     * - Host, Content-Length, Authorization: only the first value is used (duplicates discarded)
+     * - All other headers: joined with ', ' per RFC 7230
+     * - Header values containing control characters are rejected
+     *
+     * @param array<string, float|int|string> $server
+     *
+     * @return array<string, float|int|string>
+     */
+    private static function buildServerHeaders(\Workerman\Protocols\Http\Request $rawRequest, array $server): array
+    {
+        $workermanHeaders = $rawRequest->header() ?? [];
+        $rawHeaders = self::parseRawHeaderLines($rawRequest->rawHead());
+
+        foreach ($workermanHeaders as $name => $value) {
+            $nameLower = \strtolower((string) $name);
+            $key = 'HTTP_' . \strtoupper(\str_replace('-', '_', $name));
+
+            // Validate header value for control characters
+            $stringValue = (string) $value;
+            if (\preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $stringValue)) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Header "%s" contains control characters: "%s"', $nameLower, \addcslashes($stringValue, "\x00..\x1F\x7F")),
+                );
+            }
+
+            // Check if this header had duplicate values in the raw request
+            $originalValues = $rawHeaders[$nameLower] ?? null;
+            $hadDuplicates = $originalValues !== null && \count($originalValues) > 1;
+
+            if ($hadDuplicates) {
+                $server[$key] = match ($nameLower) {
+                    // RFC 6265: multiple Cookie header values must be joined with '; '
+                    'cookie' => \implode('; ', $originalValues),
+                    // Security-sensitive headers: only the first value is meaningful
+                    // Transfer-encoding is also protected against TE/TE smuggling
+                    'host', 'content-length', 'authorization', 'transfer-encoding' => $originalValues[0],
+                    // Standard HTTP behavior: join with ', ' per RFC 7230
+                    default => \implode(', ', $originalValues),
+                };
+            } else {
+                $server[$key] = $stringValue;
+            }
         }
 
         // Content-Type, Content-Length, Content-MD5 use CGI convention (no HTTP_ prefix)
@@ -123,19 +182,72 @@ final class RequestConverter
             }
         }
 
-        // For multipart requests, pass empty content to match PHP-FPM behavior
-        // (php://input is not available for multipart - body is consumed during $_POST/$_FILES parsing)
-        $content = $isMultipart ? '' : $rawRequest->rawBody();
+        return $server;
+    }
 
-        return new Request(
-            is_array($query) ? $query : [],
-            $isFormData && is_array($post) ? $post : [],
-            [],
-            is_array($cookies) ? $cookies : [],
-            $files,
-            $server,
-            $content,
-        );
+    /**
+     * Parse raw HTTP headers into name => list of values.
+     *
+     * The request line (first line of the head) is skipped.
+     * Header names are returned in lowercase.
+     *
+     * @return array<string, list<string>>
+     */
+    private static function parseRawHeaderLines(string $rawHead): array
+    {
+        $headers = [];
+        $lines = \explode("\r\n", $rawHead);
+        \array_shift($lines);
+
+        foreach ($lines as $line) {
+            if ($line === '' || $line === "\r") {
+                continue;
+            }
+            if (\str_contains($line, ':')) {
+                [$name, $value] = \explode(':', $line, 2);
+                $nameLower = \strtolower(\trim($name));
+                $value = \ltrim($value);
+                $headers[$nameLower][] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Parse cookies from the server bag's HTTP_COOKIE value.
+     *
+     * This replaces Workerman's built-in cookie() call to ensure correct
+     * handling when duplicate Cookie headers are present (see security issue #217).
+     *
+     * @param array<string, mixed> $server
+     *
+     * @return array<string, string>
+     */
+    private static function parseCookiesFromServerBag(array $server): array
+    {
+        $cookieHeader = $server['HTTP_COOKIE'] ?? '';
+        if ($cookieHeader === '') {
+            return [];
+        }
+
+        $cookies = [];
+        $pairs = \explode(';', (string) $cookieHeader);
+
+        foreach ($pairs as $pair) {
+            $pair = \trim($pair);
+            if ($pair === '') {
+                continue;
+            }
+            $parts = \explode('=', $pair, 2);
+            $name = \trim($parts[0]);
+            if ($name === '') {
+                continue;
+            }
+            $cookies[$name] = $parts[1] ?? '';
+        }
+
+        return $cookies;
     }
 
     /**

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -659,6 +659,152 @@ final class RequestConverterTest extends TestCase
         RequestConverter::toSymfonyRequest($rawRequest);
     }
 
+    public function testMultipleCookieHeadersJoinedWithSemicolon(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: session=abc123\r\n";
+        $buffer .= "Cookie: token=xyz789\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('session=abc123; token=xyz789', $symfonyRequest->server->get('HTTP_COOKIE'));
+        $this->assertSame('abc123', $symfonyRequest->cookies->get('session'));
+        $this->assertSame('xyz789', $symfonyRequest->cookies->get('token'));
+    }
+
+    public function testMultipleHostHeadersKeepsFirstOnly(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: example.com\r\n";
+        $buffer .= "Host: attacker.com\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('example.com', $symfonyRequest->server->get('HTTP_HOST'));
+        $this->assertStringNotContainsString('attacker.com', $symfonyRequest->server->get('HTTP_HOST'));
+    }
+
+    public function testMultipleContentLengthHeadersKeepsFirstOnly(): void
+    {
+        $buffer = "POST /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Content-Length: 100\r\n";
+        $buffer .= "Content-Length: 9999\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('100', $symfonyRequest->server->get('CONTENT_LENGTH'));
+        $this->assertNull($symfonyRequest->server->get('HTTP_CONTENT_LENGTH'));
+    }
+
+    public function testMultipleAuthorizationHeadersKeepsFirstOnly(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Authorization: Bearer valid-token\r\n";
+        $buffer .= "Authorization: Bearer attacker-token\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('Bearer valid-token', $symfonyRequest->server->get('HTTP_AUTHORIZATION'));
+        $this->assertStringNotContainsString('attacker-token', $symfonyRequest->server->get('HTTP_AUTHORIZATION'));
+    }
+
+    public function testNonSensitiveDuplicateHeadersJoinedWithComma(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Accept: text/plain\r\n";
+        $buffer .= "Accept: application/json\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('text/plain, application/json', $symfonyRequest->server->get('HTTP_ACCEPT'));
+    }
+
+    public function testSingleValueHeadersStillWork(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: example.com\r\n";
+        $buffer .= "Accept: application/json\r\n";
+        $buffer .= "Authorization: Basic dXNlcjpwYXNz\r\n";
+        $buffer .= "Content-Type: application/json\r\n";
+        $buffer .= "Content-Length: 123\r\n";
+        $buffer .= "X-Custom: custom-value\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('example.com', $symfonyRequest->server->get('HTTP_HOST'));
+        $this->assertSame('application/json', $symfonyRequest->server->get('HTTP_ACCEPT'));
+        $this->assertSame('Basic dXNlcjpwYXNz', $symfonyRequest->server->get('HTTP_AUTHORIZATION'));
+        $this->assertSame('application/json', $symfonyRequest->server->get('CONTENT_TYPE'));
+        $this->assertSame('123', $symfonyRequest->server->get('CONTENT_LENGTH'));
+        $this->assertSame('custom-value', $symfonyRequest->server->get('HTTP_X_CUSTOM'));
+    }
+
+    public function testMultipleTransferEncodingHeadersKeepsFirstOnly(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Transfer-Encoding: chunked\r\n";
+        $buffer .= "Transfer-Encoding: x\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('chunked', $symfonyRequest->server->get('HTTP_TRANSFER_ENCODING'));
+        $this->assertStringNotContainsString('x', $symfonyRequest->server->get('HTTP_TRANSFER_ENCODING'));
+    }
+
+    public function testMixedSingleAndDuplicateHeaders(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: example.com\r\n";
+        $buffer .= "Accept: text/plain\r\n";
+        $buffer .= "Accept: application/json\r\n";
+        $buffer .= "X-Custom: single-value\r\n";
+        $buffer .= "X-Another: value-a\r\n";
+        $buffer .= "X-Another: value-b\r\n";
+        $buffer .= "X-Another: value-c\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+        $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+        $this->assertSame('example.com', $symfonyRequest->server->get('HTTP_HOST'));
+        $this->assertSame('text/plain, application/json', $symfonyRequest->server->get('HTTP_ACCEPT'));
+        $this->assertSame('single-value', $symfonyRequest->server->get('HTTP_X_CUSTOM'));
+        $this->assertSame('value-a, value-b, value-c', $symfonyRequest->server->get('HTTP_X_ANOTHER'));
+    }
+
+    public function testHeaderWithControlCharacterIsRejected(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "X-Injected: value\x00malicious\r\n";
+        $buffer .= "\r\n";
+
+        $rawRequest = new Request($buffer);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header "x-injected" contains control characters');
+        RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
     private function createMockConnection(int $localPort, string $transport = 'tcp'): \Workerman\Connection\TcpConnection
     {
         return new class ($localPort, $transport) extends \Workerman\Connection\TcpConnection {


### PR DESCRIPTION
Closes #217

## Changes

### Security hardening in RequestConverter.php

- **Cookie**: Multiple `Cookie` header values are now joined with `; ` per RFC 6265 instead of `, `
- **Host / Content-Length / Authorization / Transfer-Encoding**: Duplicate values are discarded (only first kept)
- **Control characters**: Header values containing control characters are now rejected
- **Cookie re-parsing**: Cookies are now parsed from the fixed `HTTP_COOKIE` server value instead of Workerman's built-in parser
- **docs/security.md**: New security documentation covering all hardening measures

### Tests added

- `testMultipleCookieHeadersJoinedWithSemicolon`
- `testMultipleHostHeadersKeepsFirstOnly`
- `testMultipleContentLengthHeadersKeepsFirstOnly`
- `testMultipleAuthorizationHeadersKeepsFirstOnly`
- `testMultipleTransferEncodingHeadersKeepsFirstOnly`
- `testNonSensitiveDuplicateHeadersJoinedWithComma`
- `testSingleValueHeadersStillWork`
- `testHeaderWithControlCharacterIsRejected`
- `testMixedSingleAndDuplicateHeaders`

All 744 tests pass (9 new tests).