### PR TITLE
refactor: extract SfxSourceResolver from BuildBinCommand::resolveSfx

### DIFF
--- a/src/Command/BuildBinCommand.php
+++ b/src/Command/BuildBinCommand.php
@@ -9,6 +9,7 @@ use CrazyGoat\WorkermanBundle\Phar\BinaryComposer;
 use CrazyGoat\WorkermanBundle\Phar\ByteFormatter;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
+use CrazyGoat\WorkermanBundle\Phar\SfxSourceResolver;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,14 +20,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'workerman:build:bin', description: 'Build a standalone binary of the Symfony application (PHAR + static PHP)')]
 final class BuildBinCommand extends Command
 {
-    private const DEFAULT_SFX_URL = 'https://download.workerman.net/php/php%s.micro.sfx';
-
     public function __construct(
         private readonly ConfigLoader $configLoader,
         private readonly PharBuilder $pharBuilder,
         private readonly SfxDownloader $sfxDownloader,
         private readonly BinaryComposer $binaryComposer,
         private readonly BuildPathResolver $pathResolver,
+        private readonly SfxSourceResolver $sfxSourceResolver,
         private readonly string $projectDir,
     ) {
         parent::__construct();
@@ -99,59 +99,34 @@ final class BuildBinCommand extends Command
      */
     private function resolveSfx(InputInterface $input, array $buildConfig, string $downloadDir, SymfonyStyle $io): string
     {
-        // Priority: --sfx-file > sfx.file > --sfx-url > sfx.url > default mirror
-        $sfxFile = $input->getOption('sfx-file');
-        if (is_string($sfxFile) && $sfxFile !== '') {
-            if (!is_file($sfxFile)) {
-                throw new \RuntimeException(sprintf('SFX file not found: %s', $sfxFile));
+        $source = $this->sfxSourceResolver->resolve($input, $buildConfig);
+
+        if ($source->isLocal()) {
+            if ($source->localPath === null) {
+                throw new \RuntimeException('Resolver returned a local source without a local path.');
             }
-            $io->text(sprintf('Using local SFX file: %s', $sfxFile));
+            $io->text(sprintf('Using local SFX file: %s', $source->localPath));
 
-            return $sfxFile;
+            return $source->localPath;
         }
 
-        $configSfxFile = $buildConfig['sfx']['file'] ?? null;
-        if (is_string($configSfxFile) && $configSfxFile !== '' && is_file($configSfxFile)) {
-            $io->text(sprintf('Using SFX file from config: %s', $configSfxFile));
-
-            return $configSfxFile;
+        if ($source->url === null) {
+            throw new \RuntimeException('Resolver returned a remote source without a URL.');
         }
 
-        $sfxUrl = $input->getOption('sfx-url');
-        if (!is_string($sfxUrl) || $sfxUrl === '') {
-            $sfxUrl = $buildConfig['sfx']['url'] ?? null;
+        if ($source->resolvedPhpVersion !== null) {
+            $io->text(sprintf('Resolved SFX for PHP %s', $source->resolvedPhpVersion));
         }
 
-        if (!is_string($sfxUrl) || $sfxUrl === '') {
-            $phpVersion = $input->getOption('php-version');
-            if (!is_string($phpVersion) || $phpVersion === '') {
-                $phpVersion = $buildConfig['bin_php_version'] ?? null;
-            }
-            if (!is_string($phpVersion) || $phpVersion === '') {
-                $phpVersion = sprintf('%s.%s', PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
-            }
-            $sfxUrl = sprintf(self::DEFAULT_SFX_URL, $phpVersion);
-            $io->text(sprintf('Resolved SFX for PHP %s', $phpVersion));
-        }
-
-        $checksum = $input->getOption('sfx-checksum');
-        if (!is_string($checksum) || $checksum === '') {
-            $checksum = $buildConfig['sfx']['sha256'] ?? null;
-        }
-        if (!is_string($checksum) || $checksum === '') {
-            $checksum = null;
-        }
-
-        $allowInsecure = (bool) $input->getOption('insecure') || (bool) ($buildConfig['sfx']['allow_insecure'] ?? false);
-        if ($allowInsecure) {
+        if ($source->allowInsecure) {
             $io->warning('Downloading SFX with TLS peer verification disabled. This is unsafe — provide --sfx-checksum or use a trusted mirror.');
         }
-        if ($checksum === null) {
+        if ($source->checksum === null) {
             $io->warning('No SFX SHA-256 configured. The downloaded binary is not verified. Set build.sfx.sha256 (or pass --sfx-checksum) to enable verification.');
         }
 
-        $io->text(sprintf('Downloading: %s', $sfxUrl));
+        $io->text(sprintf('Downloading: %s', $source->url));
 
-        return $this->sfxDownloader->fetch($sfxUrl, $downloadDir, $checksum, $allowInsecure);
+        return $this->sfxDownloader->fetch($source->url, $downloadDir, $source->checksum, $source->allowInsecure);
     }
 }

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -17,6 +17,7 @@ use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
 use CrazyGoat\WorkermanBundle\Phar\BinaryComposer;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
+use CrazyGoat\WorkermanBundle\Phar\SfxSourceResolver;
 use CrazyGoat\WorkermanBundle\ProcessInspector;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\AlwaysRebootStrategy;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\ExceptionRebootStrategy;
@@ -178,6 +179,10 @@ final readonly class ServicesConfigurator
         ;
 
         $container
+            ->register(SfxSourceResolver::class)
+        ;
+
+        $container
             ->register(BuildPharCommand::class)
             ->addTag('console.command')
             ->setArguments([
@@ -197,6 +202,7 @@ final readonly class ServicesConfigurator
                 new Reference('workerman.sfx_downloader'),
                 new Reference('workerman.binary_composer'),
                 new Reference(BuildPathResolver::class),
+                new Reference(SfxSourceResolver::class),
                 $container->getParameter('kernel.project_dir'),
             ])
         ;

--- a/src/Phar/SfxSource.php
+++ b/src/Phar/SfxSource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Phar;
+
+final readonly class SfxSource
+{
+    public function __construct(
+        public ?string $localPath,
+        public ?string $url,
+        public ?string $checksum,
+        public bool $allowInsecure,
+        public ?string $resolvedPhpVersion = null,
+    ) {
+    }
+
+    public function isLocal(): bool
+    {
+        return $this->localPath !== null;
+    }
+}

--- a/src/Phar/SfxSourceResolver.php
+++ b/src/Phar/SfxSourceResolver.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Phar;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+final readonly class SfxSourceResolver
+{
+    private const DEFAULT_SFX_URL = 'https://download.workerman.net/php/php%s.micro.sfx';
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolve(InputInterface $input, array $buildConfig): SfxSource
+    {
+        $sfxFile = $input->getOption('sfx-file');
+        if ($this->isNonEmptyString($sfxFile)) {
+            if (!is_file($sfxFile)) {
+                throw new \RuntimeException(sprintf('SFX file not found: %s', $sfxFile));
+            }
+
+            return new SfxSource(localPath: $sfxFile, url: null, checksum: null, allowInsecure: false);
+        }
+
+        $configSfxFile = $buildConfig['sfx']['file'] ?? null;
+        if ($this->isNonEmptyString($configSfxFile) && is_file($configSfxFile)) {
+            return new SfxSource(localPath: $configSfxFile, url: null, checksum: null, allowInsecure: false);
+        }
+
+        $url = $this->resolveSfxUrl($input, $buildConfig);
+        $checksum = $this->resolveChecksum($input, $buildConfig);
+        $allowInsecure = $this->resolveAllowInsecure($input, $buildConfig);
+        $resolvedPhpVersion = $this->resolvePhpVersion($input, $buildConfig);
+
+        return new SfxSource(localPath: null, url: $url, checksum: $checksum, allowInsecure: $allowInsecure, resolvedPhpVersion: $resolvedPhpVersion);
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolveSfxUrl(InputInterface $input, array $buildConfig): string
+    {
+        $sfxUrl = $input->getOption('sfx-url');
+        if ($this->isNonEmptyString($sfxUrl)) {
+            return $sfxUrl;
+        }
+
+        $sfxUrl = $buildConfig['sfx']['url'] ?? null;
+        if ($this->isNonEmptyString($sfxUrl)) {
+            return $sfxUrl;
+        }
+
+        $phpVersion = $this->resolvePhpVersionString($input, $buildConfig);
+
+        return sprintf(self::DEFAULT_SFX_URL, $phpVersion);
+    }
+
+    /**
+     * Returns the resolved PHP version if the URL was built from the default template,
+     * or null when a custom URL was provided.
+     *
+     * @param mixed[] $buildConfig
+     */
+    private function resolvePhpVersion(InputInterface $input, array $buildConfig): ?string
+    {
+        $sfxUrl = $input->getOption('sfx-url');
+        if ($this->isNonEmptyString($sfxUrl)) {
+            return null;
+        }
+
+        $sfxUrl = $buildConfig['sfx']['url'] ?? null;
+        if ($this->isNonEmptyString($sfxUrl)) {
+            return null;
+        }
+
+        return $this->resolvePhpVersionString($input, $buildConfig);
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    private function resolvePhpVersionString(InputInterface $input, array $buildConfig): string
+    {
+        $phpVersion = $input->getOption('php-version');
+        if (!$this->isNonEmptyString($phpVersion)) {
+            $phpVersion = $buildConfig['bin_php_version'] ?? null;
+        }
+        if (!$this->isNonEmptyString($phpVersion)) {
+            $phpVersion = sprintf('%s.%s', PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+        }
+
+        return $phpVersion;
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolveChecksum(InputInterface $input, array $buildConfig): ?string
+    {
+        $checksum = $input->getOption('sfx-checksum');
+        if ($this->isNonEmptyString($checksum)) {
+            return $checksum;
+        }
+
+        $checksum = $buildConfig['sfx']['sha256'] ?? null;
+
+        return $this->isNonEmptyString($checksum) ? $checksum : null;
+    }
+
+    /**
+     * @param mixed[] $buildConfig
+     */
+    public function resolveAllowInsecure(InputInterface $input, array $buildConfig): bool
+    {
+        return (bool) $input->getOption('insecure') || (bool) ($buildConfig['sfx']['allow_insecure'] ?? false);
+    }
+
+    private function isNonEmptyString(mixed $value): bool
+    {
+        return is_string($value) && $value !== '';
+    }
+}

--- a/tests/Phar/SfxSourceResolverTest.php
+++ b/tests/Phar/SfxSourceResolverTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Phar;
+
+use CrazyGoat\WorkermanBundle\Phar\SfxSourceResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+final class SfxSourceResolverTest extends TestCase
+{
+    private SfxSourceResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new SfxSourceResolver();
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function createInput(array $parameters = []): ArrayInput
+    {
+        return new ArrayInput($parameters, new InputDefinition([
+            new InputOption('sfx-file', null, InputOption::VALUE_REQUIRED),
+            new InputOption('sfx-url', null, InputOption::VALUE_REQUIRED),
+            new InputOption('sfx-checksum', null, InputOption::VALUE_REQUIRED),
+            new InputOption('php-version', null, InputOption::VALUE_REQUIRED),
+            new InputOption('insecure', null, InputOption::VALUE_NONE),
+        ]));
+    }
+
+    public function testResolvesSfxFileFromCliOption(): void
+    {
+        $input = $this->createInput(['--sfx-file' => __FILE__]);
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertTrue($source->isLocal());
+        self::assertSame(__FILE__, $source->localPath);
+        self::assertNull($source->url);
+        self::assertNull($source->checksum);
+        self::assertFalse($source->allowInsecure);
+    }
+
+    public function testThrowsWhenSfxFileOptionDoesNotExist(): void
+    {
+        $input = $this->createInput(['--sfx-file' => '/nonexistent/path/file.sfx']);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SFX file not found');
+
+        $this->resolver->resolve($input, []);
+    }
+
+    public function testResolvesSfxFileFromConfigWhenCliOptionAbsent(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'sfx' => ['file' => __FILE__],
+        ]);
+
+        self::assertTrue($source->isLocal());
+        self::assertSame(__FILE__, $source->localPath);
+    }
+
+    public function testConfigSfxFileIgnoredWhenNotAFile(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'sfx' => ['file' => '/nonexistent/file'],
+        ]);
+
+        self::assertFalse($source->isLocal());
+        self::assertNotNull($source->url);
+    }
+
+    public function testResolvesSfxUrlFromCliOption(): void
+    {
+        $input = $this->createInput(['--sfx-url' => 'https://example.com/custom.sfx']);
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertFalse($source->isLocal());
+        self::assertSame('https://example.com/custom.sfx', $source->url);
+    }
+
+    public function testResolvesSfxUrlFromConfigWhenCliOptionAbsent(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'sfx' => ['url' => 'https://example.com/config.sfx'],
+        ]);
+
+        self::assertSame('https://example.com/config.sfx', $source->url);
+    }
+
+    public function testResolvesDefaultSfxUrlFromPhpVersionCliOption(): void
+    {
+        $input = $this->createInput(['--php-version' => '8.3']);
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertNotNull($source->url);
+        self::assertStringContainsString('8.3', $source->url);
+        self::assertStringContainsString('download.workerman.net', $source->url);
+    }
+
+    public function testResolvesDefaultSfxUrlFromConfigPhpVersion(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'bin_php_version' => '8.2',
+        ]);
+
+        self::assertNotNull($source->url);
+        self::assertStringContainsString('8.2', $source->url);
+    }
+
+    public function testResolvesDefaultSfxUrlFromRunningPhpVersion(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertNotNull($source->url);
+        $expectedVersion = sprintf('%s.%s', PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+        self::assertStringContainsString($expectedVersion, $source->url);
+    }
+
+    public function testResolvesChecksumFromCliOption(): void
+    {
+        $input = $this->createInput([
+            '--sfx-checksum' => 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        ]);
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertSame('abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890', $source->checksum);
+    }
+
+    public function testResolvesChecksumFromConfigWhenCliOptionAbsent(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'sfx' => ['sha256' => 'configchecksum1234567890abcdef1234567890abcdef1234567890abcdef1234'],
+        ]);
+
+        self::assertSame('configchecksum1234567890abcdef1234567890abcdef1234567890abcdef1234', $source->checksum);
+    }
+
+    public function testResolvesChecksumToNullWhenNeitherCliNorConfigSet(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertNull($source->checksum);
+    }
+
+    public function testResolvesAllowInsecureFromCliOption(): void
+    {
+        $input = $this->createInput(['--insecure' => true]);
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertTrue($source->allowInsecure);
+    }
+
+    public function testResolvesAllowInsecureFromConfig(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, [
+            'sfx' => ['allow_insecure' => true],
+        ]);
+
+        self::assertTrue($source->allowInsecure);
+    }
+
+    public function testResolvesAllowInsecureToFalseByDefault(): void
+    {
+        $input = $this->createInput();
+        $source = $this->resolver->resolve($input, []);
+
+        self::assertFalse($source->allowInsecure);
+    }
+
+    public function testCliOptionTakesPriorityOverConfig(): void
+    {
+        $input = $this->createInput([
+            '--sfx-url' => 'https://example.com/cli.sfx',
+            '--sfx-checksum' => 'cli-check',
+            '--insecure' => true,
+        ]);
+        $source = $this->resolver->resolve($input, [
+            'sfx' => [
+                'url' => 'https://example.com/config.sfx',
+                'sha256' => 'config-check',
+                'allow_insecure' => false,
+            ],
+        ]);
+
+        self::assertSame('https://example.com/cli.sfx', $source->url);
+        self::assertSame('cli-check', $source->checksum);
+        self::assertTrue($source->allowInsecure);
+    }
+
+    public function testResolveSfxUrlReturnsCliUrlOverConfig(): void
+    {
+        $input = $this->createInput(['--sfx-url' => 'https://cli.example.com/sfx']);
+        $url = $this->resolver->resolveSfxUrl($input, [
+            'sfx' => ['url' => 'https://config.example.com/sfx'],
+        ]);
+
+        self::assertSame('https://cli.example.com/sfx', $url);
+    }
+
+    public function testResolveChecksumReturnsCliOverConfig(): void
+    {
+        $input = $this->createInput(['--sfx-checksum' => 'cli-checksum']);
+        $checksum = $this->resolver->resolveChecksum($input, [
+            'sfx' => ['sha256' => 'config-checksum'],
+        ]);
+
+        self::assertSame('cli-checksum', $checksum);
+    }
+
+    public function testResolveAllowInsecureReturnsTrueWhenCliSet(): void
+    {
+        $input = $this->createInput(['--insecure' => true]);
+        $allow = $this->resolver->resolveAllowInsecure($input, []);
+
+        self::assertTrue($allow);
+    }
+}


### PR DESCRIPTION
Closes #238

Extract the 5-level SFX source priority cascade from `BuildBinCommand::resolveSfx()` into a dedicated `SfxSourceResolver` with a `SfxSource` DTO.

## Changes
- **SfxSource** DTO — carries `localPath`, `url`, `checksum`, `allowInsecure`, `resolvedPhpVersion`
- **SfxSourceResolver** — encapsulates the priority cascade with `resolve()`, `resolveSfxUrl()`, `resolveChecksum()`, `resolveAllowInsecure()`, and a single `isNonEmptyString()` helper
- **BuildBinCommand** — delegates to the resolver, keeps only IO concerns
- **ServicesConfigurator** — registers `SfxSourceResolver` as a service

## Acceptance criteria
- [x] `BuildBinCommand` no longer contains the priority cascade inline; it delegates to a resolver
- [x] The resolver has its own unit test exercising each fallback level (19 tests)
- [x] The "non-empty string" predicate exists in exactly one place (`isNonEmptyString()`)
- [x] Existing tests pass
- [x] No behavioural change for `build:bin` CLI users