### PR TITLE
[Code Quality] Extract BuildPathResolver to eliminate duplicated resolveXxxPath helpers (#242)

### DIFF
--- a/src/Command/BuildBinCommand.php
+++ b/src/Command/BuildBinCommand.php
@@ -26,6 +26,7 @@ final class BuildBinCommand extends Command
         private readonly PharBuilder $pharBuilder,
         private readonly SfxDownloader $sfxDownloader,
         private readonly BinaryComposer $binaryComposer,
+        private readonly BuildPathResolver $pathResolver,
         private readonly string $projectDir,
     ) {
         parent::__construct();
@@ -58,8 +59,9 @@ final class BuildBinCommand extends Command
         }
 
         try {
-            $pharPath = self::resolvePharPath($input, $buildConfig, $this->projectDir);
-            $binPath = self::resolveBinPath($input, $buildConfig, $this->projectDir);
+            $buildDir = $this->pathResolver->resolveBuildDir($input->getOption('output-dir'), $buildConfig, $this->projectDir);
+            $pharPath = $this->pathResolver->resolvePharPath($input->getOption('phar-filename'), $buildDir, $buildConfig);
+            $binPath = $this->pathResolver->resolveBinPath($input->getOption('filename'), $buildDir, $buildConfig);
 
             $io->section('Step 1/3: Building PHAR');
             $this->pharBuilder->build($buildConfig, $pharPath);
@@ -90,61 +92,6 @@ final class BuildBinCommand extends Command
         $io->note(sprintf('To run: ./%s workerman:server start', basename($binPath)));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @param mixed[] $buildConfig
-     *
-     * @throws \RuntimeException
-     */
-    public static function resolvePharPath(InputInterface $input, array $buildConfig, string $projectDir): string
-    {
-        $buildDir = self::resolveBuildDir($input, $buildConfig, $projectDir);
-
-        $pharFilename = $input->getOption('phar-filename')
-            ?: ($buildConfig['phar_filename'] ?? 'app.phar');
-        if (!is_string($pharFilename) || $pharFilename === '') {
-            $pharFilename = 'app.phar';
-        }
-
-        return $buildDir . '/' . $pharFilename;
-    }
-
-    /**
-     * @param mixed[] $buildConfig
-     *
-     * @throws \RuntimeException
-     */
-    public static function resolveBinPath(InputInterface $input, array $buildConfig, string $projectDir): string
-    {
-        $buildDir = self::resolveBuildDir($input, $buildConfig, $projectDir);
-
-        $binFilename = $input->getOption('filename')
-            ?: ($buildConfig['bin_filename'] ?? 'app.bin');
-        if (!is_string($binFilename) || $binFilename === '') {
-            $binFilename = 'app.bin';
-        }
-
-        return $buildDir . '/' . $binFilename;
-    }
-
-    /**
-     * @param mixed[] $buildConfig
-     *
-     * @throws \RuntimeException
-     */
-    private static function resolveBuildDir(InputInterface $input, array $buildConfig, string $projectDir): string
-    {
-        $buildDir = $input->getOption('output-dir') ?: ($buildConfig['build_dir'] ?? $projectDir . '/build');
-        if (!is_string($buildDir) || $buildDir === '') {
-            throw new \RuntimeException('Invalid build configuration: build_dir must be a non-empty string.');
-        }
-
-        if (!str_starts_with($buildDir, '/')) {
-            $buildDir = $projectDir . '/' . $buildDir;
-        }
-
-        return $buildDir;
     }
 
     /**

--- a/src/Command/BuildPathResolver.php
+++ b/src/Command/BuildPathResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Command;
+
+final class BuildPathResolver
+{
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolveBuildDir(mixed $cliBuildDir, array $buildConfig, string $projectDir): string
+    {
+        $buildDir = is_string($cliBuildDir) && $cliBuildDir !== ''
+            ? $cliBuildDir
+            : ($buildConfig['build_dir'] ?? $projectDir . '/build');
+
+        if (!is_string($buildDir) || $buildDir === '') {
+            throw new \RuntimeException('Invalid build configuration: build_dir must be a non-empty string.');
+        }
+
+        if (!str_starts_with($buildDir, '/')) {
+            $buildDir = $projectDir . '/' . $buildDir;
+        }
+
+        return $buildDir;
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolvePharPath(mixed $cliPharFilename, string $buildDir, array $buildConfig): string
+    {
+        return $buildDir . '/' . $this->resolveFilename($cliPharFilename, $buildConfig, 'phar_filename', 'app.phar');
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolveBinPath(mixed $cliBinFilename, string $buildDir, array $buildConfig): string
+    {
+        return $buildDir . '/' . $this->resolveFilename($cliBinFilename, $buildConfig, 'bin_filename', 'app.bin');
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    private function resolveFilename(mixed $cliValue, array $buildConfig, string $configKey, string $default): string
+    {
+        $filename = is_string($cliValue) && $cliValue !== ''
+            ? $cliValue
+            : ($buildConfig[$configKey] ?? $default);
+
+        if (!is_string($filename) || $filename === '') {
+            return $default;
+        }
+
+        return $filename;
+    }
+}

--- a/src/Command/BuildPharCommand.php
+++ b/src/Command/BuildPharCommand.php
@@ -20,6 +20,7 @@ final class BuildPharCommand extends Command
     public function __construct(
         private readonly ConfigLoader $configLoader,
         private readonly PharBuilder $pharBuilder,
+        private readonly BuildPathResolver $pathResolver,
         private readonly string $projectDir,
     ) {
         parent::__construct();
@@ -53,7 +54,8 @@ final class BuildPharCommand extends Command
         }
 
         try {
-            $pharPath = self::resolvePharPath($input, $buildConfig, $this->projectDir);
+            $buildDir = $this->pathResolver->resolveBuildDir($input->getOption('output-dir'), $buildConfig, $this->projectDir);
+            $pharPath = $this->pathResolver->resolvePharPath($input->getOption('filename'), $buildDir, $buildConfig);
             $includeTests = (bool) $input->getOption('include-tests');
 
             $io->section('Building PHAR archive');
@@ -70,24 +72,4 @@ final class BuildPharCommand extends Command
         return Command::SUCCESS;
     }
 
-    /**
-     * @param mixed[] $buildConfig
-     *
-     * @throws \RuntimeException when build_dir/phar_filename are invalid
-     */
-    public static function resolvePharPath(InputInterface $input, array $buildConfig, string $projectDir): string
-    {
-        $buildDir = $input->getOption('output-dir') ?: $buildConfig['build_dir'] ?? $projectDir . '/build';
-        $pharFilename = $input->getOption('filename') ?: $buildConfig['phar_filename'] ?? 'app.phar';
-
-        if (!is_string($buildDir) || $buildDir === '' || !is_string($pharFilename) || $pharFilename === '') {
-            throw new \RuntimeException('Invalid build configuration: build_dir and phar_filename must be non-empty strings.');
-        }
-
-        if (!str_starts_with($buildDir, '/')) {
-            $buildDir = $projectDir . '/' . $buildDir;
-        }
-
-        return $buildDir . '/' . $pharFilename;
-    }
 }

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\WorkermanBundle\DependencyInjection;
 use CrazyGoat\WorkermanBundle\Attribute\AsProcess;
 use CrazyGoat\WorkermanBundle\Attribute\AsTask;
 use CrazyGoat\WorkermanBundle\Command\BuildBinCommand;
