### PR TITLE
[Security] Add trusted_hosts configuration for Host header enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,5 @@ $ php -d phar.readonly=0 bin/console workerman:build:bin --help
 See [docs/build-packaging.md](docs/build-packaging.md) for full documentation, build configuration options, and known limitations.
 
 For an overview of all documentation files, see [docs/](docs/).
+
+For security-related documentation including Host-header protection and trusted hosts configuration, see [docs/security.md](docs/security.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,6 @@ This directory contains documentation for the WorkermanBundle.
 ## Index
 
 - [build-packaging.md](build-packaging.md) — PHAR and standalone binary packaging
+- [security.md](security.md) — Security hardening and trusted hosts
 
 All other user-facing documentation is in the [main README](../README.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,3 +46,30 @@ The `RequestConverter` also validates:
 
 - **URI**: Control characters in the request URI are rejected (defense against log forging and URI-based access bypass)
 - **Method**: Only uppercase ASCII letters are allowed (stricter than RFC 7230 to minimise routing bypass attacks), with a maximum length of 32 characters
+
+## Trusted Host Enforcement
+
+Host-header poisoning is a class of attack where an attacker controls the `Host` header sent to the server, potentially affecting password-reset links, cache keys, and routing decisions made by the application.
+
+By default, all `Host` header values from incoming requests are accepted. To restrict which hostnames your application responds to, configure `trusted_hosts` in your Workerman configuration:
+
+```yaml
+workerman:
+    trusted_hosts:
+        - '^example\.com$'
+        - '^api\.example\.com$'
+```
+
+Each entry is a regular expression pattern (without delimiters). Symfony adds the delimiters automatically. A request whose `Host` header does not match any pattern will be rejected with a `SuspiciousOperationException`, resulting in a 400 response.
+
+### Interaction with Symfony's `framework.trusted_hosts`
+
+If you also configure `framework.trusted_hosts` in Symfony, note that:
+
+- `workerman.trusted_hosts` is enforced **inside the Workerman worker process**, before the Symfony kernel handles the request.
+- If both are configured, the Workerman-level enforcement is sufficient — the Symfony-level setting is redundant but harmless.
+- If you use PHP-FPM alongside Workerman workers, configure both independently.
+
+### When this matters
+
+Configure `trusted_hosts` when your application generates absolute URLs based on the incoming `Host` header (e.g., password-reset emails, webhook callbacks, OAuth redirects). Without it, an attacker can craft a request with a spoofed `Host` header and trick the application into generating URLs pointing to an attacker-controlled domain.

--- a/src/DependencyInjection/ConfigurationTreeBuilder.php
+++ b/src/DependencyInjection/ConfigurationTreeBuilder.php
@@ -75,6 +75,11 @@ final readonly class ConfigurationTreeBuilder
             ->integerNode('response_chunk_size')
                 ->info('Response chunk size')
                 ->defaultValue(2048)
+                ->end()
+            ->arrayNode('trusted_hosts')
+                ->info('A list of regular expression patterns that match trusted hostnames. When configured, requests with a Host header that does not match any pattern are rejected with SuspiciousOperationException. Each pattern is a regex without delimiters (e.g., "^example\\.com$"). Leave empty to accept all hosts (default).')
+                ->prototype('scalar')->end()
+                ->defaultValue([])
                 ->end();
     }
 

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -36,6 +36,7 @@ final readonly class ServicesConfigurator
     {
         $container->setParameter('workerman.response_chunk_size', $config['response_chunk_size']);
         $container->setParameter('workerman.cache_warmup_timeout', $config['cache_warmup_timeout']);
+        $container->setParameter('workerman.trusted_hosts', $config['trusted_hosts']);
 
         $container
             ->register('workerman.config_loader', ConfigLoader::class)

--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -58,6 +58,8 @@ final class WorkermanCompilerPass implements CompilerPassInterface
             ->setArguments([
                 new Reference(KernelInterface::class),
                 new Reference('workerman.response_converter'),
+                null, // logger (optional)
+                '%workerman.trusted_hosts%', // trusted hosts patterns
             ]);
 
         $container->setAlias(SymfonyController::class, 'workerman.symfony_controller');

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -8,6 +8,7 @@ use CrazyGoat\WorkermanBundle\DTO\RequestConverter;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -23,20 +24,40 @@ final class SymfonyController
     private ?ResetInterface $servicesResetter = null;
     private bool $servicesResetterInitialized = false;
 
+    /**
+     * @param string[] $trustedHosts List of regex patterns for trusted hostnames
+     */
     public function __construct(
         private readonly KernelInterface $kernel,
         private readonly ResponseConverter $responseConverter,
         private readonly ?LoggerInterface $logger = null,
+        private readonly array $trustedHosts = [],
     ) {
     }
 
     /**
      * Process the request through Symfony kernel and return Workerman response.
      * Note: kernel->terminate() is NOT called here - use terminateIfNeeded() after sending response.
+     * On first invocation with trusted_hosts configured, applies Symfony's global trusted host patterns.
      */
     public function __invoke(Request $request, TcpConnection $connection): Response
     {
+        if ($this->trustedHosts !== []) {
+            SymfonyRequest::setTrustedHosts($this->trustedHosts);
+        }
+
         $this->symfonyRequest = RequestConverter::toSymfonyRequest($request);
+
+        // Early validation: reject non-matching Host headers before kernel boot
+        // This prevents the kernel from processing requests with spoofed Host headers
+        if ($this->trustedHosts !== []) {
+            try {
+                $this->symfonyRequest->getHost();
+            } catch (SuspiciousOperationException) {
+                return new Response(400);
+            }
+        }
+
         $this->kernel->boot();
 
         try {

--- a/tests/DependencyInjection/ServicesConfiguratorTest.php
+++ b/tests/DependencyInjection/ServicesConfiguratorTest.php
@@ -38,6 +38,7 @@ final class ServicesConfiguratorTest extends TestCase
 
         self::assertSame(2048, $this->container->getParameter('workerman.response_chunk_size'));
         self::assertSame(30, $this->container->getParameter('workerman.cache_warmup_timeout'));
+        self::assertSame([], $this->container->getParameter('workerman.trusted_hosts'));
     }
 
     public function testConfigureRegistersConfigLoader(): void
@@ -150,6 +151,7 @@ final class ServicesConfiguratorTest extends TestCase
             'stdout_file' => '%kernel.project_dir%/var/log/workerman.stdout.log',
             'max_package_size' => 10 * 1024 * 1024,
             'response_chunk_size' => 2048,
+            'trusted_hosts' => [],
             'servers' => [],
             'reload_strategy' => [
                 'exception' => [

--- a/tests/DependencyInjection/WorkermanCompilerPassTest.php
+++ b/tests/DependencyInjection/WorkermanCompilerPassTest.php
@@ -135,11 +135,13 @@ final class WorkermanCompilerPassTest extends TestCase
         $definition = $this->container->getDefinition('workerman.symfony_controller');
         $args = $definition->getArguments();
 
-        $this->assertCount(2, $args);
+        $this->assertCount(4, $args);
         $this->assertInstanceOf(Reference::class, $args[0]);
         $this->assertSame(KernelInterface::class, (string) $args[0]);
         $this->assertInstanceOf(Reference::class, $args[1]);
         $this->assertSame('workerman.response_converter', (string) $args[1]);
+        $this->assertNull($args[2]); // logger (optional)
+        $this->assertSame('%workerman.trusted_hosts%', $args[3]);
     }
 
     public function testTaskAndProcessHandlersArePublic(): void

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -10,6 +10,8 @@ use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -800,6 +802,8 @@ final class SymfonyControllerTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = $this->createMock(TcpConnection::class);
+
+        SymfonyRequest::setTrustedHosts([]);
     }
 
     private function createResponseConverter(bool $withStreamedStrategy = false): ResponseConverter
@@ -1350,5 +1354,48 @@ final class SymfonyControllerTest extends TestCase
         $controller->terminateIfNeeded();
 
         $this->assertTrue($kernel->terminateCalled, 'Terminate should be called');
+    }
+
+    public function testTrustedHostsAllowsMatchingHost(): void
+    {
+        $symfonyResponse = new SymfonyResponse('OK');
+        $kernel = new TestRequestTrackingKernel($symfonyResponse);
+        $responseConverter = $this->createResponseConverter();
+
+        $controller = new SymfonyController($kernel, $responseConverter, null, ['^example\.com$']);
+
+        $buffer = "GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        $request = new Request($buffer);
+
+        $response = $controller($request, $this->connection);
+
+        $this->assertInstanceOf(\Workerman\Protocols\Http\Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('example.com', $kernel->receivedRequest?->getHost());
+    }
+
+    public function testTrustedHostsRejectsNonMatchingHost(): void
+    {
+        $symfonyResponse = new SymfonyResponse('OK');
+        $kernel = new TestRequestTrackingKernel($symfonyResponse);
+        $responseConverter = $this->createResponseConverter();
+
+        $controller = new SymfonyController($kernel, $responseConverter, null, ['^example\.com$']);
+
+        $buffer = "GET /test HTTP/1.1\r\nHost: attacker.com\r\n\r\n";
+        $request = new Request($buffer);
+
+        $response = $controller($request, $this->connection);
+
+        $this->assertInstanceOf(\Workerman\Protocols\Http\Response::class, $response);
+        $this->assertSame(400, $response->getStatusCode());
+
+        // Kernel should NOT have handled the request (early validation before boot)
+        $this->assertNull($kernel->receivedRequest);
+
+        // Verify the static trusted hosts are still active for subsequent requests
+        $suspiciousRequest = SymfonyRequest::create('http://attacker.com/');
+        $this->expectException(SuspiciousOperationException::class);
+        $suspiciousRequest->getHost();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #213 — adds a  configuration option that restricts which `Host` header values are accepted by the application.

## Changes

### Configuration
- New `trusted_hosts` array node in `ConfigurationTreeBuilder` — accepts regex patterns without delimiters

### Runtime enforcement
- `SymfonyController` applies `Request::setTrustedHosts()` before creating the Symfony Request
- Early validation: `getHost()` is called immediately after request conversion — non-matching hosts return **400 response** without booting the kernel
- No static flag (resistant to state desync), `setTrustedHosts()` called on every request when patterns are configured (idempotent, negligible overhead)

### Tests
- Positive test: matching host is accepted (200 OK, `getHost()` returns expected value)
- Negative test: non-matching host returns 400, `getHost()` throws `SuspiciousOperationException`

### Documentation
- New section in `docs/security.md` covering trusted hosts configuration
- Cross-reference in `docs/README.md` and `README.md`

## Acceptance criteria checklist

- [x] Configuration knob in place at `ConfigurationTreeBuilder` and applied before kernel boot
- [x] Negative test: request with attacker-controlled Host not in the allowlist returns 400
- [x] Positive test: legitimate Host matching the allowlist still works
- [x] Documented in `docs/security.md` and referenced from README
- [x] Existing tests pass