### PR TITLE
[Performance] Replace 10-year DatePeriod with O(1) add() in PeriodicalTrigger::getNextRunDate

### DIFF
--- a/src/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Scheduler/Trigger/PeriodicalTrigger.php
@@ -8,8 +8,6 @@ use CrazyGoat\WorkermanBundle\Exception\InvalidTriggerException;
 
 final class PeriodicalTrigger implements TriggerInterface
 {
-    private const MAX_SCHEDULE_HORIZON = '+10 year';
-
     private \DateInterval $interval;
     private string $description;
 
@@ -46,11 +44,7 @@ final class PeriodicalTrigger implements TriggerInterface
 
     public function getNextRunDate(\DateTimeImmutable $now): \DateTimeImmutable|null
     {
-        $period = new \DatePeriod($now, $this->interval, $now->modify(self::MAX_SCHEDULE_HORIZON));
-        /** @var \Iterator<\DateTimeImmutable> $iterator */
-        $iterator = $period->getIterator();
-        $iterator->next();
-        $date = $iterator->current();
+        $date = $now->add($this->interval);
 
         return $date > $now ? $date : null;
     }

--- a/tests/PeriodicalTriggerTest.php
+++ b/tests/PeriodicalTriggerTest.php
@@ -134,12 +134,4 @@ final class PeriodicalTriggerTest extends TestCase
         ];
     }
 
-    public function testMaxScheduleHorizonConstantIsDefined(): void
-    {
-        $reflection = new \ReflectionClass(PeriodicalTrigger::class);
-        $constant = $reflection->getReflectionConstant('MAX_SCHEDULE_HORIZON');
-        $this->assertInstanceOf(\ReflectionClassConstant::class, $constant);
-        $this->assertTrue($constant->isPrivate());
-        $this->assertSame('+10 year', $constant->getValue());
-    }
 }


### PR DESCRIPTION
Closes #239

## Summary

Replaces the expensive `\DatePeriod` construction spanning 10 years in `PeriodicalTrigger::getNextRunDate()` with a simple O(1) `$now->add($this->interval)`.

## Changes

- **`src/Scheduler/Trigger/PeriodicalTrigger.php`**: Removed `MAX_SCHEDULE_HORIZON` constant; replaced `getNextRunDate()` body with `$now->add($this->interval)` — zero `DatePeriod` allocations per call.
- **`tests/PeriodicalTriggerTest.php`**: Removed `testMaxScheduleHorizonConstantIsDefined` (tested a removed implementation detail).

## Verification

- ✅ `vendor/bin/phpunit tests/PeriodicalTriggerTest.php` — 14/14 pass
- ✅ `vendor/bin/phpunit` — 830/832 pass (2 pre-existing failures in BytesFormatterTest)
- ✅ `vendor/bin/php-cs-fixer fix -v --dry-run` — no changes
- ✅ `vendor/bin/phpstan` — No errors
- ✅ `vendor/bin/rector process --dry-run` — OK