### PR TITLE
perf: skip file validation and processing when no files are present

### DIFF
--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -61,8 +61,14 @@ final class RequestConverter
         $files = $rawRequest->file() ?? [];
         $post = $rawRequest->post();
 
-        FileUploadValidator::validate($files);
-        $files = self::processFiles($files);
+        // Fast-path: skip file validation and recursive UploadedFile construction
+        // when no files are present — the most common case for HTTP requests.
+        // This avoids function call overhead for the empty-files traversal
+        // and keeps the hot path as lean as possible.
+        if ($files !== []) {
+            FileUploadValidator::validate($files);
+            $files = self::processFiles($files);
+        }
 
         $uri = $rawRequest->uri();
         $method = $rawRequest->method();

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -61,10 +61,8 @@ final class RequestConverter
         $files = $rawRequest->file() ?? [];
         $post = $rawRequest->post();
 
-        // Fast-path: skip file validation and recursive UploadedFile construction
-        // when no files are present — the most common case for HTTP requests.
-        // This avoids function call overhead for the empty-files traversal
-        // and keeps the hot path as lean as possible.
+        // Fast-path: most requests carry no files — skip validation
+        // and processing to keep the hot path lean.
         if ($files !== []) {
             FileUploadValidator::validate($files);
             $files = self::processFiles($files);


### PR DESCRIPTION
## Description

Adds a fast-path early-out in `RequestConverter::toSymfonyRequest()` to skip `FileUploadValidator::validate()` and `processFiles()` when the request carries no file uploads — the most common case for HTTP requests. The guard eliminates function call overhead on every request and makes the hot path intent explicit.

## Issue

Closes #277

## Changes

| File | Change |
|------|--------|
| `src/DTO/RequestConverter.php` | Wrap `validate()` + `processFiles()` in `if ($files !== [])` guard |

## Verification

- `vendor/bin/phpunit`: 1038 tests, 2227 assertions, all pass (8 skipped, pre-existing)
- `vendor/bin/php-cs-fixer fix --dry-run`: 0 issues
- `vendor/bin/phpstan`: No errors
- `vendor/bin/rector process --dry-run`: No errors

## Measurement protocol

```php
$iterations = 10_000;
$rawRequest = new \Workerman\Protocols\Http\Request("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");

$start = \microtime(true);
for ($i = 0; $i < $iterations; $i++) {
    RequestConverter::toSymfonyRequest($rawRequest);
}
$elapsed = \microtime(true) - $start;

$avg = ($elapsed / $iterations) * 1_000_000;
echo "$iterations requests in $elapsed s — $avg µs/req\n";
```
