### PR TITLE
perf: remove per-request Timer::add(0, ...) for terminate scheduling

### DIFF
--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -11,7 +11,6 @@ use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Utils;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
-use Workerman\Timer;
 
 final class HttpRequestHandler implements StaticFileHandlerInterface, MiddlewareDispatchInterface
 {
@@ -19,7 +18,6 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
     private array $middlewares = [];
     /** @var array<string, mixed> */
     private array $staticFileConfig = [];
-    private ?int $terminateTimerId = null;
 
     public function __construct(
         private readonly SymfonyController         $controller,
@@ -107,24 +105,6 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
     }
 
     /**
-     * Schedule kernel termination on the next event-loop tick.
-     *
-     * Cancels any previously pending terminate timer as a safety guard
-     * against stale timers from prior requests.
-     */
-    private function scheduleTerminate(): void
-    {
-        if ($this->terminateTimerId !== null) {
-            Timer::del($this->terminateTimerId);
-            $this->terminateTimerId = null;
-        }
-
-        $this->terminateTimerId = Timer::add(0, function (): void {
-            $this->doTerminate();
-        }, persistent: false);
-    }
-
-    /**
      * Determine if the connection should be closed after the response is sent.
      */
     private function shouldCloseConnection(Request $request): bool
@@ -144,21 +124,16 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
         // 2. Send response
         $this->sendResponse($connection, $response);
 
-        // 3. Schedule deferred terminate on next event-loop tick
-        $this->scheduleTerminate();
+        // 3. Terminate synchronously (send() is non-blocking, no timer needed)
+        $this->doTerminate();
 
-        // 4. Close connection if protocol demands it
+        // 5. Close connection if protocol demands it
         if ($this->shouldCloseConnection($request)) {
             $connection->close();
         }
 
-        // 5. Reload if strategy signals — terminates synchronously before reload
+        // 6. Reload if strategy signals — terminates synchronously before reload
         if ($this->rebootStrategy->shouldReboot()) {
-            if ($this->terminateTimerId !== null) {
-                Timer::del($this->terminateTimerId);
-                $this->terminateTimerId = null;
-            }
-            $this->doTerminate('Kernel termination failed during reload');
             Utils::reload();
         }
     }

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -87,7 +87,7 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
      * Execute kernel termination with error logging.
      *
      * This is the single location where terminateIfNeeded() is called,
-     * ensuring consistent error handling whether invoked deferred or synchronously.
+     * ensuring consistent error handling on every request.
      */
     private function doTerminate(string $errorPrefix = 'Kernel termination failed'): void
     {
@@ -127,12 +127,12 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
         // 3. Terminate synchronously (send() is non-blocking, no timer needed)
         $this->doTerminate();
 
-        // 5. Close connection if protocol demands it
+        // 4. Close connection if protocol demands it
         if ($this->shouldCloseConnection($request)) {
             $connection->close();
         }
 
-        // 6. Reload if strategy signals — terminates synchronously before reload
+        // 5. Reload if strategy signals — terminates synchronously before reload
         if ($this->rebootStrategy->shouldReboot()) {
             Utils::reload();
         }

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -511,34 +511,52 @@ final class HttpRequestHandlerTest extends TestCase
     }
 
     // ──────────────────────────────────────────────
-    // ScheduleTerminate schedules a deferred timer
+    // Terminate is called synchronously after send
     // ──────────────────────────────────────────────
 
-    public function testInvokeSchedulesDeferredTerminate(): void
+    public function testInvokeCallsTerminateSynchronously(): void
     {
         $connection = new MockTcpConnection();
         $request = new Request(self::HTTP11);
 
         ($this->handler)($connection, $request);
 
-        $this->assertCount(1, $this->timerEvent->delayed, 'A deferred timer should be scheduled for terminate');
-        $this->assertSame(0.0, $this->timerEvent->delayed[0]['delay'], 'Deferred timer should have zero delay');
+        // Terminate is called synchronously after send(), no timer needed
+        $this->assertTrue(
+            $this->kernel->terminateCalled,
+            'Kernel terminate should be called synchronously after response is sent',
+        );
+        $this->assertSame(1, $this->kernel->terminateCount, 'Terminate should be called exactly once');
     }
 
