### PR TITLE
[Docs] Fix Symfony version matrix badge to include ^8.0 (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Symfony version matrix badge in README now includes `^8.0` to match `composer.json` constraint ([#257](https://github.com/crazy-goat/workerman-bundle/issues/257))
+
 ## [0.19.0] - 2026-05-25
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workerman runtime for symfony applications
 ![PHP ^8.2](https://img.shields.io/badge/PHP-^8.2-777bb3.svg?style=flat)
-![Symfony ^6.4|^7.0](https://img.shields.io/badge/Symfony-^6.4|^7.0-374151.svg?style=flat)
+![Symfony ^6.4|^7.0|^8.0](https://img.shields.io/badge/Symfony-^6.4|^7.0|^8.0-374151.svg?style=flat)
 [![Tests Status](https://img.shields.io/github/actions/workflow/status/crazy-goat/workerman-bundle/tests.yaml?branch=master)](../../actions/workflows/tests.yaml)
 
 [Workerman](https://github.com/walkor/workerman) is a high-performance, asynchronous event-driven PHP framework written in pure PHP.  


### PR DESCRIPTION
## What changed

- Updated `README.md` Symfony version badge from `^6.4|^7.0` to `^6.4|^7.0|^8.0` to match the actual `composer.json` constraint
- Added `[Unreleased]` section to `CHANGELOG.md` with an entry for this fix

## Why

`composer.json` requires `^6.4|^7.0|^8.0` for Symfony, but the README badge only showed `^6.4|^7.0`. `CONTRIBUTING.md` was already correct (mentions Symfony 6.4-8.0).

## Verification

- [x] Lint passes (CS fixer, PHPStan, Rector)
- [x] All 892 PHPUnit tests pass (17 skipped as expected)
- [x] Code review (smell + security) found no issues

Closes #257