### PR TITLE
[Docs] Document build.sfx.sha256 and build.sfx.allow_insecure (#267)

### DIFF
--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -51,8 +51,10 @@ workerman:
 
         # PHPMicro SFX source (priority: sfx-file CLI > sfx.file > sfx-url > sfx.url > default)
         sfx:
-            url: null   # Custom download URL
-            file: null  # Local path to phpmicro.sfx
+            url: null        # Custom download URL
+            file: null       # Local path to phpmicro.sfx
+            sha256: null     # SHA-256 hex digest for checksum verification (strongly recommended)
+            allow_insecure: false  # Disable TLS peer verification (off by default; use only for local mirrors)
 
         # Files excluded from the PHAR
         exclude_patterns:
@@ -71,6 +73,35 @@ workerman:
             opcache.jit=1255
             memory_limit=256M
 ```
+
+### `build.sfx.sha256`
+
+The SHA-256 hex digest of the expected phpmicro.sfx binary. When configured, the downloaded
+SFX file is verified against this checksum before extraction, protecting against supply-chain
+attacks (corrupted download, man-in-the-middle substitution). **Strongly recommended** for all
+production builds.
+
+```bash
+# Obtain the checksum for a specific PHP version
+curl -sL "https://download.workerman.net/php/php8.3.micro.sfx" | sha256sum
+# Or after a successful download, verify inline:
+php bin/console workerman:build:bin --sfx-checksum="$(sha256sum /path/to/downloaded.sfx | cut -d' ' -f1)"
+```
+
+Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:306-309`.
+
+### `build.sfx.allow_insecure`
+
+Disables TLS peer verification (`verify_peer`, `verify_peer_name`) when downloading the SFX
+binary. **Off by default** — keep it off unless you are serving phpmicro.sfx from a local
+mirror with a self-signed certificate.
+
+Security implications when enabled:
+- The connection is vulnerable to man-in-the-middle attacks
+- Redirects across schemes (HTTPS → HTTP) are followed, which can downgrade the download to plaintext
+- Always pair with `build.sfx.sha256` to verify the binary after download
+
+Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:310-313`.
 
 ## How It Works
 

--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -76,16 +76,18 @@ workerman:
 
 ### `build.sfx.sha256`
 
-The SHA-256 hex digest of the expected phpmicro.sfx binary. When configured, the downloaded
-SFX file is verified against this checksum before extraction, protecting against supply-chain
-attacks (corrupted download, man-in-the-middle substitution). **Strongly recommended** for all
-production builds.
+The SHA-256 hex digest of the expected phpmicro.sfx binary. When configured, the SFX binary
+is verified against this checksum after download (and after zip extraction, if applicable),
+protecting against supply-chain attacks (corrupted download, man-in-the-middle substitution).
+**Strongly recommended** for all production builds.
+
+The `--sfx-checksum` CLI option overrides this config value when provided.
 
 ```bash
 # Obtain the checksum for a specific PHP version
 curl -sL "https://download.workerman.net/php/php8.3.micro.sfx" | sha256sum
-# Or after a successful download, verify inline:
-php bin/console workerman:build:bin --sfx-checksum="$(sha256sum /path/to/downloaded.sfx | cut -d' ' -f1)"
+# After obtaining a trusted copy, use its checksum in a subsequent build:
+php bin/console workerman:build:bin --sfx-checksum="$(sha256sum /path/to/trusted.sfx | cut -d' ' -f1)"
 ```
 
 Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:306-309`.
@@ -95,6 +97,8 @@ Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:306-309`.
 Disables TLS peer verification (`verify_peer`, `verify_peer_name`) when downloading the SFX
 binary. **Off by default** — keep it off unless you are serving phpmicro.sfx from a local
 mirror with a self-signed certificate.
+
+The `--insecure` CLI flag enables the same behavior.
 
 Security implications when enabled:
 - The connection is vulnerable to man-in-the-middle attacks


### PR DESCRIPTION
## Summary

Document the missing `build.sfx.sha256` and `build.sfx.allow_insecure` configuration options in `docs/build-packaging.md`.

## Changes

- Updated YAML configuration example to include both keys with inline comments
- Added `### build.sfx.sha256` section: explains checksum verification, how to obtain a checksum, strongly recommended label, `--sfx-checksum` CLI override
- Added `### build.sfx.allow_insecure` section: explains TLS peer verification, security implications, off-by-default, `--insecure` CLI flag
- Both sections cross-reference the config tree builder source

Closes #267