### PR TITLE
refactor: extract buildServerBag() and detectFormData() from toSymfonyRequest()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ composer.lock
 vendor/
 var/
 .vscode/
+.reasonix/
 /e2e/build/
 /e2e/vendor/
 /e2e/composer.lock

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -58,34 +58,74 @@ final class RequestConverter
     public static function toSymfonyRequest(\Workerman\Protocols\Http\Request $rawRequest): Request
     {
         $query = $rawRequest->get();
-        // IMPORTANT: Get files BEFORE post() because parsePost() clears the files array
         $files = $rawRequest->file() ?? [];
         $post = $rawRequest->post();
 
-        // Validate file structure to provide clearer error messages
         FileUploadValidator::validate($files);
-
-        // Convert Workerman's $_FILES-style arrays to UploadedFile objects
         $files = self::processFiles($files);
 
-        // Only populate POST bag for form-encoded content types
-        // JSON and other content types should leave POST bag empty (like PHP-FPM)
-        $contentType = strtolower((string) $rawRequest->header('content-type', ''));
-        $isFormUrlEncoded = str_starts_with($contentType, 'application/x-www-form-urlencoded');
-        $isMultipart = str_starts_with($contentType, 'multipart/form-data');
-        $isFormData = $isFormUrlEncoded || $isMultipart;
-
-        // Detect HTTPS from Workerman's SSL transport (configured via https:// listen address)
-        $isHttps = isset($rawRequest->connection) && $rawRequest->connection->transport === 'ssl';
-
-        $requestTimeFloat = microtime(true);
-
-        // Validate URI and method before propagating to Symfony
         $uri = $rawRequest->uri();
         $method = $rawRequest->method();
         self::validateUri($uri);
         self::validateMethod($method);
 
+        $requestTimeFloat = microtime(true);
+        $isHttps = isset($rawRequest->connection) && $rawRequest->connection->transport === 'ssl';
+        $formData = self::detectFormData((string) $rawRequest->header('content-type', ''));
+
+        $server = self::buildServerBag($rawRequest, $uri, $method, $isHttps, $requestTimeFloat);
+        $server = self::buildServerHeaders($rawRequest, $server);
+
+        $content = $formData['isMultipart'] ? '' : $rawRequest->rawBody();
+
+        return new Request(
+            is_array($query) ? $query : [],
+            $formData['isFormData'] && is_array($post) ? $post : [],
+            [],
+            self::parseCookiesFromServerBag($server),
+            $files,
+            $server,
+            $content,
+        );
+    }
+
+    /**
+     * Detect form-data content type characteristics from the Content-Type header.
+     *
+     * Determines whether the request body is form-urlencoded and/or multipart,
+     * which controls POST bag population and raw body consumption.
+     *
+     * @return array{isMultipart: bool, isFormData: bool}
+     */
+    private static function detectFormData(string $contentType): array
+    {
+        $contentType = strtolower($contentType);
+        $isFormUrlEncoded = str_starts_with($contentType, 'application/x-www-form-urlencoded');
+        $isMultipart = str_starts_with($contentType, 'multipart/form-data');
+
+        return [
+            'isMultipart' => $isMultipart,
+            'isFormData' => $isFormUrlEncoded || $isMultipart,
+        ];
+    }
+
+    /**
+     * Build the $_SERVER-style array from a Workerman request.
+     *
+     * Constructs the base server bag with REQUEST_URI, REQUEST_METHOD,
+     * SERVER_PROTOCOL, connection metadata, QUERY_STRING, request timing,
+     * and HTTPS detection.
+     *
+     *
+     * @return array<string, float|int|string>
+     */
+    private static function buildServerBag(
+        \Workerman\Protocols\Http\Request $rawRequest,
+        string $uri,
+        string $method,
+        bool $isHttps,
+        float $requestTimeFloat,
+    ): array {
         $server = [
             'REQUEST_URI' => $uri,
             'REQUEST_METHOD' => $method,
@@ -103,22 +143,7 @@ final class RequestConverter
             $server['HTTPS'] = 'on';
         }
 
-        // Build server headers from raw HTTP with security hardening
-        $server = self::buildServerHeaders($rawRequest, $server);
-
-        // For multipart requests, pass empty content to match PHP-FPM behavior
-        // (php://input is not available for multipart - body is consumed during $_POST/$_FILES parsing)
-        $content = $isMultipart ? '' : $rawRequest->rawBody();
-
-        return new Request(
-            is_array($query) ? $query : [],
-            $isFormData && is_array($post) ? $post : [],
-            [],
-            self::parseCookiesFromServerBag($server),
-            $files,
-            $server,
-            $content,
-        );
+        return $server;
     }
 
     /**

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -826,6 +826,125 @@ final class RequestConverterTest extends TestCase
         };
     }
 
+    public function testDetectFormDataWithMultipartContentType(): void
+    {
+        $result = $this->callPrivateStaticMethod('detectFormData', ['multipart/form-data; boundary=xyz']);
+
+        $this->assertTrue($result['isMultipart']);
+        $this->assertTrue($result['isFormData']);
+    }
+
+    public function testDetectFormDataWithFormUrlEncoded(): void
+    {
+        $result = $this->callPrivateStaticMethod('detectFormData', ['application/x-www-form-urlencoded']);
+
+        $this->assertFalse($result['isMultipart']);
+        $this->assertTrue($result['isFormData']);
+    }
+
+    public function testDetectFormDataWithJsonContentType(): void
+    {
+        $result = $this->callPrivateStaticMethod('detectFormData', ['application/json']);
+
+        $this->assertFalse($result['isMultipart']);
+        $this->assertFalse($result['isFormData']);
+    }
+
+    public function testDetectFormDataWithEmptyContentType(): void
+    {
+        $result = $this->callPrivateStaticMethod('detectFormData', ['']);
+
+        $this->assertFalse($result['isMultipart']);
+        $this->assertFalse($result['isFormData']);
+    }
+
+    public function testDetectFormDataIsCaseInsensitive(): void
+    {
+        $result = $this->callPrivateStaticMethod('detectFormData', ['MULTIPART/FORM-DATA; boundary=test']);
+
+        $this->assertTrue($result['isMultipart']);
+        $this->assertTrue($result['isFormData']);
+    }
+
+    public function testBuildServerBagWithConnection(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+        $rawRequest->connection = $this->createMockConnection(8080);
+
+        $server = $this->callPrivateStaticMethod('buildServerBag', [
+            $rawRequest,
+            '/test',
+            'GET',
+            false,
+            1234567890.123,
+        ]);
+
+        $this->assertSame('/test', $server['REQUEST_URI']);
+        $this->assertSame('GET', $server['REQUEST_METHOD']);
+        $this->assertSame('HTTP/1.1', $server['SERVER_PROTOCOL']);
+        $this->assertSame('192.168.1.1', $server['REMOTE_ADDR']);
+        $this->assertSame(12345, $server['REMOTE_PORT']);
+        $this->assertSame(8080, $server['SERVER_PORT']);
+        $this->assertSame('0.0.0.0', $server['SERVER_NAME']);
+        $this->assertSame('', $server['QUERY_STRING']);
+        $this->assertSame(1234567890, $server['REQUEST_TIME']);
+        $this->assertSame(1234567890.123, $server['REQUEST_TIME_FLOAT']);
+        $this->assertArrayNotHasKey('HTTPS', $server);
+    }
+
+    public function testBuildServerBagWithoutConnection(): void
+    {
+        $buffer = "GET /test?foo=bar HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $rawRequest = new Request($buffer);
+        $rawRequest->connection = null;
+
+        $server = $this->callPrivateStaticMethod('buildServerBag', [
+            $rawRequest,
+            '/test?foo=bar',
+            'GET',
+            false,
+            1234567890.456,
+        ]);
+
+        $this->assertSame('127.0.0.1', $server['REMOTE_ADDR']);
+        $this->assertSame(0, $server['REMOTE_PORT']);
+        $this->assertSame(80, $server['SERVER_PORT']);
+        $this->assertSame('localhost', $server['SERVER_NAME']);
+        $this->assertSame('foo=bar', $server['QUERY_STRING']);
+        $this->assertArrayNotHasKey('HTTPS', $server);
+    }
+
+    public function testBuildServerBagWithHttps(): void
+    {
+        $buffer = "GET /secure HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        $rawRequest = new Request($buffer);
+        $rawRequest->connection = $this->createMockConnection(443, 'ssl');
+
+        $server = $this->callPrivateStaticMethod('buildServerBag', [
+            $rawRequest,
+            '/secure',
+            'GET',
+            true,
+            1234567890.789,
+        ]);
+
+        $this->assertSame('on', $server['HTTPS']);
+        $this->assertSame(443, $server['SERVER_PORT']);
+    }
+
+    /**
+     * Call a private static method via reflection for unit testing.
+     *
+     * @param array<int, mixed> $args
+     */
+    private function callPrivateStaticMethod(string $methodName, array $args): mixed
+    {
+        $reflection = new \ReflectionMethod(RequestConverter::class, $methodName);
+
+        return $reflection->invokeArgs(null, $args);
+    }
+
     /**
      * @param array<int, array{name: string, filename: string, content: string}> $fields
      */


