### PR TITLE
Move PHAR stub from HEREDOC to resources/phar-stub.tpl template

### DIFF
--- a/resources/phar-stub.tpl
+++ b/resources/phar-stub.tpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+define('IN_PHAR', true);
+Phar::mapPhar('__PHAR_ALIAS__');
+
+$runtimeDir = isset($_SERVER['WORKERMAN_RUNTIME_DIR']) && $_SERVER['WORKERMAN_RUNTIME_DIR'] !== ''
+    ? rtrim((string) $_SERVER['WORKERMAN_RUNTIME_DIR'], '/')
+    : dirname(Phar::running(false));
+
+$_SERVER['APP_RUNTIME'] = '__RUNTIME_CLASS__';
+$_ENV['APP_CACHE_DIR'] = $runtimeDir . '/var/cache';
+$_ENV['APP_LOG_DIR'] = $runtimeDir . '/var/log';
+
+foreach (['/var/cache', '/var/log', '/var/run'] as $sub) {
+    $dir = $runtimeDir . $sub;
+    if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+        fwrite(STDERR, sprintf('Unable to create runtime directory "%s". Set WORKERMAN_RUNTIME_DIR to a writable path.' . PHP_EOL, $dir));
+        exit(1);
+    }
+}
+
+// Load external .env if it exists
+if (file_exists($runtimeDir . '/.env')) {
+    if (class_exists('Symfony\Component\Dotenv\Dotenv')) {
+        (new Symfony\Component\Dotenv\Dotenv())->load($runtimeDir . '/.env');
+    }
+}
+
+require 'phar://__PHAR_ALIAS__/vendor/autoload.php';
+
+$env = $_SERVER['APP_ENV'] ?? '__APP_ENV__';
+$debug = (bool)($_SERVER['APP_DEBUG'] ?? false);
+
+$kernel = new __KERNEL_CLASS__($env, $debug);
+$application = new Symfony\Bundle\FrameworkBundle\Console\Application($kernel);
+$application->run(new Symfony\Component\Console\Input\ArgvInput());
+
+__HALT_COMPILER();

--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -142,6 +142,12 @@ final readonly class PharBuilder
 
     /**
      * @param mixed[] $buildConfig
+     *
+     * Placeholders replaced in the stub template:
+     *   __PHAR_ALIAS__    — PHAR archive alias
+     *   __KERNEL_CLASS__  — Symfony kernel FQCN
+     *   __RUNTIME_CLASS__ — Workerman Runtime class FQCN
+     *   __APP_ENV__       — default environment name
      */
     public function generateStub(array $buildConfig, string $pharAlias = 'app.phar'): string
     {
@@ -150,46 +156,18 @@ final readonly class PharBuilder
             ? $buildConfig['kernel_class']
             : 'App\\Kernel';
 
-        return <<<"PHP"
-#!/usr/bin/env php
-<?php
+        $templatePath = __DIR__ . '/../../resources/phar-stub.tpl';
+        $template = file_get_contents($templatePath);
 
-define('IN_PHAR', true);
-Phar::mapPhar('{$pharAlias}');
+        if ($template === false) {
+            throw new \RuntimeException(sprintf('Unable to read PHAR stub template from "%s".', $templatePath));
+        }
 
-\$runtimeDir = isset(\$_SERVER['WORKERMAN_RUNTIME_DIR']) && \$_SERVER['WORKERMAN_RUNTIME_DIR'] !== ''
-    ? rtrim((string) \$_SERVER['WORKERMAN_RUNTIME_DIR'], '/')
-    : dirname(Phar::running(false));
-
-\$_SERVER['APP_RUNTIME'] = '{$runtimeEnv}';
-\$_ENV['APP_CACHE_DIR'] = \$runtimeDir . '/var/cache';
-\$_ENV['APP_LOG_DIR'] = \$runtimeDir . '/var/log';
-
-foreach (['/var/cache', '/var/log', '/var/run'] as \$sub) {
-    \$dir = \$runtimeDir . \$sub;
-    if (!is_dir(\$dir) && !mkdir(\$dir, 0755, true) && !is_dir(\$dir)) {
-        fwrite(STDERR, sprintf('Unable to create runtime directory "%s". Set WORKERMAN_RUNTIME_DIR to a writable path.' . PHP_EOL, \$dir));
-        exit(1);
-    }
-}
-
-// Load external .env if it exists
-if (file_exists(\$runtimeDir . '/.env')) {
-    if (class_exists('Symfony\\Component\\Dotenv\\Dotenv')) {
-        (new Symfony\\Component\\Dotenv\\Dotenv())->load(\$runtimeDir . '/.env');
-    }
-}
-
-require 'phar://{$pharAlias}/vendor/autoload.php';
-
-\$env = \$_SERVER['APP_ENV'] ?? '{$this->environment}';
-\$debug = (bool)(\$_SERVER['APP_DEBUG'] ?? false);
-
-\$kernel = new {$kernelClass}(\$env, \$debug);
-\$application = new Symfony\\Bundle\\FrameworkBundle\\Console\\Application(\$kernel);
-\$application->run(new Symfony\\Component\\Console\\Input\\ArgvInput());
-
-__HALT_COMPILER();
-PHP;
+        return strtr($template, [
+            '__PHAR_ALIAS__'    => $pharAlias,
+            '__KERNEL_CLASS__'  => $kernelClass,
+            '__RUNTIME_CLASS__' => $runtimeEnv,
+            '__APP_ENV__'       => $this->environment,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

Refactors `PharBuilder::generateStub()` by extracting the 40-line HEREDOC PHAR stub into a standalone template file `resources/phar-stub.tpl`.

## Changes

- Created `resources/phar-stub.tpl` — the PHAR stub PHP source with placeholder tokens (`__PHAR_ALIAS__`, `__KERNEL_CLASS__`, `__RUNTIME_CLASS__`, `__APP_ENV__`)
- Updated `PharBuilder::generateStub()` to load the template via `file_get_contents()` and replace placeholders with `strtr()` (non-cascading substitution)
- Documented placeholders in the PHPDoc
- Added `\RuntimeException` with descriptive message when the template file cannot be read

## Why

- Removes PHP-in-PHP string escaping noise from the builder class
- Template file gets proper IDE syntax highlighting and linting
- Placeholder token names are explicit and maintainable
- Changes to the stub no longer require editing PHP string literals

Closes #234