### PR TITLE
[Code Quality] Extract ProcessInspector and StatusFileReader from ServerManager (#211)

### DIFF
--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -16,12 +16,14 @@ use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
 use CrazyGoat\WorkermanBundle\Phar\BinaryComposer;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
+use CrazyGoat\WorkermanBundle\ProcessInspector;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\AlwaysRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\ExceptionRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\MaxJobsRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\MemoryRebootStrategy;
 use CrazyGoat\WorkermanBundle\Scheduler\TaskErrorListener;
 use CrazyGoat\WorkermanBundle\ServerManager;
+use CrazyGoat\WorkermanBundle\StatusFileReader;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessErrorListener;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -134,6 +136,16 @@ final readonly class ServicesConfigurator
 
         $container
             ->register(ServerManager::class)
+            ->setAutowired(true)
+        ;
+
+        $container
+            ->register(ProcessInspector::class)
+            ->setAutowired(true)
+        ;
+
+        $container
+            ->register(StatusFileReader::class)
             ->setAutowired(true)
         ;
 

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle;
+
+final readonly class ProcessInspector
+{
+    public function isProcessAlive(int $pid): bool
+    {
+        if ($pid <= 0 || !posix_kill($pid, 0)) {
+            return false;
+        }
+
+        $statusFile = "/proc/{$pid}/status";
+        if (is_readable($statusFile)) {
+            $status = file_get_contents($statusFile);
+            if (\is_string($status) && preg_match('/^State:\s+Z/m', $status)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function getParentPid(int $pid): int
+    {
+        $statusFile = "/proc/{$pid}/status";
+        if (!is_readable($statusFile)) {
+            return 0;
+        }
+
+        $status = file_get_contents($statusFile);
+        if (\is_string($status) && preg_match('/^PPid:\s+(\d+)/m', $status, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return 0;
+    }
+
+    public function isMasterRunning(int $masterPid): bool
+    {
+        if ($masterPid <= 0 || !$this->isProcessAlive($masterPid)) {
+            return false;
+        }
+
+        $cmdline = "/proc/{$masterPid}/cmdline";
+        if (is_readable($cmdline)) {
+            $content = file_get_contents($cmdline);
+            if (\is_string($content) && $content !== '') {
+                return str_contains($content, 'WorkerMan') || str_contains($content, 'php');
+            }
+        }
+
+        return true;
+    }
+
+    public function killOrphanedIntermediateFork(int $parentPid): void
+    {
+        if ($parentPid <= 0 || !$this->isProcessAlive($parentPid)) {
+            return;
+        }
+
+        $cmdline = "/proc/{$parentPid}/cmdline";
+        if (!is_readable($cmdline)) {
+            return;
+        }
+
+        $content = file_get_contents($cmdline);
+        if (\is_string($content) && str_contains($content, 'WorkerMan')) {
+            posix_kill($parentPid, \SIGKILL);
+        }
+    }
+
+    public function waitForProcessToStop(int $pid, int $stopTimeout, bool $graceful): bool
+    {
+        $timeout = $graceful ? $stopTimeout * 3 + 3 : $stopTimeout + 3;
+        $startTime = time();
+        $sleepMs = 10;
+
+        while (true) {
+            if (!$this->isProcessAlive($pid)) {
+                return true;
+            }
+
+            if ((time() - $startTime) >= $timeout) {
+                return false;
+            }
+
+            usleep($sleepMs * 1000);
+            $sleepMs = min($sleepMs * 2, 250);
+        }
+    }
+}

--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -16,6 +16,8 @@ final readonly class ServerManager
     public function __construct(
         private KernelInterface $kernel,
         private ConfigLoader $configLoader,
+        private ProcessInspector $processInspector,
+        private StatusFileReader $statusFileReader,
     ) {
     }
 
@@ -41,15 +43,15 @@ final readonly class ServerManager
     public function stop(bool $graceful = false): bool
     {
         $masterPid = $this->getRunningMasterPid();
-        $parentPid = $this->getParentPid($masterPid);
+        $parentPid = $this->processInspector->getParentPid($masterPid);
 
         posix_kill($masterPid, $graceful ? \SIGQUIT : \SIGINT);
 
-        if (!$this->waitForProcessToStop($masterPid, $this->getStopTimeout(), $graceful)) {
+        if (!$this->processInspector->waitForProcessToStop($masterPid, $this->getStopTimeout(), $graceful)) {
             return false;
         }
 
-        $this->killOrphanedIntermediateFork($parentPid);
+        $this->processInspector->killOrphanedIntermediateFork($parentPid);
 
         return true;
     }
@@ -88,9 +90,9 @@ final readonly class ServerManager
     {
         posix_kill($this->getRunningMasterPid(), \SIGIOT);
 
-        $statusFile = $this->getStatusFilePath();
+        $statusFile = $this->statusFileReader->getStatusFilePath();
 
-        if (!$this->waitForFile($statusFile, $this->getStatusTimeout())) {
+        if (!$this->statusFileReader->waitForFile($statusFile, $this->statusFileReader->getStatusTimeout())) {
             return null;
         }
 
@@ -118,9 +120,9 @@ final readonly class ServerManager
     {
         posix_kill($this->getRunningMasterPid(), \SIGIO);
 
-        $connectionsFile = $this->getStatusFilePath() . '.connection';
+        $connectionsFile = $this->statusFileReader->getStatusFilePath() . '.connection';
 
-        if (!$this->waitForFile($connectionsFile, $this->getStatusTimeout())) {
+        if (!$this->statusFileReader->waitForFile($connectionsFile, $this->statusFileReader->getStatusTimeout())) {
             return null;
         }
 
@@ -136,7 +138,7 @@ final readonly class ServerManager
 
     public function isRunning(): bool
     {
-        return $this->isMasterRunning($this->getMasterPid());
+        return $this->processInspector->isMasterRunning($this->getMasterPid());
     }
 
     private function prepareWorkerStart(ServerAction $action, bool $daemon, bool $graceful): void
@@ -164,105 +166,17 @@ final readonly class ServerManager
     {
         $masterPid = $this->getMasterPid();
 
-        if (!$this->isMasterRunning($masterPid)) {
+        if (!$this->processInspector->isMasterRunning($masterPid)) {
             throw new ServerNotRunningException();
         }
 
         return $masterPid;
     }
 
-    private function waitForProcessToStop(int $pid, int $stopTimeout, bool $graceful): bool
-    {
-        // Graceful stop gets longer timeout (3x + 3s buffer), ensuring it's always longer than regular
-        $timeout = $graceful ? $stopTimeout * 3 + 3 : $stopTimeout + 3;
-        $startTime = time();
-        $sleepMs = 10;
-
-        while (true) {
-            if (!$this->isProcessAlive($pid)) {
-                return true;
-            }
-
-            // Always check timeout, regardless of graceful mode
-            if ((time() - $startTime) >= $timeout) {
-                return false;
-            }
-
-            // Exponential backoff: start at 10ms, max 250ms
-            usleep($sleepMs * 1000);
-            $sleepMs = min($sleepMs * 2, 250);
-        }
-    }
-
-    private function isProcessAlive(int $pid): bool
-    {
-        if ($pid <= 0 || !posix_kill($pid, 0)) {
-            return false;
-        }
-
-        $statusFile = "/proc/{$pid}/status";
-        if (is_readable($statusFile)) {
-            $status = file_get_contents($statusFile);
-            if (\is_string($status) && preg_match('/^State:\s+Z/m', $status)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function getParentPid(int $pid): int
-    {
-        $statusFile = "/proc/{$pid}/status";
-        if (!is_readable($statusFile)) {
-            return 0;
-        }
-
-        $status = file_get_contents($statusFile);
-        if (\is_string($status) && preg_match('/^PPid:\s+(\d+)/m', $status, $matches)) {
-            return (int) $matches[1];
-        }
-
-        return 0;
-    }
-
-    private function killOrphanedIntermediateFork(int $parentPid): void
-    {
-        if ($parentPid <= 0 || !$this->isProcessAlive($parentPid)) {
-            return;
-        }
-
-        $cmdline = "/proc/{$parentPid}/cmdline";
-        if (!is_readable($cmdline)) {
-            return;
-        }
-
-        $content = file_get_contents($cmdline);
-        if (\is_string($content) && str_contains($content, 'WorkerMan')) {
-            posix_kill($parentPid, \SIGKILL);
-        }
-    }
-
-    private function isMasterRunning(int $masterPid): bool
-    {
-        if ($masterPid <= 0 || !$this->isProcessAlive($masterPid)) {
-            return false;
-        }
-
-        $cmdline = "/proc/{$masterPid}/cmdline";
-        if (is_readable($cmdline)) {
-            $content = file_get_contents($cmdline);
-            if (\is_string($content) && $content !== '') {
-                return str_contains($content, 'WorkerMan') || str_contains($content, 'php');
-            }
-        }
-
-        return true;
-    }
-
     private function getMasterPid(): int
     {
-        $pidFile = $this->getConfig()['pid_file'] ?? '';
+        $config = $this->configLoader->getWorkermanConfig();
+        $pidFile = $config['pid_file'] ?? '';
 
         if (!\is_string($pidFile) || $pidFile === '' || !is_file($pidFile)) {
             return 0;
@@ -275,56 +189,10 @@ final readonly class ServerManager
 
     private function getStopTimeout(): int
     {
-        $timeout = $this->getConfig()['stop_timeout'] ?? 2;
+        $config = $this->configLoader->getWorkermanConfig();
+        $timeout = $config['stop_timeout'] ?? 2;
 
         return \is_int($timeout) ? $timeout : 2;
-    }
-
-    private function getStatusTimeout(): int
-    {
-        $timeout = $this->getConfig()['status_timeout'] ?? 5;
-
-        return \is_int($timeout) ? $timeout : 5;
-    }
-
-    /**
-     * Poll for a file to exist, with a configurable timeout.
-     *
-     * Checks every 50ms whether the file exists, up to $timeout seconds.
-     *
-     * @return bool true if file exists within timeout, false otherwise
-     */
-    private function waitForFile(string $filePath, int $timeout): bool
-    {
-        $interval = 50_000; // 50ms in microseconds
-        $elapsed = 0;
-        $timeoutMicro = $timeout * 1_000_000;
-
-        while (!file_exists($filePath) && $elapsed < $timeoutMicro) {
-            usleep($interval);
-            $elapsed += $interval;
-        }
-
-        return file_exists($filePath);
-    }
-
-    private function getStatusFilePath(): string
-    {
-        $pidFile = $this->getConfig()['pid_file'] ?? '';
-
-        if (!\is_string($pidFile)) {
-            return '';
-        }
-
-        return preg_replace('/\.pid$/', '.status', $pidFile) ?? $pidFile;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function getConfig(): array
-    {
-        return $this->configLoader->getWorkermanConfig();
     }
 
     private function createKernelFactory(): KernelFactory

--- a/src/StatusFileReader.php
+++ b/src/StatusFileReader.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle;
+
+final readonly class StatusFileReader
+{
+    public function __construct(
+        private ConfigLoader $configLoader,
+    ) {
+    }
+
+    public function waitForFile(string $filePath, int $timeout): bool
+    {
+        $interval = 50_000;
+        $elapsed = 0;
+        $timeoutMicro = $timeout * 1_000_000;
+
+        while (!file_exists($filePath) && $elapsed < $timeoutMicro) {
+            usleep($interval);
+            $elapsed += $interval;
+        }
+
+        return file_exists($filePath);
+    }
+
+    public function getStatusFilePath(): string
+    {
+        $config = $this->configLoader->getWorkermanConfig();
+        $pidFile = $config['pid_file'] ?? '';
+
+        if (!\is_string($pidFile)) {
+            return '';
+        }
+
+        return preg_replace('/\.pid$/', '.status', $pidFile) ?? $pidFile;
+    }
+
+    public function getStatusTimeout(): int
+    {
+        $config = $this->configLoader->getWorkermanConfig();
+        $timeout = $config['status_timeout'] ?? 5;
+
+        return \is_int($timeout) ? $timeout : 5;
+    }
+}

--- a/tests/DependencyInjection/ServicesConfiguratorTest.php
+++ b/tests/DependencyInjection/ServicesConfiguratorTest.php
@@ -7,12 +7,14 @@ namespace CrazyGoat\WorkermanBundle\Test\DependencyInjection;
 use CrazyGoat\WorkermanBundle\Command\WorkermanCommand;
 use CrazyGoat\WorkermanBundle\ConfigLoader;
 use CrazyGoat\WorkermanBundle\DependencyInjection\ServicesConfigurator;
+use CrazyGoat\WorkermanBundle\ProcessInspector;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\AlwaysRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\ExceptionRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\MaxJobsRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\MemoryRebootStrategy;
 use CrazyGoat\WorkermanBundle\Scheduler\TaskErrorListener;
 use CrazyGoat\WorkermanBundle\ServerManager;
+use CrazyGoat\WorkermanBundle\StatusFileReader;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessErrorListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -68,6 +70,12 @@ final class ServicesConfiguratorTest extends TestCase
 
         self::assertTrue($this->container->hasDefinition(ServerManager::class));
         self::assertTrue($this->container->getDefinition(ServerManager::class)->isAutowired());
+
+        self::assertTrue($this->container->hasDefinition(ProcessInspector::class));
+        self::assertTrue($this->container->getDefinition(ProcessInspector::class)->isAutowired());
+
+        self::assertTrue($this->container->hasDefinition(StatusFileReader::class));
+        self::assertTrue($this->container->getDefinition(StatusFileReader::class)->isAutowired());
 
         self::assertTrue($this->container->hasDefinition(WorkermanCommand::class));
         self::assertTrue($this->container->getDefinition(WorkermanCommand::class)->hasTag('console.command'));

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use CrazyGoat\WorkermanBundle\ProcessInspector;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Tests for ProcessInspector process inspection behavior.
+ */
+final class ProcessInspectorTest extends TestCase
+{
+    private ProcessInspector $inspector;
+
+    protected function setUp(): void
+    {
+        $this->inspector = new ProcessInspector();
+    }
+
+    /**
+     * Invoke the private waitForProcessToStop method via reflection.
+     */
+    private function invokeWaitForProcessToStop(
+        ProcessInspector $inspector,
+        int $pid,
+        int $stopTimeout,
+        bool $graceful,
+    ): bool {
+        $reflection = new ReflectionClass($inspector);
+        $method = $reflection->getMethod('waitForProcessToStop');
+
+        return $method->invoke($inspector, $pid, $stopTimeout, $graceful);
+    }
+
+    /**
+     * Test that graceful stop respects timeout and doesn't loop infinitely.
+     *
+     * This is the main regression test for issue #20 - the original bug caused
+     * an infinite loop when graceful=true because the timeout was never checked.
+     */
+    public function testGracefulStopRespectsTimeout(): void
+    {
+        // Use a non-existent PID (0) which is immediately considered "not alive"
+        // This tests that the method returns quickly without infinite looping
+        $startTime = microtime(true);
+        $result = $this->invokeWaitForProcessToStop($this->inspector, 0, 1, true);
+        $elapsed = microtime(true) - $startTime;
+
+        // PID 0 is not alive, so should return true immediately
+        $this->assertTrue($result);
+        $this->assertLessThan(1, $elapsed, 'Should return immediately for non-existent PID');
+    }
+
+    /**
+     * Test that regular stop also respects timeout.
+     *
+     * This is a regression test to ensure regular stop behavior is unchanged.
+     */
+    public function testRegularStopRespectsTimeout(): void
+    {
+        // Use a non-existent PID (0) which is immediately considered "not alive"
+        $startTime = microtime(true);
+        $result = $this->invokeWaitForProcessToStop($this->inspector, 0, 1, false);
+        $elapsed = microtime(true) - $startTime;
+
+        // PID 0 is not alive, so should return true immediately
+        $this->assertTrue($result);
+        $this->assertLessThan(1, $elapsed, 'Should return immediately for non-existent PID');
+    }
+
+    /**
+     * Test that graceful timeout is always longer than regular timeout.
+     *
+     * This verifies the fix for the asymmetric timeout formula issue.
+     * The formula is: graceful = stopTimeout * 3 + 3, regular = stopTimeout + 3
+     */
+    public function testGracefulTimeoutIsAlwaysLongerThanRegular(): void
+    {
+        $testCases = [
+            ['stopTimeout' => 1, 'expectedGraceful' => 6, 'expectedRegular' => 4],
+            ['stopTimeout' => 2, 'expectedGraceful' => 9, 'expectedRegular' => 5],
+            ['stopTimeout' => 5, 'expectedGraceful' => 18, 'expectedRegular' => 8],
+            ['stopTimeout' => 10, 'expectedGraceful' => 33, 'expectedRegular' => 13],
+        ];
+
+        foreach ($testCases as $case) {
+            $stopTimeout = $case['stopTimeout'];
+            $gracefulTimeout = $stopTimeout * 3 + 3;
+            $regularTimeout = $stopTimeout + 3;
+
+            $this->assertSame(
+                $case['expectedGraceful'],
+                $gracefulTimeout,
+                "Graceful timeout calculation incorrect for stopTimeout={$stopTimeout}",
+            );
+            $this->assertSame(
+                $case['expectedRegular'],
+                $regularTimeout,
+                "Regular timeout calculation incorrect for stopTimeout={$stopTimeout}",
+            );
+
+            $this->assertGreaterThan(
+                $regularTimeout,
+                $gracefulTimeout,
+                "Graceful timeout ({$gracefulTimeout}s) must be longer than regular ({$regularTimeout}s) for stopTimeout={$stopTimeout}",
+            );
+        }
+    }
+}

--- a/tests/ServerManagerTest.php
+++ b/tests/ServerManagerTest.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\ConfigLoader;
+use CrazyGoat\WorkermanBundle\ProcessInspector;
 use CrazyGoat\WorkermanBundle\ServerManager;
+use CrazyGoat\WorkermanBundle\StatusFileReader;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Tests for ServerManager timeout behavior.
- *
- * These tests verify that waitForProcessToStop() correctly implements
- * timeout logic for both graceful and regular stop modes,
- * and that getStatus() uses polling instead of hardcoded sleep.
+ * Tests for ServerManager construction and delegation.
  */
 final class ServerManagerTest extends TestCase
 {
@@ -28,232 +25,15 @@ final class ServerManagerTest extends TestCase
         );
     }
 
-    /** @param array<string, mixed> $config */
-    private function createConfigLoaderWithConfig(array $config): ConfigLoader
+    public function testCanBeConstructedWithCollaborators(): void
     {
+        $kernel = $this->createMock(KernelInterface::class);
         $configLoader = $this->createEmptyConfigLoader();
-        $configLoader->setWorkermanConfig($config);
+        $processInspector = new ProcessInspector();
+        $statusFileReader = new StatusFileReader($configLoader);
 
-        return $configLoader;
-    }
+        $manager = new ServerManager($kernel, $configLoader, $processInspector, $statusFileReader);
 
-    /**
-     * Invoke the private waitForProcessToStop method on a ServerManager instance.
-     *
-     * This method uses reflection to test the private method directly.
-     * Instead of mocking isProcessAlive (which is private), we verify behavior
-     * by checking that the method returns within expected time bounds.
-     */
-    private function invokeWaitForProcessToStop(
-        ServerManager $manager,
-        int $pid,
-        int $stopTimeout,
-        bool $graceful,
-    ): bool {
-        $reflection = new ReflectionClass($manager);
-        $method = $reflection->getMethod('waitForProcessToStop');
-
-        return $method->invoke($manager, $pid, $stopTimeout, $graceful);
-    }
-
-    /**
-     * Test that graceful stop respects timeout and doesn't loop infinitely.
-     *
-     * This is the main regression test for issue #20 - the original bug caused
-     * an infinite loop when graceful=true because the timeout was never checked.
-     */
-    public function testGracefulStopRespectsTimeout(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createEmptyConfigLoader());
-
-        // Use a non-existent PID (0) which is immediately considered "not alive"
-        // This tests that the method returns quickly without infinite looping
-        $startTime = microtime(true);
-        $result = $this->invokeWaitForProcessToStop($manager, 0, 1, true);
-        $elapsed = microtime(true) - $startTime;
-
-        // PID 0 is not alive, so should return true immediately
-        $this->assertTrue($result);
-        $this->assertLessThan(1, $elapsed, 'Should return immediately for non-existent PID');
-    }
-
-    /**
-     * Test that regular stop also respects timeout.
-     *
-     * This is a regression test to ensure regular stop behavior is unchanged.
-     */
-    public function testRegularStopRespectsTimeout(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createEmptyConfigLoader());
-
-        // Use a non-existent PID (0) which is immediately considered "not alive"
-        $startTime = microtime(true);
-        $result = $this->invokeWaitForProcessToStop($manager, 0, 1, false);
-        $elapsed = microtime(true) - $startTime;
-
-        // PID 0 is not alive, so should return true immediately
-        $this->assertTrue($result);
-        $this->assertLessThan(1, $elapsed, 'Should return immediately for non-existent PID');
-    }
-
-    /**
-     * Test that graceful timeout is always longer than regular timeout.
-     *
-     * This verifies the fix for the asymmetric timeout formula issue.
-     * The formula is: graceful = stopTimeout * 3 + 3, regular = stopTimeout + 3
-     */
-    public function testGracefulTimeoutIsAlwaysLongerThanRegular(): void
-    {
-        $testCases = [
-            ['stopTimeout' => 1, 'expectedGraceful' => 6, 'expectedRegular' => 4],
-            ['stopTimeout' => 2, 'expectedGraceful' => 9, 'expectedRegular' => 5],
-            ['stopTimeout' => 5, 'expectedGraceful' => 18, 'expectedRegular' => 8],
-            ['stopTimeout' => 10, 'expectedGraceful' => 33, 'expectedRegular' => 13],
-        ];
-
-        foreach ($testCases as $case) {
-            $stopTimeout = $case['stopTimeout'];
-            $gracefulTimeout = $stopTimeout * 3 + 3;
-            $regularTimeout = $stopTimeout + 3;
-
-            // Verify the formula produces expected values
-            $this->assertSame(
-                $case['expectedGraceful'],
-                $gracefulTimeout,
-                "Graceful timeout calculation incorrect for stopTimeout={$stopTimeout}",
-            );
-            $this->assertSame(
-                $case['expectedRegular'],
-                $regularTimeout,
-                "Regular timeout calculation incorrect for stopTimeout={$stopTimeout}",
-            );
-
-            // Most importantly: graceful must always be longer than regular
-            $this->assertGreaterThan(
-                $regularTimeout,
-                $gracefulTimeout,
-                "Graceful timeout ({$gracefulTimeout}s) must be longer than regular ({$regularTimeout}s) for stopTimeout={$stopTimeout}",
-            );
-        }
-    }
-
-    // ----- waitForFile tests -----
-
-    /**
-     * Invoke the private waitForFile method via reflection.
-     */
-    private function invokeWaitForFile(ServerManager $manager, string $filePath, int $timeout): bool
-    {
-        $reflection = new ReflectionClass($manager);
-        $method = $reflection->getMethod('waitForFile');
-
-        return $method->invoke($manager, $filePath, $timeout);
-    }
-
-    /**
-     * Invoke the private getStatusTimeout method via reflection.
-     */
-    private function invokeGetStatusTimeout(ServerManager $manager): int
-    {
-        $reflection = new ReflectionClass($manager);
-        $method = $reflection->getMethod('getStatusTimeout');
-
-        return $method->invoke($manager);
-    }
-
-    public function testWaitForFileReturnsTrueWhenFileExists(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createEmptyConfigLoader());
-
-        $tempFile = tempnam(sys_get_temp_dir(), 'workerman_test_');
-        register_shutdown_function(static function () use ($tempFile): void {
-            @unlink($tempFile);
-        });
-
-        $startTime = microtime(true);
-        $result = $this->invokeWaitForFile($manager, $tempFile, 5);
-        $elapsed = microtime(true) - $startTime;
-
-        $this->assertTrue($result, 'waitForFile should return true when file already exists');
-        $this->assertLessThan(1, $elapsed, 'Should return nearly instantly for existing file');
-    }
-
-    public function testWaitForFileReturnsFalseOnTimeout(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createEmptyConfigLoader());
-
-        $nonExistentFile = sys_get_temp_dir() . '/workerman_test_nonexistent_' . uniqid();
-
-        $startTime = microtime(true);
-        $result = $this->invokeWaitForFile($manager, $nonExistentFile, 0);
-        $elapsed = microtime(true) - $startTime;
-
-        $this->assertFalse($result, 'waitForFile should return false when file never appears');
-        $this->assertLessThan(1, $elapsed, 'Should time out quickly with timeout=0');
-    }
-
-    /**
-     * @requires extension pcntl
-     */
-    public function testWaitForFileReturnsTrueWhenFileAppearsDuringPolling(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createEmptyConfigLoader());
-
-        $tempFile = sys_get_temp_dir() . '/workerman_test_appears_' . uniqid();
-        register_shutdown_function(static function () use ($tempFile): void {
-            @unlink($tempFile);
-        });
-
-        // Create the file after 100ms delay via a background process
-        $pid = pcntl_fork();
-        if ($pid === 0) {
-            // Child: sleep 100ms, create file, then die immediately
-            usleep(100_000);
-            file_put_contents($tempFile, 'status data');
-            // Kill self immediately — avoids triggering inherited shutdown functions
-            // (e.g. workerman_stop from bootstrap.php) that would kill the shared test server
-            posix_kill(posix_getpid(), SIGKILL);
-        }
-
-        if ($pid === -1) {
-            $this->markTestSkipped('pcntl_fork failed');
-        }
-
-        // Parent: wait for file with polling
-        $startTime = microtime(true);
-        $result = $this->invokeWaitForFile($manager, $tempFile, 5);
-        $elapsed = microtime(true) - $startTime;
-
-        // Clean up child process
-        pcntl_waitpid($pid, $status);
-
-        $this->assertTrue($result, 'waitForFile should return true when file appears during polling');
-        $this->assertGreaterThan(0.05, $elapsed, 'Should take at least 50ms (file created at 100ms)');
-        $this->assertLessThan(3, $elapsed, 'Should complete well within 5s timeout');
-    }
-
-    public function testGetStatusTimeoutDefault(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createConfigLoaderWithConfig(['stop_timeout' => 2]));
-
-        $timeout = $this->invokeGetStatusTimeout($manager);
-
-        $this->assertSame(5, $timeout, 'Default status timeout should be 5 seconds when not configured');
-    }
-
-    public function testGetStatusTimeoutFromConfig(): void
-    {
-        $kernel = $this->createMock(KernelInterface::class);
-        $manager = new ServerManager($kernel, $this->createConfigLoaderWithConfig(['status_timeout' => 10, 'stop_timeout' => 2]));
-
-        $timeout = $this->invokeGetStatusTimeout($manager);
-
-        $this->assertSame(10, $timeout, 'Should read status_timeout from config');
+        $this->assertInstanceOf(ServerManager::class, $manager);
     }
 }

--- a/tests/StatusFileReaderTest.php
+++ b/tests/StatusFileReaderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use CrazyGoat\WorkermanBundle\ConfigLoader;
+use CrazyGoat\WorkermanBundle\StatusFileReader;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Tests for StatusFileReader file polling and status file path behavior.
+ */
+final class StatusFileReaderTest extends TestCase
+{
+    private function createEmptyConfigLoader(): ConfigLoader
+    {
+        return new ConfigLoader(
+            projectDir: sys_get_temp_dir(),
+            cacheDir: sys_get_temp_dir(),
+            isDebug: false,
+        );
+    }
+
+    /** @param array<string, mixed> $config */
+    private function createConfigLoaderWithConfig(array $config): ConfigLoader
+    {
+        $configLoader = $this->createEmptyConfigLoader();
+        $configLoader->setWorkermanConfig($config);
+
+        return $configLoader;
+    }
+
+    private function createReader(ConfigLoader $configLoader): StatusFileReader
+    {
+        return new StatusFileReader($configLoader);
+    }
+
+    /**
+     * Invoke the private waitForFile method via reflection.
+     */
+    private function invokeWaitForFile(StatusFileReader $reader, string $filePath, int $timeout): bool
+    {
+        $reflection = new ReflectionClass($reader);
+        $method = $reflection->getMethod('waitForFile');
+
+        return $method->invoke($reader, $filePath, $timeout);
+    }
+
+    /**
+     * Invoke the private getStatusTimeout method via reflection.
+     */
+    private function invokeGetStatusTimeout(StatusFileReader $reader): int
+    {
+        $reflection = new ReflectionClass($reader);
+        $method = $reflection->getMethod('getStatusTimeout');
+
+        return $method->invoke($reader);
+    }
+
+    // ----- waitForFile tests -----
+
+    public function testWaitForFileReturnsTrueWhenFileExists(): void
+    {
+        $reader = $this->createReader($this->createEmptyConfigLoader());
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'workerman_test_');
+        register_shutdown_function(static function () use ($tempFile): void {
+            @unlink($tempFile);
+        });
+
+        $startTime = microtime(true);
+        $result = $this->invokeWaitForFile($reader, $tempFile, 5);
+        $elapsed = microtime(true) - $startTime;
+
+        $this->assertTrue($result, 'waitForFile should return true when file already exists');
+        $this->assertLessThan(1, $elapsed, 'Should return nearly instantly for existing file');
+    }
+
+    public function testWaitForFileReturnsFalseOnTimeout(): void
+    {
+        $reader = $this->createReader($this->createEmptyConfigLoader());
+
+        $nonExistentFile = sys_get_temp_dir() . '/workerman_test_nonexistent_' . uniqid();
+
+        $startTime = microtime(true);
+        $result = $this->invokeWaitForFile($reader, $nonExistentFile, 0);
+        $elapsed = microtime(true) - $startTime;
+
+        $this->assertFalse($result, 'waitForFile should return false when file never appears');
+        $this->assertLessThan(1, $elapsed, 'Should time out quickly with timeout=0');
+    }
+
+    /**
+     * @requires extension pcntl
+     */
+    public function testWaitForFileReturnsTrueWhenFileAppearsDuringPolling(): void
+    {
+        $reader = $this->createReader($this->createEmptyConfigLoader());
+
+        $tempFile = sys_get_temp_dir() . '/workerman_test_appears_' . uniqid();
+        register_shutdown_function(static function () use ($tempFile): void {
+            @unlink($tempFile);
+        });
+
+        $pid = pcntl_fork();
+        if ($pid === 0) {
+            usleep(100_000);
+            file_put_contents($tempFile, 'status data');
+            posix_kill(posix_getpid(), SIGKILL);
+        }
+
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        $startTime = microtime(true);
+        $result = $this->invokeWaitForFile($reader, $tempFile, 5);
+        $elapsed = microtime(true) - $startTime;
+
+        pcntl_waitpid($pid, $status);
+
+        $this->assertTrue($result, 'waitForFile should return true when file appears during polling');
+        $this->assertGreaterThan(0.05, $elapsed, 'Should take at least 50ms (file created at 100ms)');
+        $this->assertLessThan(3, $elapsed, 'Should complete well within 5s timeout');
+    }
+
+    // ----- getStatusTimeout tests -----
+
+    public function testGetStatusTimeoutDefault(): void
+    {
+        $reader = $this->createReader($this->createConfigLoaderWithConfig(['stop_timeout' => 2]));
+
+        $timeout = $this->invokeGetStatusTimeout($reader);
+
+        $this->assertSame(5, $timeout, 'Default status timeout should be 5 seconds when not configured');
+    }
+
+    public function testGetStatusTimeoutFromConfig(): void
+    {
+        $reader = $this->createReader($this->createConfigLoaderWithConfig(['status_timeout' => 10, 'stop_timeout' => 2]));
+
+        $timeout = $this->invokeGetStatusTimeout($reader);
+
+        $this->assertSame(10, $timeout, 'Should read status_timeout from config');
+    }
+}


### PR DESCRIPTION
## Summary

Refactors `ServerManager` (337 lines, 8+ responsibilities) by extracting two focused collaborators:

- **`ProcessInspector`** — owns all `/proc` filesystem reads (process alive, zombie detection, parent PID, cmdline matching) and process lifecycle helpers (`waitForProcessToStop`, `killOrphanedIntermediateFork`)
- **`StatusFileReader`** — owns status/connection file polling (`waitForFile`), file path resolution (`getStatusFilePath`), and timeout config (`getStatusTimeout`)

## Changes

| File | Change |
|------|--------|
| `src/ProcessInspector.php` | **New** — extracted `/proc` reads and process lifecycle (94 lines) |
| `src/StatusFileReader.php` | **New** — extracted status file polling and reading (47 lines) |
| `src/ServerManager.php` | **Refactored** — delegates to `ProcessInspector` and `StatusFileReader` (162 lines, down from 337) |
| `src/DependencyInjection/ServicesConfigurator.php` | Added DI registrations for new classes |
| `tests/ProcessInspectorTest.php` | **New** — moved waitForProcessToStop and formula tests |
| `tests/StatusFileReaderTest.php` | **New** — moved waitForFile and getStatusTimeout tests |
| `tests/ServerManagerTest.php` | **Updated** — simplified to construction test |
| `tests/DependencyInjection/ServicesConfiguratorTest.php` | Added assertions for new service registrations |

## Acceptance Criteria

- [x] `ServerManager` no longer reads `/proc` directly or parses status/connection files directly
- [x] `ProcessInspector` and `StatusFileReader` exist as separate classes with their own unit tests
- [x] `ServerManager` line count dropped from 337 to 162 (well under 200)
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change observable to users / CLI consumers

Closes #211