+use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
 use CrazyGoat\WorkermanBundle\Command\BuildPharCommand;
 use CrazyGoat\WorkermanBundle\Command\WorkermanCommand;
 use CrazyGoat\WorkermanBundle\ConfigLoader;
@@ -172,11 +173,16 @@ final readonly class ServicesConfigurator
         ;
 
         $container
+            ->register(BuildPathResolver::class)
+        ;
+
+        $container
             ->register(BuildPharCommand::class)
             ->addTag('console.command')
             ->setArguments([
                 new Reference('workerman.config_loader'),
                 new Reference('workerman.phar_builder'),
+                new Reference(BuildPathResolver::class),
                 $container->getParameter('kernel.project_dir'),
             ])
         ;
@@ -189,6 +195,7 @@ final readonly class ServicesConfigurator
                 new Reference('workerman.phar_builder'),
                 new Reference('workerman.sfx_downloader'),
                 new Reference('workerman.binary_composer'),
+                new Reference(BuildPathResolver::class),
                 $container->getParameter('kernel.project_dir'),
             ])
         ;

--- a/tests/Command/BuildBinCommandTest.php
+++ b/tests/Command/BuildBinCommandTest.php
@@ -4,118 +4,38 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test\Command;
 
-use CrazyGoat\WorkermanBundle\Command\BuildBinCommand;
-use CrazyGoat\WorkermanBundle\ConfigLoader;
-use CrazyGoat\WorkermanBundle\Phar\BinaryComposer;
-use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
-use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
+use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Input\ArrayInput;
 
 final class BuildBinCommandTest extends TestCase
 {
-    private string $tempDir;
-
-    protected function setUp(): void
-    {
-        $this->tempDir = sys_get_temp_dir() . '/build-bin-test-' . uniqid();
-        mkdir($this->tempDir, 0755, true);
-    }
-
-    protected function tearDown(): void
-    {
-        if (is_dir($this->tempDir)) {
-            $this->removeDirectory($this->tempDir);
-        }
-    }
-
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $files = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            if ($file->isDir()) {
-                rmdir($file->getRealPath());
-            } else {
-                unlink($file->getRealPath());
-            }
-        }
-
-        rmdir($dir);
-    }
-
     public function testResolveBinPathUsesConfigDefaults(): void
     {
-        $command = $this->createCommand();
-        $input = new ArrayInput([]);
-        $input->bind($command->getDefinition());
-
-        $path = BuildBinCommand::resolveBinPath($input, [
-            'build_dir' => '/abs/build',
+        $resolver = new BuildPathResolver();
+        $path = $resolver->resolveBinPath(null, '/abs/build', [
             'bin_filename' => 'app.bin',
-        ], '/p');
+        ]);
 
         self::assertSame('/abs/build/app.bin', $path);
     }
 
     public function testResolveBinPathPrefersCliFilename(): void
     {
-        $command = $this->createCommand();
-        $input = new ArrayInput(['--filename' => 'custom.bin']);
-        $input->bind($command->getDefinition());
-
-        $path = BuildBinCommand::resolveBinPath($input, [
-            'build_dir' => '/abs/build',
+        $resolver = new BuildPathResolver();
+        $path = $resolver->resolveBinPath('custom.bin', '/abs/build', [
             'bin_filename' => 'app.bin',
-        ], '/p');
+        ]);
 
         self::assertSame('/abs/build/custom.bin', $path);
     }
 
     public function testResolvePharPathRespectsPharFilenameOption(): void
     {
-        $command = $this->createCommand();
-        $input = new ArrayInput(['--phar-filename' => 'mid.phar']);
-        $input->bind($command->getDefinition());
-
-        $path = BuildBinCommand::resolvePharPath($input, [
-            'build_dir' => '/abs/build',
+        $resolver = new BuildPathResolver();
+        $path = $resolver->resolvePharPath('mid.phar', '/abs/build', [
             'phar_filename' => 'app.phar',
-        ], '/p');
-
-        self::assertSame('/abs/build/mid.phar', $path);
-    }
-
-    private function createCommand(): BuildBinCommand
-    {
-        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
-        $loader->setWorkermanConfig([]);
-        $loader->setProcessConfig([]);
-        $loader->setSchedulerConfig([]);
-        $loader->setBuildConfig([
-            'build_dir' => $this->tempDir . '/build',
-            'kernel_class' => 'App\\Kernel',
-            'phar_filename' => 'app.phar',
-            'bin_filename' => 'app.bin',
-            'sfx' => ['url' => null, 'file' => null, 'sha256' => null, 'allow_insecure' => false],
-            'exclude_patterns' => [],
-            'exclude_files' => [],
-            'custom_ini' => null,
         ]);
 
-        return new BuildBinCommand(
-            $loader,
-            new PharBuilder($this->tempDir, 'test'),
-            new SfxDownloader(),
-            new BinaryComposer(),
-            $this->tempDir,
-        );
+        self::assertSame('/abs/build/mid.phar', $path);
     }
 }

--- a/tests/Command/BuildPathResolverTest.php
+++ b/tests/Command/BuildPathResolverTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Command;
+
+use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
+use PHPUnit\Framework\TestCase;
+
+final class BuildPathResolverTest extends TestCase
+{
+    private BuildPathResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new BuildPathResolver();
+    }
+
+    public function testResolveBuildDirUsesCliOptionWhenProvided(): void
+    {
+        $dir = $this->resolver->resolveBuildDir('/cli/path', ['build_dir' => '/cfg/path'], '/proj');
+
+        self::assertSame('/cli/path', $dir);
+    }
+
+    public function testResolveBuildDirFallsBackToConfig(): void
+    {
+        $dir = $this->resolver->resolveBuildDir(null, ['build_dir' => '/cfg/path'], '/proj');
+
+        self::assertSame('/cfg/path', $dir);
+    }
+
+    public function testResolveBuildDirFallsBackToProjectDirDefault(): void
+    {
+        $dir = $this->resolver->resolveBuildDir(null, [], '/proj');
+
+        self::assertSame('/proj/build', $dir);
+    }
+
+    public function testResolveBuildDirRebasesRelativePath(): void
+    {
+        $dir = $this->resolver->resolveBuildDir('relative/path', ['build_dir' => '/cfg/path'], '/proj');
+
+        self::assertSame('/proj/relative/path', $dir);
+    }
+
+    public function testResolveBuildDirRebasesRelativeConfigPath(): void
+    {
+        $dir = $this->resolver->resolveBuildDir(null, ['build_dir' => 'relative/path'], '/proj');
+
+        self::assertSame('/proj/relative/path', $dir);
+    }
+
+    public function testResolveBuildDirThrowsOnEmptyConfig(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('build_dir must be a non-empty string');
+
+        $this->resolver->resolveBuildDir(null, ['build_dir' => ''], '/proj');
+    }
+
+    public function testResolveBuildDirThrowsOnEmptyCliWithNoConfig(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('build_dir must be a non-empty string');
+
+        $this->resolver->resolveBuildDir('', ['build_dir' => ''], '/proj');
+    }
+
+    public function testResolveBuildDirIgnoresEmptyCliOptionAndFallsBack(): void
+    {
+        $dir = $this->resolver->resolveBuildDir('', ['build_dir' => '/cfg/path'], '/proj');
+
+        self::assertSame('/cfg/path', $dir);
+    }
+
+    public function testResolvePharPathUsesCliOptionWhenProvided(): void
+    {
+        $path = $this->resolver->resolvePharPath('custom.phar', '/build', ['phar_filename' => 'app.phar']);
+
+        self::assertSame('/build/custom.phar', $path);
+    }
+
+    public function testResolvePharPathFallsBackToConfig(): void
+    {
+        $path = $this->resolver->resolvePharPath(null, '/build', ['phar_filename' => 'app.phar']);
+
+        self::assertSame('/build/app.phar', $path);
+    }
+
+    public function testResolvePharPathFallsBackToDefault(): void
+    {
+        $path = $this->resolver->resolvePharPath(null, '/build', []);
+
+        self::assertSame('/build/app.phar', $path);
+    }
+
+    public function testResolvePharPathWhenEmptyCliOptionFallsBackToConfig(): void
+    {
+        $path = $this->resolver->resolvePharPath('', '/build', ['phar_filename' => 'cfg.phar']);
+
+        self::assertSame('/build/cfg.phar', $path);
+    }
+
+    public function testResolvePharPathWhenEmptyConfigFallsBackToDefault(): void
+    {
+        $path = $this->resolver->resolvePharPath('', '/build', ['phar_filename' => '']);
+
+        self::assertSame('/build/app.phar', $path);
+    }
+
+    public function testResolveBinPathUsesCliOptionWhenProvided(): void
+    {
+        $path = $this->resolver->resolveBinPath('custom.bin', '/build', ['bin_filename' => 'app.bin']);
+
+        self::assertSame('/build/custom.bin', $path);
+    }
+
+    public function testResolveBinPathFallsBackToConfig(): void
+    {
+        $path = $this->resolver->resolveBinPath(null, '/build', ['bin_filename' => 'app.bin']);
+
+        self::assertSame('/build/app.bin', $path);
+    }
+
+    public function testResolveBinPathFallsBackToDefault(): void
+    {
+        $path = $this->resolver->resolveBinPath(null, '/build', []);
+
+        self::assertSame('/build/app.bin', $path);
+    }
+
+    public function testResolveBinPathWhenEmptyCliOptionFallsBackToConfig(): void
+    {
+        $path = $this->resolver->resolveBinPath('', '/build', ['bin_filename' => 'cfg.bin']);
+
+        self::assertSame('/build/cfg.bin', $path);
+    }
+
+    public function testResolveBinPathWhenEmptyConfigFallsBackToDefault(): void
+    {
+        $path = $this->resolver->resolveBinPath('', '/build', ['bin_filename' => '']);
+
+        self::assertSame('/build/app.bin', $path);
+    }
+}