### PR DESCRIPTION
## Description

Closes #301

Refactors \`RequestConverter::toSymfonyRequest()\` by extracting two private helper methods:

1. **\`buildServerBag()\`** — owns the \`\$_SERVER\` array construction (URI, method, protocol, connection metadata, query string, timing, HTTPS flag)
2. **\`detectFormData()\`** — owns content-type / multipart sniffing

### Before
\`toSymfonyRequest()\` was ~60 lines mixing 5+ concerns: query/files/post extraction, file validation, content-type sniffing, HTTPS detection, server bag construction, header building, multipart handling.

### After
\`toSymfonyRequest()\` is ~27 lines of pure orchestration, calling helpers in a clear linear order.

### Changes
- \`src/DTO/RequestConverter.php\`: extracted \`buildServerBag()\` and \`detectFormData()\`; slimmed \`toSymfonyRequest()\`
- \`tests/RequestConverterTest.php\`: 8 new unit tests covering the extracted methods in isolation
- \`.gitignore\`: added \`.reasonix/\`

### Verification
- ✅ All 50 existing tests pass (no behavioural change)
- ✅ 8 new tests for extracted helpers pass
- ✅ CS Fixer clean
- ✅ PHPStan clean
- ✅ Rector clean
- ✅ Total: 58 tests, 178 assertions