### PR TITLE
[Docs] README 'What new in this fork' no longer advertises deprecated serve_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Please see [CONTRIBUTING.md](https://github.com/crazy-goat/workerman-bundle/blob
 
 ## What new in this fork
 * `servers.reuse_port` - on linux machines u can use kernel load balancer if `SO_REUSEPORT` is enabled  
-* `servers.serve_files` - set to `false` to disable serving file (**deprecated**, use [StaticFilesMiddleware](#static-files-middleware) instead). Default: `false`
 *  By default `luzrain/workerman-bundle` parse data to `psr7` request and then to symfony `Request`.
 This `workerman-bundle` will create symfony request without psr7 it increase performance, but it is still experimental. 
 ## Getting started


### PR DESCRIPTION
## Description

Removes the `servers.serve_files` bullet from the 'What new in this fork' section in README.md. The feature has been deprecated since `0.9.3` (see `src/DependencyInjection/ConfigurationTreeBuilder.php:122`), yet it was still being presented as a current feature of this fork.

The replacement (StaticFilesMiddleware) is already documented in the middlewares section with configuration examples.

## Acceptance criteria

- [x] `README.md:17-20` no longer presents `serve_files` as an active feature
- [x] Cross-checked 'What new' against current code: `reuse_port` and PSR-7 notes are still valid
- [x] No remaining contradiction between README 'What new' and the `@deprecated` annotations in `src/`

Closes #268