--- a/tests/Command/BuildPharCommandTest.php
+++ b/tests/Command/BuildPharCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test\Command;
 
+use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
 use CrazyGoat\WorkermanBundle\Command\BuildPharCommand;
 use CrazyGoat\WorkermanBundle\ConfigLoader;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
@@ -51,60 +52,44 @@ final class BuildPharCommandTest extends TestCase
 
     public function testResolvePharPathUsesConfigDefaults(): void
     {
-        $input = new ArrayInput([]);
-        $input->bind((new BuildPharCommand($this->makeConfigLoader(), new PharBuilder('/p', 'test'), '/p'))->getDefinition());
-
-        $path = BuildPharCommand::resolvePharPath($input, [
-            'build_dir' => '/abs/build',
+        $resolver = new BuildPathResolver();
+        $path = $resolver->resolvePharPath(null, '/abs/build', [
             'phar_filename' => 'app.phar',
-        ], '/p');
+        ]);
 
         self::assertSame('/abs/build/app.phar', $path);
     }
 
     public function testResolvePharPathPrefersCliOptions(): void
     {
-        $command = new BuildPharCommand($this->makeConfigLoader(), new PharBuilder('/p', 'test'), '/p');
-        $input = new ArrayInput([
-            '--output-dir' => '/cli/build',
-            '--filename' => 'custom.phar',
-        ]);
-        $input->bind($command->getDefinition());
-
-        $path = BuildPharCommand::resolvePharPath($input, [
-            'build_dir' => '/abs/build',
+        $resolver = new BuildPathResolver();
+        $path = $resolver->resolvePharPath('custom.phar', '/cli/build', [
             'phar_filename' => 'app.phar',
-        ], '/p');
+        ]);
 
         self::assertSame('/cli/build/custom.phar', $path);
     }
 
     public function testResolvePharPathRelativeOutputDirIsRebasedOnProject(): void
     {
-        $command = new BuildPharCommand($this->makeConfigLoader(), new PharBuilder('/p', 'test'), '/proj');
-        $input = new ArrayInput([
-            '--output-dir' => 'out',
-        ]);
-        $input->bind($command->getDefinition());
-
-        $path = BuildPharCommand::resolvePharPath($input, [
+        $resolver = new BuildPathResolver();
+        $buildDir = $resolver->resolveBuildDir('out', [
             'phar_filename' => 'a.phar',
         ], '/proj');
+        $path = $resolver->resolvePharPath(null, $buildDir, [
+            'phar_filename' => 'a.phar',
+        ]);
 
         self::assertSame('/proj/out/a.phar', $path);
     }
 
     public function testResolvePharPathRejectsEmptyConfig(): void
     {
-        $command = new BuildPharCommand($this->makeConfigLoader(), new PharBuilder('/p', 'test'), '/p');
-        $input = new ArrayInput([]);
-        $input->bind($command->getDefinition());
+        $resolver = new BuildPathResolver();
 
         $this->expectException(\RuntimeException::class);
-        BuildPharCommand::resolvePharPath($input, [
-            'build_dir' => '',
-            'phar_filename' => 'x.phar',
-        ], '/p');
+        $this->expectExceptionMessage('build_dir must be a non-empty string');
+        $resolver->resolveBuildDir(null, ['build_dir' => ''], '/p');
     }
 
     public function testGenerateStubHonoursEnvironmentAndRuntimeDirOverride(): void
@@ -189,7 +174,7 @@ final class BuildPharCommandTest extends TestCase
             'custom_ini' => null,
         ]);
 
