### PR TITLE
feat: replace stringly-typed listen-scheme switch with ListenScheme enum (#305)

### DIFF
--- a/src/Exception/UnsupportedListenSchemeException.php
+++ b/src/Exception/UnsupportedListenSchemeException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Exception;
+
+/**
+ * Exception thrown when an unsupported listen scheme is provided.
+ *
+ * Supported schemes: http://, https://, ws://, wss://
+ */
+final class UnsupportedListenSchemeException extends WorkermanException
+{
+}

--- a/src/Worker/ListenScheme.php
+++ b/src/Worker/ListenScheme.php
@@ -33,6 +33,8 @@ enum ListenScheme: string
      */
     public static function fromListen(string $listen): self
     {
+        // Order matters: longer prefixes (https, wss) must be checked before
+        // shorter ones (http, ws) to avoid false-positive prefix matches.
         return match (true) {
             str_starts_with($listen, 'https://') => self::Https,
             str_starts_with($listen, 'wss://')   => self::Wss,

--- a/src/Worker/ListenScheme.php
+++ b/src/Worker/ListenScheme.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Worker;
+
+use CrazyGoat\WorkermanBundle\Exception\UnsupportedListenSchemeException;
+
+/**
+ * Supported listen schemes for Workerman server configuration.
+ *
+ * Each case maps a user-facing scheme (e.g. "https") to the internal
+ * Workerman listen prefix and transport that Workerman expects.
+ *
+ * @see https://github.com/crazy-goat/workerman-bundle?tab=readme-ov-file
+ */
+enum ListenScheme: string
+{
+    case Http = 'http';
+    case Https = 'https';
+    case Ws = 'ws';
+    case Wss = 'wss';
+
+    /**
+     * Parse a listen URL string and return the matching scheme.
+     *
+     * Extracts the scheme prefix (e.g. "https" from "https://0.0.0.0:443")
+     * and maps it to the corresponding enum case.
+     *
+     * @param string $listen The full listen URL (e.g. "http://0.0.0.0:80")
+     * @return self The matching scheme
+     * @throws UnsupportedListenSchemeException If the scheme is not supported
+     */
+    public static function fromListen(string $listen): self
+    {
+        return match (true) {
+            str_starts_with($listen, 'https://') => self::Https,
+            str_starts_with($listen, 'wss://')   => self::Wss,
+            str_starts_with($listen, 'ws://')    => self::Ws,
+            str_starts_with($listen, 'http://')  => self::Http,
+            default => throw new UnsupportedListenSchemeException(sprintf(
+                'Unsupported listen scheme in "%s". Supported schemes: http://, https://, ws://, wss://',
+                $listen,
+            )),
+        };
+    }
+
+    /**
+     * The Workerman listen prefix for this scheme.
+     *
+     * Workerman uses different protocol prefixes internally:
+     * - http:// remains http://
+     * - https:// becomes http:// (SSL is handled via transport)
+     * - ws:// becomes websocket://
+     * - wss:// becomes websocket:// (SSL is handled via transport)
+     */
+    public function workermanPrefix(): string
+    {
+        return match ($this) {
+            self::Http, self::Https => 'http://',
+            self::Ws, self::Wss     => 'websocket://',
+        };
+    }
+
+    /**
+     * The Workerman transport for this scheme.
+     *
+     * - http:// and ws:// use plain tcp
+     * - https:// and wss:// use ssl (requires SSL context configuration)
+     */
+    public function transport(): string
+    {
+        return match ($this) {
+            self::Https, self::Wss => 'ssl',
+            self::Http, self::Ws  => 'tcp',
+        };
+    }
+
+    /**
+     * Whether this scheme requires SSL context configuration.
+     */
+    public function requiresSslContext(): bool
+    {
+        return $this->transport() === 'ssl';
+    }
+}

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -29,20 +29,11 @@ final readonly class ServerWorker
     ) {
         $listen = $serverConfig['listen'] ?? '';
         assert(is_string($listen));
-        $transport = 'tcp';
-        $context = [];
 
-        if (str_starts_with($listen, 'https://')) {
-            $listen = str_replace('https://', 'http://', $listen);
-            $transport = 'ssl';
-            $context = $this->createSslContext($serverConfig);
-        } elseif (str_starts_with($listen, 'ws://')) {
-            $listen = str_replace('ws://', 'websocket://', $listen);
-        } elseif (str_starts_with($listen, 'wss://')) {
-            $listen = str_replace('wss://', 'websocket://', $listen);
-            $transport = 'ssl';
-            $context = $this->createSslContext($serverConfig);
-        }
+        $scheme = ListenScheme::fromListen($listen);
+        $listen = str_replace($scheme->value . '://', $scheme->workermanPrefix(), $listen);
+        $transport = $scheme->transport();
+        $context = $scheme->requiresSslContext() ? $this->createSslContext($serverConfig) : [];
 
         $worker = new Worker($listen, $context);
         $worker->name = sprintf('%s %s', self::PROCESS_TITLE, $serverConfig['name']);

--- a/tests/Worker/ListenSchemeTest.php
+++ b/tests/Worker/ListenSchemeTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Worker;
+
+use CrazyGoat\WorkermanBundle\Exception\UnsupportedListenSchemeException;
+use CrazyGoat\WorkermanBundle\Worker\ListenScheme;
+use PHPUnit\Framework\TestCase;
+
+final class ListenSchemeTest extends TestCase
+{
+    // --- fromListen() ---
+
+    /** @dataProvider provideValidListenUrls */
+    public function testFromListenReturnsCorrectScheme(string $listen, ListenScheme $expected): void
+    {
+        $this->assertSame($expected, ListenScheme::fromListen($listen));
+    }
+
+    /** @return iterable<string, array{string, ListenScheme}> */
+    public static function provideValidListenUrls(): iterable
+    {
+        yield 'http with port' => ['http://0.0.0.0:80', ListenScheme::Http];
+        yield 'http with ipv6' => ['http://[::]:8080', ListenScheme::Http];
+        yield 'http with hostname' => ['http://localhost:8000', ListenScheme::Http];
+        yield 'https with port' => ['https://0.0.0.0:443', ListenScheme::Https];
+        yield 'https with hostname' => ['https://example.com:8443', ListenScheme::Https];
+        yield 'ws with port' => ['ws://0.0.0.0:8080', ListenScheme::Ws];
+        yield 'ws with hostname' => ['ws://chat.example.com:8080', ListenScheme::Ws];
+        yield 'wss with port' => ['wss://0.0.0.0:8443', ListenScheme::Wss];
+        yield 'wss with hostname' => ['wss://chat.example.com:443', ListenScheme::Wss];
+    }
+
+    /** @dataProvider provideInvalidListenUrls */
+    public function testFromListenThrowsForUnsupportedScheme(string $listen): void
+    {
+        $this->expectException(UnsupportedListenSchemeException::class);
+        $this->expectExceptionMessageMatches('/Unsupported listen scheme.*' . preg_quote($listen, '/') . '/');
+
+        ListenScheme::fromListen($listen);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideInvalidListenUrls(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'tcp scheme' => ['tcp://0.0.0.0:9090'];
+        yield 'unix socket' => ['unix:///tmp/workerman.sock'];
+        yield 'ftp scheme' => ['ftp://0.0.0.0:21'];
+        yield 'no scheme just path' => ['/var/run/workerman.sock'];
+        yield 'random string' => ['not-a-url'];
+        yield 'only port' => [':8080'];
+    }
+
+    // --- workermanPrefix() ---
+
+    /** @dataProvider providePrefixExpectations */
+    public function testWorkermanPrefix(ListenScheme $scheme, string $expectedPrefix): void
+    {
+        $this->assertSame($expectedPrefix, $scheme->workermanPrefix());
+    }
+
+    /** @return iterable<string, array{ListenScheme, string}> */
+    public static function providePrefixExpectations(): iterable
+    {
+        yield 'http keeps http' => [ListenScheme::Http, 'http://'];
+        yield 'https becomes http' => [ListenScheme::Https, 'http://'];
+        yield 'ws becomes websocket' => [ListenScheme::Ws, 'websocket://'];
+        yield 'wss becomes websocket' => [ListenScheme::Wss, 'websocket://'];
+    }
+
+    // --- transport() ---
+
+    /** @dataProvider provideTransportExpectations */
+    public function testTransport(ListenScheme $scheme, string $expectedTransport): void
+    {
+        $this->assertSame($expectedTransport, $scheme->transport());
+    }
+
+    /** @return iterable<string, array{ListenScheme, string}> */
+    public static function provideTransportExpectations(): iterable
+    {
+        yield 'http uses tcp' => [ListenScheme::Http, 'tcp'];
+        yield 'https uses ssl' => [ListenScheme::Https, 'ssl'];
+        yield 'ws uses tcp' => [ListenScheme::Ws, 'tcp'];
+        yield 'wss uses ssl' => [ListenScheme::Wss, 'ssl'];
+    }
+
+    // --- requiresSslContext() ---
+
+    /** @dataProvider provideSslExpectations */
+    public function testRequiresSslContext(ListenScheme $scheme, bool $expected): void
+    {
+        $this->assertSame($expected, $scheme->requiresSslContext());
+    }
+
+    /** @return iterable<string, array{ListenScheme, bool}> */
+    public static function provideSslExpectations(): iterable
+    {
+        yield 'http needs no ssl' => [ListenScheme::Http, false];
+        yield 'https needs ssl' => [ListenScheme::Https, true];
+        yield 'ws needs no ssl' => [ListenScheme::Ws, false];
+        yield 'wss needs ssl' => [ListenScheme::Wss, true];
+    }
+
+    // --- enum value consistency ---
+
+    public function testEnumValuesMatchListenPrefixes(): void
+    {
+        $this->assertSame('http', ListenScheme::Http->value);
+        $this->assertSame('https', ListenScheme::Https->value);
+        $this->assertSame('ws', ListenScheme::Ws->value);
+        $this->assertSame('wss', ListenScheme::Wss->value);
+    }
+}

--- a/tests/Worker/ListenSchemeTest.php
+++ b/tests/Worker/ListenSchemeTest.php
@@ -36,7 +36,10 @@ final class ListenSchemeTest extends TestCase
     public function testFromListenThrowsForUnsupportedScheme(string $listen): void
     {
         $this->expectException(UnsupportedListenSchemeException::class);
-        $this->expectExceptionMessageMatches('/Unsupported listen scheme.*' . preg_quote($listen, '/') . '/');
+        $this->expectExceptionMessage(sprintf(
+            'Unsupported listen scheme in "%s". Supported schemes: http://, https://, ws://, wss://',
+            $listen,
+        ));
 
         ListenScheme::fromListen($listen);
     }


### PR DESCRIPTION
## Description

Replaces the fragile stringly-typed listen-scheme if/elseif switch in \`ServerWorker\` with a proper PHP 8.1 backed enum \`ListenScheme\`.

Closes #305

## Changes

- **\`src/Worker/ListenScheme.php\`** — new backed enum with:
  - \`fromListen()\` — parses the scheme from a listen URL
  - \`workermanPrefix()\` — maps to Workerman's internal protocol prefix
  - \`transport()\` — returns \`tcp\` or \`ssl\`
  - \`requiresSslContext()\` — whether SSL config is needed
- **\`src/Exception/UnsupportedListenSchemeException.php\`** — new typed exception extending \`WorkermanException\`
- **\`src/Worker/ServerWorker.php\`** — refactored to use \`ListenScheme::fromListen()\` instead of manual \`str_starts_with\` / \`str_replace\` chains
- **\`tests/Worker/ListenSchemeTest.php\`** — 29 tests covering parsing, prefix mapping, transport, SSL context detection, error handling, and value consistency

## Verification

- \`vendor/bin/phpunit\` — all 1002 tests pass (11 pre-existing errors from missing ext-zip, none related)
- \`vendor/bin/php-cs-fixer fix --dry-run\` — 0 files to fix
- \`vendor/bin/phpstan\` — OK, no errors
- \`vendor/bin/rector process --dry-run\` — OK
- Pre-push hook passed