### PR TITLE
[Code Quality] FileUploadValidator::validateFileEntry refactored into focused helpers (#208)

### DIFF
--- a/src/Validator/FileUploadValidator.php
+++ b/src/Validator/FileUploadValidator.php
@@ -76,7 +76,6 @@ final class FileUploadValidator
      */
     private static function validateFileEntry(string $fieldName, mixed $fileData): void
     {
-        // Non-array file data is invalid
         if (!is_array($fileData)) {
             throw new FileUploadValidationException(
                 sprintf(
@@ -87,74 +86,82 @@ final class FileUploadValidator
             );
         }
 
-        // Handle nested file arrays (e.g., files[field][])
         if (self::isFileList($fileData)) {
-            foreach ($fileData as $index => $nestedFile) {
-                if (!is_array($nestedFile)) {
-                    throw new FileUploadValidationException(
-                        sprintf(
-                            'Malformed file upload data for field "%s" at index %s: expected array, got %s',
-                            $fieldName,
-                            $index,
-                            gettype($nestedFile),
-                        ),
-                    );
-                }
-                self::validateSingleFileArray($fieldName . '[' . $index . ']', $nestedFile);
-            }
+            self::validateFileList($fieldName, $fileData);
 
             return;
         }
 
-        // Check if this is a file structure or nested associative array (e.g., files[field][subfield])
         if (self::isSingleFileEntry($fileData)) {
             self::validateSingleFileArray($fieldName, $fileData);
 
             return;
         }
 
-        // Nested associative array - validate each entry
-        foreach ($fileData as $subFieldName => $subFileData) {
-            if (is_array($subFileData)) {
-                if (self::isFileList($subFileData)) {
-                    // Array of files in nested field
-                    foreach ($subFileData as $index => $nestedFile) {
-                        if (is_array($nestedFile)) {
-                            self::validateSingleFileArray($fieldName . '[' . $subFieldName . '][' . $index . ']', $nestedFile);
-                        } else {
-                            throw new FileUploadValidationException(
-                                sprintf(
-                                    'Malformed file upload data for field "%s[%s][%s]": expected array, got %s',
-                                    $fieldName,
-                                    $subFieldName,
-                                    $index,
-                                    gettype($nestedFile),
-                                ),
-                            );
-                        }
-                    }
-                } elseif (self::isSingleFileEntry($subFileData)) {
-                    // Single file in nested field
-                    self::validateSingleFileArray($fieldName . '[' . $subFieldName . ']', $subFileData);
-                } else {
-                    // Unrecognized nested structure
-                    throw new FileUploadValidationException(
-                        sprintf(
-                            'Malformed file upload data for field "%s[%s]": unrecognized structure. ' .
-                            'Expected file keys (name, tmp_name) or array of files. Got keys: %s',
-                            $fieldName,
-                            $subFieldName,
-                            implode(', ', array_keys($subFileData)),
-                        ),
-                    );
-                }
+        self::validateNestedAssociative($fieldName, $fileData);
+    }
+
+    /**
+     * Validate an indexed list of file entries.
+     *
+     * @param string        $fieldName The form field name
+     * @param array<int, mixed> $list      The list of file entries
+     *
+     * @throws FileUploadValidationException if file structure is malformed
+     */
+    private static function validateFileList(string $fieldName, array $list): void
+    {
+        foreach ($list as $index => $entry) {
+            $entryFieldName = $fieldName . '[' . $index . ']';
+            if (!is_array($entry)) {
+                throw new FileUploadValidationException(
+                    sprintf(
+                        'Malformed file upload data for field "%s": expected array, got %s',
+                        $entryFieldName,
+                        gettype($entry),
+                    ),
+                );
+            }
+            self::validateSingleFileArray($entryFieldName, $entry);
+        }
+    }
+
+    /**
+     * Validate a nested associative array structure.
+     *
+     * Each sub-field is validated as a file list, single file entry, or falls through
+     * to an unrecognized-structure error.
+     *
+     * @param string             $fieldName The form field name
+     * @param array<string, mixed> $data      The nested associative array
+     *
+     * @throws FileUploadValidationException if file structure is malformed
+     */
+    private static function validateNestedAssociative(string $fieldName, array $data): void
+    {
+        foreach ($data as $subFieldName => $subFileData) {
+            $nestedFieldName = $fieldName . '[' . $subFieldName . ']';
+            if (!is_array($subFileData)) {
+                throw new FileUploadValidationException(
+                    sprintf(
+                        'Malformed file upload data for field "%s": expected array, got %s',
+                        $nestedFieldName,
+                        gettype($subFileData),
+                    ),
+                );
+            }
+
+            if (self::isFileList($subFileData)) {
+                self::validateFileList($nestedFieldName, $subFileData);
+            } elseif (self::isSingleFileEntry($subFileData)) {
+                self::validateSingleFileArray($nestedFieldName, $subFileData);
             } else {
                 throw new FileUploadValidationException(
                     sprintf(
-                        'Malformed file upload data for field "%s[%s]": expected array, got %s',
-                        $fieldName,
-                        $subFieldName,
-                        gettype($subFileData),
+                        'Malformed file upload data for field "%s": unrecognized structure. ' .
+                        'Expected file keys (name, tmp_name) or array of files. Got keys: %s',
+                        $nestedFieldName,
+                        implode(', ', array_keys($subFileData)),
                     ),
                 );
             }


### PR DESCRIPTION
## Description

Refactors `FileUploadValidator::validateFileEntry()` which was a long (85 lines), deeply nested (4-level) method with duplicated patterns for file-list iteration.

### Changes

- Extracted `validateFileList()` helper — validates an indexed list of file entries
- Extracted `validateNestedAssociative()` helper — validates nested associative arrays
- `validateFileEntry()` is now a linear dispatcher with max 2-level nesting
- The duplicated "iterate list + guard non-array" pattern is now in exactly one place (`validateFileList()`)
- Error messages preserved; one format improvement: non-array entries in a list now use `fieldName[index]` notation (consistent with the rest of the class)

### Acceptance criteria

- [x] The "is this a list-of-files?" predicate appears in exactly one location — `isFileList()`, already a single static method
- [x] `validateFileEntry()` has at most 2-level nesting
- [x] Each recognised shape (single, list, nested) is handled by a dedicated helper
- [x] Existing tests pass (757/757, 0 failures)
- [x] phpstan level 8 passes with no errors
- [x] No behavioural change observable to API consumers

Closes #208