### PR TITLE
fix: block cross-scheme redirects and require checksum for SFX download

### DIFF
--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -79,7 +79,7 @@ workerman:
 The SHA-256 hex digest of the expected phpmicro.sfx binary. When configured, the SFX binary
 is verified against this checksum after download (and after zip extraction, if applicable),
 protecting against supply-chain attacks (corrupted download, man-in-the-middle substitution).
-**Strongly recommended** for all production builds.
+**Required** for all builds unless `--unsafe-no-checksum` is explicitly passed.
 
 The `--sfx-checksum` CLI option overrides this config value when provided.
 
@@ -92,6 +92,21 @@ php bin/console workerman:build:bin --sfx-checksum="$(sha256sum /path/to/trusted
 
 Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:306-309`.
 
+### `--unsafe-no-checksum`
+
+Bypasses the mandatory checksum requirement and allows the download without SHA-256 verification.
+Use only when:
+- You are downloading from a trusted, local mirror
+- You have verified the binary integrity through out-of-band means
+
+Without this flag, the build **fails** with an error when no `--sfx-checksum` or `build.sfx.sha256`
+is configured.
+
+```bash
+# Warning: skips checksum verification
+php bin/console workerman:build:bin --unsafe-no-checksum
+```
+
 ### `build.sfx.allow_insecure`
 
 Disables TLS peer verification (`verify_peer`, `verify_peer_name`) when downloading the SFX
@@ -102,7 +117,7 @@ The `--insecure` CLI flag enables the same behavior.
 
 Security implications when enabled:
 - The connection is vulnerable to man-in-the-middle attacks
-- Redirects across schemes (HTTPS → HTTP) are followed, which can downgrade the download to plaintext
+- Cross-scheme redirects (HTTPS → HTTP) are **blocked** with a hard error
 - Always pair with `build.sfx.sha256` to verify the binary after download
 
 Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:310-313`.
@@ -166,11 +181,14 @@ Options:
 php bin/console workerman:build:bin [options]
 
 Options:
-  -o, --output-dir=DIR     Output directory
-      --filename=NAME      Output filename (default: config build.bin_filename)
-      --sfx-file=PATH      Local path to phpmicro.sfx
-      --sfx-url=URL        URL to download phpmicro.sfx
-      --php-version=VER    PHP version for static binary (e.g., 8.3)
+  -o, --output-dir=DIR         Output directory
+      --filename=NAME          Output filename (default: config build.bin_filename)
+      --sfx-file=PATH          Local path to phpmicro.sfx
+      --sfx-url=URL            URL to download phpmicro.sfx
+      --sfx-checksum=HASH      Expected SHA-256 hex digest (mandatory unless --unsafe-no-checksum)
+      --php-version=VER        PHP version for static binary (e.g., 8.3)
+      --insecure               Disable TLS peer verification (not recommended)
+      --unsafe-no-checksum     Skip SHA-256 verification (not recommended)
 ```
 
 ## References

--- a/docs/security.md
+++ b/docs/security.md
@@ -135,3 +135,26 @@ The `SfxDownloader` downloads and extracts `phpmicro.sfx` from upstream HTTPS mi
 
 If any entry fails validation, the build aborts with a `\RuntimeException`.
 
+## SFX Download Protection (Redirect Scheme)
+
+When downloading `phpmicro.sfx` with `--insecure` (or `build.sfx.allow_insecure: true`), TLS peer
+verification is disabled. To prevent an on-path attacker from downgrading the download from HTTPS
+to plain HTTP via a redirect:
+
+- **Automatic redirect following is disabled** in the stream context
+- Each redirect response is inspected manually
+- **Cross-scheme redirects (HTTPS → HTTP) are blocked** with a hard error
+- Redirects within the same scheme (HTTPS → HTTPS) are still allowed (up to 5 hops)
+
+This defense is always active when `allow_insecure` is enabled, regardless of whether a checksum
+is configured.
+
+## SFX Checksum Requirement
+
+The build **fails** if no SHA-256 checksum is configured, unless `--unsafe-no-checksum` is explicitly
+passed. This ensures supply-chain integrity by default:
+
+- `--sfx-checksum=HASH` or config `build.sfx.sha256` → checksum verified after download
+- `--unsafe-no-checksum` → no verification (not recommended)
+- Neither → build aborts with an error
+

--- a/src/Command/BuildBinCommand.php
+++ b/src/Command/BuildBinCommand.php
@@ -44,6 +44,7 @@ final class BuildBinCommand extends Command
             ->addOption('sfx-checksum', null, InputOption::VALUE_REQUIRED, 'Expected SHA-256 of the SFX binary (hex)')
             ->addOption('php-version', null, InputOption::VALUE_REQUIRED, 'PHP version for the static binary (e.g. 8.3)')
             ->addOption('insecure', null, InputOption::VALUE_NONE, 'Disable TLS peer verification when downloading the SFX (not recommended)')
+            ->addOption('unsafe-no-checksum', null, InputOption::VALUE_NONE, 'Skip SHA-256 checksum verification (not recommended; use only with a trusted mirror)')
         ;
     }
 
@@ -122,6 +123,12 @@ final class BuildBinCommand extends Command
             $io->warning('Downloading SFX with TLS peer verification disabled. This is unsafe — provide --sfx-checksum or use a trusted mirror.');
         }
         if ($source->checksum === null) {
+            if (!$input->getOption('unsafe-no-checksum')) {
+                throw new \RuntimeException(
+                    'No SFX SHA-256 checksum configured. Use --sfx-checksum to provide one, '
+                    . 'or --unsafe-no-checksum to skip verification (not recommended).',
+                );
+            }
             $io->warning('No SFX SHA-256 configured. The downloaded binary is not verified. Set build.sfx.sha256 (or pass --sfx-checksum) to enable verification.');
         }
 

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -85,14 +85,109 @@ final class SfxDownloader
 
     private function downloadTo(string $url, string $destination, bool $allowInsecure): void
     {
-        $context = $this->buildContext($url, $allowInsecure);
+        if ($allowInsecure) {
+            $this->downloadWithRedirectCheck($url, $destination, $allowInsecure);
 
+            return;
+        }
+
+        $context = $this->buildContext($url, $allowInsecure);
+        $this->downloadStream($url, $destination, $context);
+    }
+
+    private function downloadWithRedirectCheck(string $url, string $destination, bool $allowInsecure): void
+    {
+        $maxRedirects = 5;
+        $currentUrl = $url;
+
+        for ($i = 0; $i <= $maxRedirects; $i++) {
+            $context = $this->buildContext($currentUrl, $allowInsecure);
+
+            $in = @fopen($currentUrl, 'rb', false, $context);
+            if (!is_resource($in)) {
+                $err = error_get_last()['message'] ?? 'unknown error';
+                throw new \RuntimeException(sprintf('Failed to open "%s" for download: %s', $currentUrl, $err));
+            }
+
+            $responseHeaders = $this->getHttpResponseHeaders(get_defined_vars());
+
+            $httpCode = 0;
+            if (isset($responseHeaders[0]) && preg_match('#^HTTP/\d+\.\d+\s+(\d+)#', $responseHeaders[0], $m)) {
+                $httpCode = (int) $m[1];
+            }
+
+            if ($httpCode < 300 || $httpCode >= 400) {
+                $this->writeStream($in, $destination);
+
+                return;
+            }
+
+            fclose($in);
+
+            $location = null;
+            foreach ($responseHeaders as $header) {
+                if (str_starts_with(strtolower($header), 'location:')) {
+                    $location = trim(substr($header, 9));
+                    break;
+                }
+            }
+
+            if ($location === null) {
+                throw new \RuntimeException(sprintf('Redirect response (%d) without Location header from "%s".', $httpCode, $currentUrl));
+            }
+
+            $location = $this->resolveRedirectUrl($currentUrl, $location);
+
+            if (str_starts_with($currentUrl, 'https://') && str_starts_with(strtolower($location), 'http://')) {
+                throw new \RuntimeException(sprintf(
+                    'Blocked cross-scheme redirect from HTTPS to "%s". Disable redirects or use a trusted mirror.',
+                    $location,
+                ));
+            }
+
+            $currentUrl = $location;
+        }
+
+        throw new \RuntimeException(sprintf('Too many redirects (max %d) for "%s".', $maxRedirects, $url));
+    }
+
+    private function resolveRedirectUrl(string $base, string $location): string
+    {
+        if (preg_match('#^https?://#i', $location)) {
+            return $location;
+        }
+
+        $parts = parse_url($base);
+        if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+            return $location;
+        }
+
+        $scheme = $parts['scheme'];
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+        if ($location === '' || $location[0] !== '/') {
+            $basePath = isset($parts['path']) ? dirname($parts['path']) : '/';
+
+            return $scheme . '://' . $host . $port . rtrim($basePath, '/') . '/' . $location;
+        }
+
+        return $scheme . '://' . $host . $port . $location;
+    }
+
+    private function downloadStream(string $url, string $destination, mixed $context): void
+    {
         $in = @fopen($url, 'rb', false, $context);
         if (!is_resource($in)) {
             $err = error_get_last()['message'] ?? 'unknown error';
             throw new \RuntimeException(sprintf('Failed to open "%s" for download: %s', $url, $err));
         }
 
+        $this->writeStream($in, $destination);
+    }
+
+    private function writeStream(mixed $in, string $destination): void
+    {
         $out = fopen($destination, 'wb');
         if (!is_resource($out)) {
             fclose($in);
@@ -103,7 +198,7 @@ final class SfxDownloader
             while (!feof($in)) {
                 $chunk = fread($in, self::DOWNLOAD_CHUNK);
                 if ($chunk === false) {
-                    throw new \RuntimeException(sprintf('Failed to read from "%s".', $url));
+                    throw new \RuntimeException('Failed to read from stream.');
                 }
                 if ($chunk === '') {
                     continue;
@@ -137,8 +232,8 @@ final class SfxDownloader
         return stream_context_create([
             'ssl' => $sslOptions,
             'http' => [
-                'follow_location' => 1,
-                'max_redirects' => 5,
+                'follow_location' => $allowInsecure ? 0 : 1,
+                'max_redirects' => $allowInsecure ? 0 : 5,
                 'timeout' => 60,
             ],
         ]);
@@ -299,6 +394,18 @@ final class SfxDownloader
                 $entryName,
             ));
         }
+    }
+
+    /**
+     * @param array<string, mixed> $definedVars
+     *
+     * @return list<string>
+     */
+    private function getHttpResponseHeaders(array $definedVars): array
+    {
+        $headerVar = 'http_response_header';
+
+        return $definedVars[$headerVar] ?? [];
     }
 
     /**

--- a/tests/Command/BuildBinCommandTest.php
+++ b/tests/Command/BuildBinCommandTest.php
@@ -5,10 +5,45 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test\Command;
 
 use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
+use CrazyGoat\WorkermanBundle\ConfigLoader;
 use PHPUnit\Framework\TestCase;
 
 final class BuildBinCommandTest extends TestCase
 {
+    public function testConfigureHasUnsafeNoChecksumOption(): void
+    {
+        $command = $this->createCommand();
+        $option = $command->getDefinition()->getOption('unsafe-no-checksum');
+
+        self::assertInstanceOf(\Symfony\Component\Console\Input\InputOption::class, $option);
+        self::assertFalse($option->acceptValue());
+    }
+
+    public function testConfigureHasInsecureOption(): void
+    {
+        $command = $this->createCommand();
+        $option = $command->getDefinition()->getOption('insecure');
+
+        self::assertInstanceOf(\Symfony\Component\Console\Input\InputOption::class, $option);
+        self::assertFalse($option->acceptValue());
+    }
+
+    private function createCommand(): \CrazyGoat\WorkermanBundle\Command\BuildBinCommand
+    {
+        $configLoader = new ConfigLoader('/tmp', '/tmp/cache/test', false);
+        $configLoader->setBuildConfig([]);
+
+        return new \CrazyGoat\WorkermanBundle\Command\BuildBinCommand(
+            $configLoader,
+            new \CrazyGoat\WorkermanBundle\Phar\PharBuilder('/tmp', 'test'),
+            new \CrazyGoat\WorkermanBundle\Phar\SfxDownloader(),
+            new \CrazyGoat\WorkermanBundle\Phar\BinaryComposer(),
+            new BuildPathResolver(),
+            new \CrazyGoat\WorkermanBundle\Phar\SfxSourceResolver(),
+            '/tmp',
+        );
+    }
+
     public function testResolveBinPathUsesConfigDefaults(): void
     {
         $resolver = new BuildPathResolver();

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -8,6 +8,10 @@ use CrazyGoat\WorkermanBundle\Exception\SfxExtractionException;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group network
+ */
+
 final class SfxDownloaderTest extends TestCase
 {
     private string $tempDir;
@@ -273,5 +277,99 @@ final class SfxDownloaderTest extends TestCase
 
         self::assertFileExists($result);
         self::assertStringEqualsFile($result, 'fallback-entry-content');
+    }
+
+    public function testBuildContextReturnsNullForHttpUrl(): void
+    {
+        $result = $this->invokeBuildContext('http://example.com/file.sfx', false);
+
+        self::assertNull($result);
+    }
+
+    public function testBuildContextReturnsNullForHttpUrlEvenWhenInsecure(): void
+    {
+        $result = $this->invokeBuildContext('http://example.com/file.sfx', true);
+
+        self::assertNull($result);
+    }
+
+    public function testBuildContextDisablesFollowLocationWhenInsecure(): void
+    {
+        $context = $this->invokeBuildContext('https://example.com/file.sfx', true);
+        self::assertNotNull($context);
+
+        $options = stream_context_get_options($context);
+        self::assertArrayHasKey('http', $options);
+        self::assertSame(0, $options['http']['follow_location']);
+        self::assertFalse($options['ssl']['verify_peer']);
+        self::assertFalse($options['ssl']['verify_peer_name']);
+    }
+
+    public function testBuildContextEnablesFollowLocationWhenSecure(): void
+    {
+        $context = $this->invokeBuildContext('https://example.com/file.sfx', false);
+        self::assertNotNull($context);
+
+        $options = stream_context_get_options($context);
+        self::assertArrayHasKey('http', $options);
+        self::assertSame(1, $options['http']['follow_location']);
+        self::assertTrue($options['ssl']['verify_peer']);
+        self::assertTrue($options['ssl']['verify_peer_name']);
+    }
+
+    public function testResolveRedirectUrlAbsolute(): void
+    {
+        $result = $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com/a/b/c.sfx', 'https://other.com/d.sfx');
+
+        self::assertSame('https://other.com/d.sfx', $result);
+    }
+
+    public function testResolveRedirectUrlRelativePath(): void
+    {
+        $result = $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com/a/b/c.sfx', 'd.sfx');
+
+        self::assertSame('https://example.com/a/b/d.sfx', $result);
+    }
+
+    public function testResolveRedirectUrlAbsolutePath(): void
+    {
+        $result = $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com/a/b/c.sfx', '/d.sfx');
+
+        self::assertSame('https://example.com/d.sfx', $result);
+    }
+
+    public function testResolveRedirectUrlWithPort(): void
+    {
+        $result = $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com:8443/a/b/c.sfx', '/d.sfx');
+
+        self::assertSame('https://example.com:8443/d.sfx', $result);
+    }
+
+    public function testDownloadWithRedirectCheckExtractsSfxFilename(): void
+    {
+        $tempFile = $this->tempDir . '/downloaded.sfx';
+        file_put_contents($tempFile, 'sfx-content');
+
+        $result = (new SfxDownloader())->fetch(
+            'file://' . $tempFile,
+            $this->tempDir . '/out',
+            null,
+            true,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'sfx-content');
+    }
+
+    private function invokeBuildContext(string $url, bool $allowInsecure): mixed
+    {
+        return $this->invokePrivateSfxMethod('buildContext', $url, $allowInsecure);
+    }
+
+    private function invokePrivateSfxMethod(string $methodName, mixed ...$args): mixed
+    {
+        $method = new \ReflectionMethod(SfxDownloader::class, $methodName);
+
+        return $method->invoke(new SfxDownloader(), ...$args);
     }
 }


### PR DESCRIPTION
- Disable follow_location when allowInsecure is true and handle redirects
  manually to prevent HTTPS → HTTP downgrade attacks
- Add --unsafe-no-checksum option to bypass mandatory checksum requirement
- Build now fails hard (not warns) when no SHA-256 checksum is configured
  and --unsafe-no-checksum is not passed
- Update docs/build-packaging.md and docs/security.md with new options
- Add tests for context options, redirect URL resolution, and command options

Closes #248