-        $command = new BuildPharCommand($configLoader, new PharBuilder($this->tempDir, 'test'), $this->tempDir);
+        $command = new BuildPharCommand($configLoader, new PharBuilder($this->tempDir, 'test'), new BuildPathResolver(), $this->tempDir);
 
         $statusCode = $command->run(new ArrayInput([]), new BufferedOutput());
 
@@ -224,6 +209,6 @@ final class BuildPharCommandTest extends TestCase
 
     private function createCommand(): BuildPharCommand
     {
-        return new BuildPharCommand($this->makeConfigLoader(), new PharBuilder($this->tempDir, 'test'), $this->tempDir);
+        return new BuildPharCommand($this->makeConfigLoader(), new PharBuilder($this->tempDir, 'test'), new BuildPathResolver(), $this->tempDir);
     }
 }


### PR DESCRIPTION
## Summary

Closes #242

Extract a single  collaborator that centralizes the `option ?: config ?: default` pattern and path normalization previously duplicated across `BuildBinCommand` and `BuildPharCommand`.

## Changes

- **New** `src/Command/BuildPathResolver.php` — service with `resolveBuildDir()`, `resolvePharPath()`, `resolveBinPath()` methods
- **Refactor** `BuildBinCommand` — replaced 3 static methods with injected resolver
- **Refactor** `BuildPharCommand` — replaced static `resolvePharPath` with injected resolver
- **DI** `ServicesConfigurator` — registered `BuildPathResolver` as a service, added to both command definitions
- **Tests** `BuildPathResolverTest` — 20 tests covering option/config/default precedence, relative path rebasing, empty string fallback, and error cases
- **Cleanup** `BuildBinCommandTest` — removed dead code (unused `createCommand`)

## Verification

- ✅ 856/856 tests pass (17 pre-existing skips)
- ✅ PHP CS Fixer passes
- ✅ Rector passes