### PR TITLE
[Code Quality] Add final keyword to SupervisorWorker

### DIFF
--- a/src/Worker/SupervisorWorker.php
+++ b/src/Worker/SupervisorWorker.php
@@ -8,7 +8,7 @@ use CrazyGoat\WorkermanBundle\KernelFactory;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessHandler;
 use Workerman\Worker;
 
-readonly class SupervisorWorker
+final readonly class SupervisorWorker
 {
     private const PROCESS_TITLE = '[Process]';
 


### PR DESCRIPTION
Closes #265

## Summary

Added the `final` keyword to `SupervisorWorker` to make it consistent with all other worker classes in `src/Worker/` (`FileMonitorWorker`, `ServerWorker`, `SchedulerWorker`).

## Changes

- `src/Worker/SupervisorWorker.php:11` — changed `readonly class` to `final readonly class`

## Verification

- [x] All 816 tests pass (17 skipped)
- [x] PHP-CS-Fixer dry-run clean
- [x] PHPStan clean
- [x] Rector dry-run clean
- [x] Code review found zero issues
- [x] No subclass of SupervisorWorker exists in the codebase
- [x] No test mocks SupervisorWorker