### PR TITLE
[Docs] Add UPGRADE.md covering 0.12–0.17 breaking changes (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,11 +105,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Utils::reload()` method as the canonical name for graceful worker restart ([#32](https://github.com/crazy-goat/workerman-bundle/issues/32))
   - `Utils::reboot()` is preserved as a deprecated alias with deprecation notice
   - Updated all internal callers and watcher classes
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-017) for details
 
 - Added `SymfonyController` injection via DI into `HttpRequestHandler` ([#158](https://github.com/crazy-goat/workerman-bundle/issues/158))
   - `HttpRequestHandler` now accepts `SymfonyController $controller` via constructor injection
   - `WorkermanCompilerPass` registers `workerman.symfony_controller` service with autowiring alias
   - Removed unused `KernelInterface` and `ResponseConverter` dependencies
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-017) for details
 
 ### Changed
 
@@ -132,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed dead `StreamResponseInterface` and `streamContent()` method from `StreamedBinaryFileResponse` — the generator-based streaming was never called by the response pipeline; `BinaryFileResponseStrategy` handles it via `withFile()` ([#165](https://github.com/crazy-goat/workerman-bundle/issues/165))
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-017) for details
 
 - Removed 8 permanently skipped tests from `HttpRequestHandlerTest` that were never executed ([#154](https://github.com/crazy-goat/workerman-bundle/issues/154))
 
@@ -150,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unconditionally. HTTPS is now detected only from the actual SSL transport
   layer. Users behind reverse proxies must configure Symfony's trusted
   proxies. ([#152](https://github.com/crazy-goat/workerman-bundle/issues/152))
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-016) for details
 
 ### Fixed
 
@@ -234,6 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **New format:** `['workerman' => ..., 'process' => ..., 'scheduler' => ...]`
   - Uses `ConfigSection` enum values as keys for clarity and type safety
   - **Migration**: Clear cache after upgrade: `rm -rf var/cache/*`
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-015) for details
 
 ## [0.14.0] - 2026-04-14
 
@@ -279,6 +284,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All strategy implementations must be updated to accept the new parameter
   - Enables connection-aware features like immediate temp file cleanup on connection close
   - **Migration**: Add `TcpConnection $connection` parameter to your custom strategy's `convert()` method
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-014) for details
 
 - `BinaryFileResponseStrategy` now deletes temp files immediately after connection closes
   - Uses Workerman's `onClose` callback instead of loading file into memory
@@ -291,6 +297,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously `getContent()` returned full raw body including file contents
   - Files remain accessible via `$request->files` as before
   - **Migration**: If your code relies on reading raw multipart body via `getContent()`, you'll need to adapt it
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-014) for details
 
 - `StreamedBinaryFileResponse::streamContent()` simplified chunking logic
   - Removed redundant inner while loop that was effectively a no-op
@@ -339,6 +346,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Critical**: Priority-based strategy ordering is now enforced in compiler pass
   - Strategies are sorted by priority tag value (descending) before registration
   - Makes strategy ordering resilient to service registration order changes
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-013) for details
 
 ## [0.12.0] - 2026-04-04
 
@@ -381,6 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 9 `\InvalidArgumentException` throw sites replaced with domain-specific validation/scheduler/middleware exceptions
   - 2 `\RuntimeException` throw sites replaced with `KernelCreationException` and `InvalidCacheDirectoryException`
   - 1 `\LogicException` throw site replaced with `InvalidCronExpressionException`
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-012) for details
 
 ### Removed
 
@@ -388,6 +397,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CrazyGoat\WorkermanBundle\ServerAlreadyRunningException` → `CrazyGoat\WorkermanBundle\Exception\ServerAlreadyRunningException`
   - `CrazyGoat\WorkermanBundle\ServerNotRunningException` → `CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException`
   - `CrazyGoat\WorkermanBundle\ServerStopFailedException` → `CrazyGoat\WorkermanBundle\Exception\ServerStopFailedException`
+  - See [UPGRADE.md](UPGRADE.md#upgrading-to-012) for details
 
 ### Fixed
 
@@ -412,42 +422,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration Guide
 
-#### For consumers catching specific exceptions
-
-Update your catch blocks to use the new exception classes:
-
-```php
-// Before
-use CrazyGoat\WorkermanBundle\ServerAlreadyRunningException;
-
-// After
-use CrazyGoat\WorkermanBundle\Exception\ServerAlreadyRunningException;
-```
-
-#### For consumers catching generic exceptions
-
-**No changes required** - backward compatibility is maintained for:
-- Code catching `\RuntimeException` (all exceptions extend it via `WorkermanException`)
-- Code catching `\InvalidArgumentException` (validation/scheduler/middleware exceptions extend it)
-
-#### For consumers catching LogicException
-
-**Breaking change**: The exception thrown when cron expression package is not installed changed from `\LogicException` to `InvalidCronExpressionException` (extends `\InvalidArgumentException`).
-
-Update your code:
-
-```php
-// Before
-try {
-    new CronExpressionTrigger('* * * * *');
-} catch (\LogicException $e) {
-    // Handle missing package
-}
-
-// After
-try {
-    new CronExpressionTrigger('* * * * *');
-} catch (InvalidCronExpressionException $e) {
-    // Handle missing package or invalid expression
-}
-```
+For detailed migration instructions for all breaking changes, see [UPGRADE.md](UPGRADE.md#upgrading-to-012).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,239 @@
+# Upgrade Guide
+
+This document lists breaking changes between releases and describes how to migrate from one version to another.
+
+---
+
+## Upgrading to 0.17
+
+### `Utils::reboot()` deprecated in favour of `Utils::reload()`
+
+`Utils::reboot()` is deprecated and will be removed in a future release. Use `Utils::reload()` instead.
+
+**Before:**
+
+```php
+use CrazyGoat\WorkermanBundle\Utils;
+
+Utils::reboot();
+Utils::reboot(rebootAllWorkers: true);
+```
+
+**After:**
+
+```php
+use CrazyGoat\WorkermanBundle\Utils;
+
+Utils::reload();
+Utils::reload(reloadAllWorkers: true);
+```
+
+### `HttpRequestHandler` constructor signature changed
+
+`HttpRequestHandler` now accepts `SymfonyController $controller` via constructor injection and no longer requires `KernelInterface` and `ResponseConverter`. If you instantiate this class directly (not recommended), update your call.
+
+**Before:**
+
+```php
+$handler = new HttpRequestHandler($kernel, $rebootStrategy, $responseConverter);
+```
+
+**After:**
+
+```php
+$handler = new HttpRequestHandler($controller, $rebootStrategy);
+```
+
+### Removed `StreamResponseInterface` and `streamContent()`
+
+The `StreamResponseInterface` and `streamContent()` method on `StreamedBinaryFileResponse` have been removed. `BinaryFileResponseStrategy` handles streaming via `withFile()`.
+
+**Migration:** Remove any references to `StreamResponseInterface` or `streamContent()` in your code.
+
+---
+
+## Upgrading to 0.16
+
+### `X-Forwarded-Proto` no longer trusted by default
+
+`RequestConverter` no longer trusts the `X-Forwarded-Proto` header unconditionally. HTTPS is detected only from the actual SSL transport layer. If you are behind a reverse proxy, configure Symfony's trusted proxies:
+
+```yaml
+# config/packages/framework.yaml
+framework:
+    trusted_proxies: '127.0.0.1,REMOTE_ADDR'
+    trusted_headers: ['x-forwarded-proto', 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-port']
+```
+
+---
+
+## Upgrading to 0.15
+
+### Config cache format changed
+
+The config cache file format changed from numeric indices to string keys using `ConfigSection` enum values.
+
+**Old format:**
+
+```php
+[0 => [...], 1 => [...], 2 => [...]]
+```
+
+**New format:**
+
+```php
+['workerman' => [...], 'process' => [...], 'scheduler' => [...]]
+```
+
+**Migration:** Clear the cache after upgrading:
+
+```bash
+rm -rf var/cache/*
+```
+
+---
+
+## Upgrading to 0.14
+
+### `Request::withHeader()` deprecated
+
+`Request::withHeader()` is deprecated in favour of `setHeader()`. `withHeader()` is kept as an alias for backward compatibility but will be removed in a future release.
+
+**Before:**
+
+```php
+$request->withHeader('X-Custom', 'value');
+```
+
+**After:**
+
+```php
+$request->setHeader('X-Custom', 'value');
+```
+
+### `ResponseConverterStrategyInterface::convert()` now requires `TcpConnection`
+
+The `convert()` method on `ResponseConverterStrategyInterface` now requires a third `TcpConnection $connection` parameter.
+
+**Before:**
+
+```php
+public function convert(SymfonyResponse $response, array $headers): WorkermanResponse;
+```
+
+**After:**
+
+```php
+public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse;
+```
+
+**Migration:** Add `TcpConnection $connection` as the third parameter to your custom strategy's `convert()` method.
+
+### `RequestConverter::toSymfonyRequest()` returns empty content for multipart
+
+`toSymfonyRequest()` now returns an empty string for `getContent()` on `multipart/form-data` requests, matching PHP-FPM behaviour where `php://input` is not available for multipart. Files remain accessible via `$request->files`.
+
+**Migration:** If your code reads the raw multipart body via `getContent()`, adapt it to use `$request->files` or `$request->request` instead.
+
+See: `src/DTO/RequestConverter.php`
+
+---
+
+## Upgrading to 0.13
+
+### Priority-based strategy ordering enforced
+
+Response converter strategies are now sorted by priority tag value (descending) in the compiler pass. Previously the order depended on service registration order.
+
+**Migration:** If you have custom `ResponseConverterStrategyInterface` implementations, ensure they are tagged with the correct priority:
+
+```yaml
+services:
+    App\Response\MyCustomStrategy:
+        tags:
+            - { name: 'workerman.response_converter.strategy', priority: 50 }
+```
+
+Strategies are registered with the `workerman.response_converter.strategy` tag. The built-in strategies use the following priorities:
+
+| Strategy                   | Priority |
+|----------------------------|----------|
+| `BinaryFileResponseStrategy` | 100      |
+| `StreamedResponseStrategy`   | 50       |
+| `DefaultResponseStrategy`    | 0        |
+
+---
+
+## Upgrading to 0.12
+
+### Exception namespace migration
+
+Root-level exception classes have been moved into the `Exception` namespace. Update your import statements:
+
+**Before:**
+
+```php
+use CrazyGoat\WorkermanBundle\ServerAlreadyRunningException;
+use CrazyGoat\WorkermanBundle\ServerNotRunningException;
+use CrazyGoat\WorkermanBundle\ServerStopFailedException;
+```
+
+**After:**
+
+```php
+use CrazyGoat\WorkermanBundle\Exception\ServerAlreadyRunningException;
+use CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException;
+use CrazyGoat\WorkermanBundle\Exception\ServerStopFailedException;
+```
+
+### Generic PHP exceptions replaced with typed exceptions
+
+9 `\InvalidArgumentException` throw sites and 2 `\RuntimeException` throw sites have been replaced with domain-specific exceptions. Code catching generic exceptions (`\RuntimeException`, `\InvalidArgumentException`) continues to work, but there are two noteworthy changes:
+
+| Before                          | After                                                |
+|---------------------------------|------------------------------------------------------|
+| `\InvalidArgumentException`     | `FileUploadValidationException`, `ConfigurationValidationException`, `InvalidTriggerException`, `InvalidCronExpressionException`, `InvalidMiddlewareException`, `StaticFileMiddlewareException` |
+| `\RuntimeException`             | `KernelCreationException`, `InvalidCacheDirectoryException`  |
+| `\LogicException`               | `InvalidCronExpressionException` (extends `\InvalidArgumentException`) |
+
+**Exception hierarchy:**
+
+```text
+WorkermanExceptionInterface
+├── WorkermanException (extends \RuntimeException)
+│   ├── ServerException
+│   │   ├── ServerAlreadyRunningException
+│   │   ├── ServerNotRunningException
+│   │   └── ServerStopFailedException
+│   └── KernelException
+│       ├── KernelCreationException
+│       └── InvalidCacheDirectoryException
+├── ValidationException (extends \InvalidArgumentException)
+│   ├── FileUploadValidationException
+│   └── ConfigurationValidationException
+├── SchedulerException (extends \InvalidArgumentException)
+│   ├── InvalidTriggerException
+│   └── InvalidCronExpressionException
+├── MiddlewareException (extends \InvalidArgumentException)
+│   ├── InvalidMiddlewareException
+│   └── StaticFileMiddlewareException
+└── NoResponseStrategyException (extends \LogicException)
+```
+
+**Migration:** If you were catching `\LogicException` from cron expression instantiation, update to catch `InvalidCronExpressionException`:
+
+```php
+// Before
+try {
+    new CronExpressionTrigger('* * * * *');
+} catch (\LogicException $e) {
+    // Handle missing package
+}
+
+// After
+try {
+    new CronExpressionTrigger('* * * * *');
+} catch (InvalidCronExpressionException $e) {
+    // Handle missing package or invalid expression
+}
+```


### PR DESCRIPTION
## Description

Adds a consolidated UPGRADE.md migration guide covering all breaking changes from 0.12 through 0.17, and cross-links from CHANGELOG.md entries.

## Changes

- **New:** `UPGRADE.md` at repo root with per-version subsections (0.12–0.17)
  - Concrete migration steps (FQCN before/after, signature changes, config keys)
  - Code examples for each breaking change
  - Full typed exception hierarchy diagram
- **Updated:** `CHANGELOG.md` entries now link to corresponding `UPGRADE.md` sections
- **Removed:** Redundant inline migration guide from CHANGELOG 0.12.0 section (replaced by link to UPGRADE.md)

## Acceptance criteria

- [x] UPGRADE.md exists at repo root and covers 0.12 through 0.17 breaking changes
- [x] Each CHANGELOG breaking entry links to the corresponding UPGRADE.md section
- [x] Migration steps are concrete (FQCN before/after, signature changes, config keys)
- [x] No remaining gap between the existence of breaking changes and a documented migration path

Closes #256