### PR TITLE
[Tests] Add ByteFormatterTest covering all unit boundaries and fractional values (#241)

### DIFF
--- a/tests/Phar/ByteFormatterTest.php
+++ b/tests/Phar/ByteFormatterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Phar;
+
+use CrazyGoat\WorkermanBundle\Phar\ByteFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class ByteFormatterTest extends TestCase
+{
+    public function testZeroBytes(): void
+    {
+        self::assertSame('0 B', ByteFormatter::format(0));
+    }
+
+    public function testSingleByte(): void
+    {
+        self::assertSame('1 B', ByteFormatter::format(1));
+    }
+
+    public function testUpperBoundOfBytes(): void
+    {
+        self::assertSame('1023 B', ByteFormatter::format(1023));
+    }
+
+    public function testLowerBoundOfKilobytes(): void
+    {
+        self::assertSame('1 KB', ByteFormatter::format(1024));
+    }
+
+    public function testFractionalKilobytes(): void
+    {
+        self::assertSame('1.5 KB', ByteFormatter::format(1536));
+    }
+
+    public function testRoundedKilobytes(): void
+    {
+        self::assertSame('1.23 KB', ByteFormatter::format(1258));
+    }
+
+    public function testJustBelowMegabyteBoundaryRoundsUpInKilobytes(): void
+    {
+        self::assertSame('1024 KB', ByteFormatter::format(1048575));
+    }
+
+    public function testLowerBoundOfMegabytes(): void
+    {
+        self::assertSame('1 MB', ByteFormatter::format(1048576));
+    }
+
+    public function testFractionalMegabytes(): void
+    {
+        self::assertSame('2.5 MB', ByteFormatter::format(2621440));
+    }
+
+    public function testLowerBoundOfGigabytes(): void
+    {
+        self::assertSame('1 GB', ByteFormatter::format(1073741824));
+    }
+
+    public function testFractionalGigabytes(): void
+    {
+        self::assertSame('1.5 GB', ByteFormatter::format(1610612736));
+    }
+
+    public function testBeyondGigabytesStaysInGigabytes(): void
+    {
+        self::assertSame('1024 GB', ByteFormatter::format(1099511627776));
+    }
+}


### PR DESCRIPTION
## Description

Adds a dedicated test for `ByteFormatter::format()` which previously had no test coverage.

## Acceptance criteria

- [x] New test exists at `tests/Phar/ByteFormatterTest.php` and is executed by `vendor/bin/phpunit`
- [x] Test covers each unit boundary (B, KB, MB, GB) and at least one fractional value per unit
- [x] Test fails if a unit boundary shifts by one byte (regression-protective)
- [x] Existing tests continue to pass (871 tests, 0 failures)

## Coverage highlights

- Zero bytes, single byte, and upper bound of byte range
- KB/MB/GB boundaries and fractional values
- Rounding behavior (e.g. `1258 → 1.23 KB`)
- Unit-selection-before-rounding edge case (`1048575 → 1024 KB`)
- Large values beyond GB stay in GB

Closes #241