-    public function testInvokeCancelsPreviousTimerOnSubsequentRequest(): void
+    public function testInvokeCallsTerminateBeforeClosingConnection(): void
+    {
+        $connection = new MockTcpConnection();
+        $request = new Request(self::HTTP10);
+
+        $this->kernel->terminateCalled = false;
+        $this->kernel->terminateCount = 0;
+
+        ($this->handler)($connection, $request);
+
+        // HTTP/1.0 closes connection, but terminate was already called synchronously
+        $this->assertTrue($this->kernel->terminateCalled, 'Terminate called before close');
+        $this->assertTrue($connection->closed, 'Connection closed after terminate');
+    }
+
+    public function testInvokeNoTimerAllocations(): void
     {
         $connection = new MockTcpConnection();
         $request = new Request(self::HTTP11);
 
-        // First request schedules a timer
         ($this->handler)($connection, $request);
-        $firstTimerCount = \count($this->timerEvent->delayed);
 
-        // Second request should cancel the first timer and schedule a new one
-        ($this->handler)($connection, $request);
-        $secondTimerCount = \count($this->timerEvent->delayed);
-
-        $this->assertSame($firstTimerCount + 1, $secondTimerCount, 'Each request should schedule exactly one new timer');
+        // No timers should have been scheduled for terminate
+        $this->assertCount(
+            0,
+            $this->timerEvent->delayed,
+            'No deferred timers should be scheduled — terminate is synchronous',
+        );
     }
 
     // ──────────────────────────────────────────────
@@ -567,17 +585,17 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $this->kernel->terminateCount);
     }
 
-    public function testInvokeRebootPathDoesNotAffectNonRebootRequests(): void
+    public function testInvokeRebootPathCalledOnEveryRequest(): void
     {
         $connection = new MockTcpConnection();
         $request = new Request(self::HTTP11);
 
         ($this->handler)($connection, $request);
 
-        // terminate should NOT have been called during normal request (it's deferred via timer)
-        $this->assertFalse(
+        // terminate IS called synchronously on every request now
+        $this->assertTrue(
             $this->kernel->terminateCalled,
-            'Kernel terminate should NOT be called during normal request handling',
+            'Kernel terminate should be called on every request (no more timer deferral)',
         );
     }
 
@@ -587,23 +605,15 @@ final class HttpRequestHandlerTest extends TestCase
 
     public function testDoTerminateCallsControllerTerminateIfNeeded(): void
     {
-        // First, invoke the controller so it has a stored request/response for terminateIfNeeded
+        // __invoke now calls doTerminate synchronously — verify terminate is called through the normal path
         $tempConn = new MockTcpConnection();
         ($this->handler)($tempConn, new Request(self::HTTP11));
 
-        $reflection = new \ReflectionClass($this->handler);
-        $method = $reflection->getMethod('doTerminate');
-
-        // Reset terminate tracking from the invoke above
-        $this->kernel->terminateCalled = false;
-        $this->kernel->terminateCount = 0;
-
-        $method->invoke($this->handler);
-
         $this->assertTrue(
             $this->kernel->terminateCalled,
-            'doTerminate() should call controller->terminateIfNeeded()',
+            'doTerminate() should call controller->terminateIfNeeded() via __invoke',
         );
+        $this->assertSame(1, $this->kernel->terminateCount);
     }
 
     public function testDoTerminateDoesNotThrowOnControllerException(): void


### PR DESCRIPTION
## Summary

Replaces `Timer::add(0, ...)` deferred terminate scheduling with a synchronous `doTerminate()` call after `sendResponse()`. Since `$connection->send()` is non-blocking (called with `$raw = true`), there is no reason to defer kernel termination to the next event-loop tick.

## What changed

**`src/Http/HttpRequestHandler.php`**
- Removed `$terminateTimerId` property — no more timer bookkeeping
- Removed `scheduleTerminate()` method — timer + closure allocation per request eliminated
- `__invoke()` now calls `doTerminate()` synchronously after sending the response
- Reboot path simplified (no timer to cancel)
- Removed unused `use Workerman\Timer` import

**`tests/HttpRequestHandlerTest.php`**
- Replaced timer-based assertions with synchronous-terminate assertions
- `testInvokeSchedulesDeferredTerminate` → `testInvokeCallsTerminateSynchronously`
- `testInvokeCancelsPreviousTimerOnSubsequentRequest` → `testInvokeCallsTerminateBeforeClosingConnection` + `testInvokeNoTimerAllocations`
- Updated `testInvokeRebootPathDoesNotAffectNonRebootRequests` → expects terminate on every request

## Per-request savings

| Resource | Before | After |
|---|---|---|
| Closure allocations | 1 per request | 0 |
| Timer-wheel insertions | 1 per request | 0 |
| Timer-cancel checks | 1 per request | 0 |
| Object field ($terminateTimerId) | 1 (nullable int) | 0 |

## Why this is safe

`$connection->send(Http::encode($response, $connection), **true**)` is non-blocking — the `true` second argument means Workerman queues the data on the connection's write buffer without immediate flush. Kernel termination listeners run after the response is already queued, which is the same timing guarantee the deferred timer provided.

## Verification

- `vendor/bin/phpunit tests/HttpRequestHandlerTest.php` — 37/37 ✅
- `vendor/bin/php-cs-fixer fix --dry-run` — 0 files changed ✅
- `vendor/bin/phpstan` — No errors ✅
- `vendor/bin/rector process --dry-run` — OK ✅

Closes #273
