### PR TITLE
[Code Quality] SfxDownloader::extractZip refactored into staged methods with typed exception (#251)

### DIFF
--- a/src/Exception/SfxExtractionException.php
+++ b/src/Exception/SfxExtractionException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Exception;
+
+final class SfxExtractionException extends \RuntimeException implements WorkermanExceptionInterface
+{
+}

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Phar;
 
+use CrazyGoat\WorkermanBundle\Exception\SfxExtractionException;
+
 /**
  * Downloads phpmicro.sfx (the static PHP runtime used to build standalone
  * binaries) from an HTTPS mirror, optionally verifying a SHA-256 digest.
@@ -19,7 +21,8 @@ final class SfxDownloader
      *
      * @return string Path to the resolved SFX file on disk
      *
-     * @throws \RuntimeException on any download/extract/verification failure
+     * @throws SfxExtractionException when the extracted zip contains no usable SFX entry
+     * @throws \RuntimeException on any other download/extract/verification failure
      */
     public function fetch(
         string $url,
@@ -141,7 +144,42 @@ final class SfxDownloader
         ]);
     }
 
+    /**
+     * Extract a phpmicro.sfx zip archive.
+     *
+     * Stages:
+     *  1. Open the zip archive with integrity checks.
+     *  2. List all entry names (validating each against zip-slip).
+     *  3. Extract all entries to the destination directory.
+     *  4. Locate the SFX entry:
+     *     a. Try the entry whose basename matches the zip filename (minus .zip).
+     *     b. Fall back to the first regular file entry from the archive.
+     *
+     * @throws SfxExtractionException when no suitable SFX entry is found
+     * @throws \RuntimeException on archive open, validation, or extraction failures
+     */
     private function extractZip(string $zipPath, string $destinationDir): string
+    {
+        $zip = $this->openArchive($zipPath);
+
+        try {
+            $entryNames = $this->listEntryNames($zip);
+            $this->extractToDirectory($zip, $zipPath, $destinationDir);
+        } finally {
+            $zip->close();
+        }
+
+        return $this->locateSfxEntry($entryNames, $zipPath, $destinationDir);
+    }
+
+    /**
+     * Open a zip archive with integrity checks.
+     *
+     * @return \ZipArchive The opened archive (caller must close)
+     *
+     * @throws \RuntimeException if the zip extension is missing or the archive cannot be opened
+     */
+    private function openArchive(string $zipPath): \ZipArchive
     {
         if (!class_exists(\ZipArchive::class)) {
             throw new \RuntimeException('The zip extension is required to extract the downloaded SFX archive.');
@@ -152,6 +190,18 @@ final class SfxDownloader
             throw new \RuntimeException(sprintf('Failed to open zip archive "%s".', $zipPath));
         }
 
+        return $zip;
+    }
+
+    /**
+     * List all entry names in a zip archive, validating each against zip-slip attacks.
+     *
+     * @return string[] Non-empty entry names
+     *
+     * @throws \RuntimeException if any entry name fails validation
+     */
+    private function listEntryNames(\ZipArchive $zip): array
+    {
         $names = [];
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $name = $zip->getNameIndex($i);
@@ -161,26 +211,53 @@ final class SfxDownloader
             }
         }
 
+        return $names;
+    }
+
+    /**
+     * Extract all zip entries to the destination directory.
+     *
+     * @throws \RuntimeException if extraction fails
+     */
+    private function extractToDirectory(\ZipArchive $zip, string $zipPath, string $destinationDir): void
+    {
         if (!$zip->extractTo($destinationDir)) {
-            $zip->close();
-            throw new \RuntimeException(sprintf('Failed to extract zip archive "%s".', $zipPath));
+            throw new \RuntimeException(sprintf('Failed to extract zip archive "%s" to "%s".', $zipPath, $destinationDir));
         }
-        $zip->close();
+    }
 
