### PR TITLE
[Tests] Add TaskErrorListenerTest and ProcessErrorListenerTest (#237)

### DIFF
--- a/tests/Scheduler/TaskErrorListenerTest.php
+++ b/tests/Scheduler/TaskErrorListenerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Scheduler;
+
+use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
+use CrazyGoat\WorkermanBundle\Scheduler\TaskErrorListener;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class TaskErrorListenerTest extends TestCase
+{
+    public function testOnExceptionLogsCriticalWithTaskNameAndThrowable(): void
+    {
+        $exception = new \RuntimeException('Something went wrong');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('critical')
+            ->willReturnCallback(function (string $message, array $context) use ($exception): void {
+                $this->assertSame('Error thrown while executing task "{task}". Message: "{message}"', $message);
+                $this->assertSame($exception, $context['exception']);
+                $this->assertSame('my_task', $context['task']);
+                $this->assertSame('Something went wrong', $context['message']);
+            });
+
+        $listener = new TaskErrorListener($logger);
+        $listener->onException(new TaskErrorEvent($exception, 'App\Service\MyService', 'my_task'));
+    }
+
+    public function testOnExceptionSubscribesToTaskErrorEvent(): void
+    {
+        $this->assertSame(
+            [TaskErrorEvent::class => ['onException', -128]],
+            TaskErrorListener::getSubscribedEvents(),
+        );
+    }
+}

--- a/tests/Supervisor/ProcessErrorListenerTest.php
+++ b/tests/Supervisor/ProcessErrorListenerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Supervisor;
+
+use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
+use CrazyGoat\WorkermanBundle\Supervisor\ProcessErrorListener;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class ProcessErrorListenerTest extends TestCase
+{
+    public function testOnExceptionLogsCriticalWithProcessNameAndThrowable(): void
+    {
+        $exception = new \RuntimeException('Process failed');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('critical')
+            ->willReturnCallback(function (string $message, array $context) use ($exception): void {
+                $this->assertSame('Error thrown while executing process "{process}". Message: "{message}"', $message);
+                $this->assertSame($exception, $context['exception']);
+                $this->assertSame('my_process', $context['process']);
+                $this->assertSame('Process failed', $context['message']);
+            });
+
+        $listener = new ProcessErrorListener($logger);
+        $listener->onException(new ProcessErrorEvent($exception, 'App\Service\MyService', 'my_process'));
+    }
+
+    public function testOnExceptionSubscribesToProcessErrorEvent(): void
+    {
+        $this->assertSame(
+            [ProcessErrorEvent::class => ['onException', -128]],
+            ProcessErrorListener::getSubscribedEvents(),
+        );
+    }
+}


### PR DESCRIPTION
Closes #237

## Summary

Adds unit tests for `TaskErrorListener` and `ProcessErrorListener` which were previously uncovered.

## Changes

- **tests/Scheduler/TaskErrorListenerTest.php** — verifies `critical()` is called with the PSR-3 template, correct context (exception, task, message), and that `getSubscribedEvents()` returns the expected event mapping
- **tests/Supervisor/ProcessErrorListenerTest.php** — same coverage for the process variant

## Acceptance criteria

- [x] New tests exist at `tests/Scheduler/TaskErrorListenerTest.php` and `tests/Supervisor/ProcessErrorListenerTest.php`
- [x] Each test asserts the logger is invoked with the correct message and context
- [x] Tests fail if the listener stops logging the throwable (regression-protective)
- [x] Existing tests continue to pass (835 tests, no regressions)

## Verification

- `vendor/bin/phpunit` — ✅ 835 tests, 1874 assertions, 17 skipped (unchanged)
- `composer run lint` — ✅ php-cs-fixer, phpstan, rector all pass