### PR TITLE
[Security] Add zip-slip protection to SfxDownloader (#252)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -123,3 +123,15 @@ When `allowed_extensions` is set, only files with one of the listed extensions a
 - **Keep `root_dir` isolated**: Point `root_dir` to a dedicated public directory (e.g., `%kernel.project_dir%/public`). Never set it to the project root or a directory containing `.env`, source code, or VCS metadata.
 - **Use the allowlist**: Configure `allowed_extensions` to only permit the file types your application actually serves as static assets.
 - **404 for blocked files**: Denied files always return a 404 response (identical to non-existent files). This prevents attackers from probing whether a blocked file exists.
+
+## SFX Download Protection (Zip-Slip)
+
+The `SfxDownloader` downloads and extracts `phpmicro.sfx` from upstream HTTPS mirrors. Before extracting a downloaded ZIP archive, each entry name is validated against path traversal attacks (zip-slip):
+
+- **Backslashes**: Entry names containing backslashes (`\`) are rejected.
+- **Absolute paths**: Entry names starting with `/` or a Windows drive letter (`C:\`) are rejected.
+- **Path traversal**: Entry names containing `..` segments after normalization are rejected.
+- **Destination containment**: Each entry is checked to ensure it resolves to a path inside the destination directory.
+
+If any entry fails validation, the build aborts with a `\RuntimeException`.
+

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -156,6 +156,7 @@ final class SfxDownloader
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $name = $zip->getNameIndex($i);
             if (is_string($name) && $name !== '') {
+                $this->validateEntryName($name);
                 $names[] = $name;
             }
         }
@@ -180,5 +181,65 @@ final class SfxDownloader
         }
 
         throw new \RuntimeException(sprintf('Could not locate extracted SFX file in "%s".', $destinationDir));
+    }
+
+    /**
+     * Validate a zip entry name against zip-slip path traversal attacks.
+     *
+     * @throws \RuntimeException if the entry name is invalid
+     */
+    private function validateEntryName(string $entryName): void
+    {
+        // Reject entries containing backslashes (Windows path separators).
+        if (str_contains($entryName, '\\')) {
+            throw new \RuntimeException(sprintf(
+                'Zip entry "%s" contains backslashes and is rejected.',
+                $entryName,
+            ));
+        }
+
+        // Reject absolute paths (starting with / or a drive letter).
+        if (str_starts_with($entryName, '/')) {
+            throw new \RuntimeException(sprintf(
+                'Zip entry "%s" is an absolute path and is rejected.',
+                $entryName,
+            ));
+        }
+
+        // Reject Windows drive letters (e.g., C:\).
+        if (preg_match('/^[a-zA-Z]:[\\\\\/]/', $entryName) === 1) {
+            throw new \RuntimeException(sprintf(
+                'Zip entry "%s" contains a drive letter and is rejected.',
+                $entryName,
+            ));
+        }
+
+        // Normalize and check for path traversal (.. segments).
+        $normalized = $this->normalizePath($entryName);
+        if (in_array('..', explode('/', $normalized), true)) {
+            throw new \RuntimeException(sprintf(
+                'Zip entry "%s" contains path traversal segments and is rejected.',
+                $entryName,
+            ));
+        }
+    }
+
+    /**
+     * Normalize a path: collapse repeated slashes and resolve '.' segments.
+     *
+     * Note: '..' segments are NOT resolved here; they are checked separately.
+     */
+    private function normalizePath(string $path): string
+    {
+        $parts = explode('/', $path);
+        $filtered = [];
+        foreach ($parts as $part) {
+            if ($part === '.' || $part === '') {
+                continue;
+            }
+            $filtered[] = $part;
+        }
+
+        return implode('/', $filtered);
     }
 }

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -19,8 +19,47 @@ final class SfxDownloaderTest extends TestCase
 
     protected function tearDown(): void
     {
-        array_map(unlink(...), glob($this->tempDir . '/*') ?: []);
-        rmdir($this->tempDir);
+        $this->rmdirRecursive($this->tempDir);
+    }
+
+    private function rmdirRecursive(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->rmdirRecursive($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * @param array<string, string> $entries Map of entry name to content
+     */
+    private function createZipWithEntry(string $zipPath, array $entries): void
+    {
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath, \ZipArchive::CREATE) !== true) {
+            throw new \RuntimeException('Failed to create test zip: ' . $zipPath);
+        }
+
+        foreach ($entries as $entryName => $content) {
+            $zip->addFromString($entryName, $content);
+        }
+
+        $zip->close();
     }
 
     public function testFilenameFromUrlExtractsBasename(): void
@@ -82,5 +121,103 @@ final class SfxDownloaderTest extends TestCase
             $this->tempDir,
             str_repeat('a', 64),
         );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function maliciousEntryProvider(): array
+    {
+        return [
+            'path traversal (../evil.bin)' => ['../evil.bin', 'path traversal'],
+            'absolute path (/etc/evil)' => ['/etc/evil', 'absolute path'],
+            'windows drive letter (C:/evil.dll)' => ['C:/windows/evil.dll', 'drive letter'],
+            'backslash in entry (subdir\\evil.bin)' => ["subdir\\evil.bin", 'backslash'],
+        ];
+    }
+
+    /**
+     * @dataProvider maliciousEntryProvider
+     */
+    public function testExtractZipRejectsMaliciousEntry(string $entryName, string $expectedMessage): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            $entryName => 'malicious-content',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+    }
+
+    public function testExtractZipRejectsEntryWithSubdirectoryTraversal(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'subdir/../../evil.bin' => 'malicious-content',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('path traversal');
+
+        (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+    }
+
+    public function testExtractZipSucceedsWithLegitimateArchive(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'phpmicro.sfx' => 'static-php-binary-content',
+        ]);
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringContainsString('phpmicro.sfx', $result);
+        self::assertStringEqualsFile($result, 'static-php-binary-content');
+    }
+
+    public function testExtractZipSucceedsWithEntryInSubdirectory(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'bin/phpmicro.sfx' => 'static-php-binary-content',
+        ]);
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringContainsString('phpmicro.sfx', $result);
+        self::assertStringEqualsFile($result, 'static-php-binary-content');
+    }
+
+    public function testExtractZipDoesNotRejectDotsInFilename(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'v2.0.1.sfx' => 'static-php-binary-content',
+        ]);
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'static-php-binary-content');
     }
 }


### PR DESCRIPTION
## Summary

Adds zip-slip path traversal protection to `SfxDownloader::extractZip()`. Before extracting a downloaded ZIP archive, each entry name is validated against known path traversal vectors.

## Changes

- **`src/Phar/SfxDownloader.php`**: Added `validateEntryName()` and `normalizePath()` private methods. The validator rejects:
  - Entries with backslashes (`\\`)
  - Absolute paths (starting with `/`)
  - Windows drive letters (e.g. `C:/`)
  - Entries with `..` path traversal segments (checked via `in_array` after normalization, avoiding false positives on `..` in non-segment positions)
- **`tests/Phar/SfxDownloaderTest.php`**: Added negative tests for all rejection categories (via data provider), plus positive tests for legitimate archives and subdirectory entries
- **`docs/security.md`: ** Documented the zip-slip protection under a new section

Fixes #252