-        $extracted = rtrim($destinationDir, '/') . '/' . str_replace('.zip', '', basename($zipPath));
-        if (is_file($extracted)) {
-            return $extracted;
+    /**
+     * Locate the extracted SFX entry on disk.
+     *
+     * Detection rules:
+     *  1. Try the entry whose basename matches the zip filename (minus .zip extension),
+     *     resolved under the destination directory.
+     *  2. Fall back to the first regular file entry from the archive
+     *     that exists on disk after extraction.
+     *
+     * @param string[] $entryNames Validated entry names from the archive
+     *
+     * @throws SfxExtractionException when no suitable SFX entry can be found
+     */
+    private function locateSfxEntry(array $entryNames, string $zipPath, string $destinationDir): string
+    {
+        $expected = rtrim($destinationDir, '/') . '/' . str_replace('.zip', '', basename($zipPath));
+        if (is_file($expected)) {
+            return $expected;
         }
 
-        // Fall back to the first regular file entry from the archive.
-        foreach ($names as $name) {
+        foreach ($entryNames as $name) {
             $candidate = rtrim($destinationDir, '/') . '/' . $name;
             if (is_file($candidate)) {
                 return $candidate;
             }
         }
 
-        throw new \RuntimeException(sprintf('Could not locate extracted SFX file in "%s".', $destinationDir));
+        throw new SfxExtractionException(sprintf(
+            'Could not locate extracted SFX file in "%s". Archive entries: ["%s"]',
+            $destinationDir,
+            implode('", "', $entryNames),
+        ));
     }
 
     /**

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test\Phar;
 
+use CrazyGoat\WorkermanBundle\Exception\SfxExtractionException;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
 use PHPUnit\Framework\TestCase;
 
@@ -219,5 +220,58 @@ final class SfxDownloaderTest extends TestCase
 
         self::assertFileExists($result);
         self::assertStringEqualsFile($result, 'static-php-binary-content');
+    }
+
+    public function testExtractZipThrowsTypedExceptionWhenNoEntryFound(): void
+    {
+        $zipPath = $this->tempDir . '/orphan.sfx.zip';
+
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath, \ZipArchive::CREATE) !== true) {
+            throw new \RuntimeException('Failed to create test zip: ' . $zipPath);
+        }
+        $zip->addEmptyDir('subdir');
+        $zip->close();
+
+        $this->expectException(SfxExtractionException::class);
+        $this->expectExceptionMessage('Could not locate extracted SFX file');
+
+        (new SfxDownloader())->fetch(
+            'https://example.invalid/orphan.sfx.zip',
+            $this->tempDir,
+        );
+    }
+
+    public function testExtractZipPrimaryRuleMatchesZipBasename(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'phpmicro.sfx' => 'primary-rule-match',
+            'other.bin' => 'should-not-be-picked',
+        ]);
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertStringEndsWith('phpmicro.sfx', $result);
+        self::assertStringEqualsFile($result, 'primary-rule-match');
+    }
+
+    public function testExtractZipFallbackPicksFirstFileEntry(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'release.sfx' => 'fallback-entry-content',
+        ]);
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'fallback-entry-content');
     }
 }


### PR DESCRIPTION
## Description

Refactors `SfxDownloader::extractZip()` into five focused private methods with clear responsibilities, introducing a typed `SfxExtractionException` for when no suitable SFX entry is found.

Resolves #251.

## Changes

- **New:** `src/Exception/SfxExtractionException.php` — typed exception extending `\RuntimeException` with `WorkermanExceptionInterface`
- **Refactored:** `src/Phar/SfxDownloader.php` — `extractZip()` split into:
  1. `openArchive()` — opens zip with `CHECKCONS` integrity
  2. `listEntryNames()` — enumerates and validates entries against zip-slip
  3. `extractToDirectory()` — extracts to filesystem
  4. `locateSfxEntry()` — locates SFX binary (primary basename match → fallback to first file entry)
  5. `extractZip()` — orchestrator with `finally`-based resource cleanup
- **Tests:** 3 new test cases for typed exception, primary rule, and fallback behavior

## Verification

- ✅ All 16 existing tests pass (no regressions)
- ✅ PHP-CS-Fixer dry-run clean
- ✅ PHPStan clean
- ✅ Rector clean