### PR TITLE
refactor: extract shared RecursiveDirectoryIterator boilerplate into FileMonitorWatcher base class (#285)

### DIFF
--- a/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
@@ -46,6 +46,24 @@ abstract class FileMonitorWatcher
         return false;
     }
 
+    /**
+     * Create a recursive directory iterator with the given flags and mode.
+     *
+     * Both PollingMonitorWatcher and InotifyMonitorWatcher need this same
+     * boilerplate; centralising it here means traversal behaviour (skip
+     * dot-dirs, follow symlinks, etc.) can be changed in one place.
+     *
+     * @param positive-int $flags  FilesystemIterator flags (e.g. SKIP_DOTS | UNIX_PATHS)
+     * @param positive-int $mode   RecursiveIteratorIterator mode (e.g. LEAVES_ONLY, SELF_FIRST)
+     */
+    final protected function createRecursiveIterator(string $dir, int $flags, int $mode): \RecursiveIteratorIterator
+    {
+        return new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, $flags),
+            $mode,
+        );
+    }
+
     final protected function reload(): void
     {
         Utils::reload(reloadAllWorkers: true);

--- a/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
@@ -53,8 +53,10 @@ abstract class FileMonitorWatcher
      * boilerplate; centralising it here means traversal behaviour (skip
      * dot-dirs, follow symlinks, etc.) can be changed in one place.
      *
-     * @param positive-int $flags  FilesystemIterator flags (e.g. SKIP_DOTS | UNIX_PATHS)
-     * @param positive-int $mode   RecursiveIteratorIterator mode (e.g. LEAVES_ONLY, SELF_FIRST)
+     * @param int<0, max> $flags FilesystemIterator flags (e.g. SKIP_DOTS | UNIX_PATHS)
+     * @param 0|1|2       $mode  RecursiveIteratorIterator mode (LEAVES_ONLY=0, SELF_FIRST=1, CHILD_FIRST=2)
+     *
+     * @return \RecursiveIteratorIterator<\RecursiveDirectoryIterator>
      */
     final protected function createRecursiveIterator(string $dir, int $flags, int $mode): \RecursiveIteratorIterator
     {

--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -23,8 +23,11 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
             stream_set_blocking($this->fd, false);
 
             foreach ($this->sourceDir as $dir) {
-                $dirIterator = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS);
-                $iterator = new \RecursiveIteratorIterator($dirIterator, \RecursiveIteratorIterator::SELF_FIRST);
+                $iterator = $this->createRecursiveIterator(
+                    $dir,
+                    \FilesystemIterator::SKIP_DOTS,
+                    \RecursiveIteratorIterator::SELF_FIRST,
+                );
 
                 $this->watchDir($dir);
 

--- a/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
@@ -25,11 +25,11 @@ final class PollingMonitorWatcher extends FileMonitorWatcher
         $filesProcessed = 0;
 
         foreach ($this->sourceDir as $dirIdx => $dir) {
-            $dirIterator = new \RecursiveDirectoryIterator(
+            $iterator = $this->createRecursiveIterator(
                 $dir,
                 \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS,
+                \RecursiveIteratorIterator::LEAVES_ONLY,
             );
-            $iterator = new \RecursiveIteratorIterator($dirIterator, \RecursiveIteratorIterator::LEAVES_ONLY);
 
             $resumeFrom = $this->resumePaths[$dirIdx] ?? null;
             $resuming = ($resumeFrom !== null);

--- a/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
@@ -128,11 +128,12 @@ final class FileMonitorWatcherTest extends TestCase
         return $reflection->invoke($watcher, $filename);
     }
 
+    /** @return \RecursiveIteratorIterator<\RecursiveDirectoryIterator> */
     private function invokeCreateRecursiveIterator(FileMonitorWatcher $watcher, string $dir, int $flags, int $mode): \RecursiveIteratorIterator
     {
         $reflection = new \ReflectionMethod(FileMonitorWatcher::class, 'createRecursiveIterator');
 
-        /** @var \RecursiveIteratorIterator */
+        /** @var \RecursiveIteratorIterator<\RecursiveDirectoryIterator> */
         return $reflection->invoke($watcher, $dir, $flags, $mode);
     }
 

--- a/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
@@ -81,11 +81,59 @@ final class FileMonitorWatcherTest extends TestCase
         $this->assertFalse($this->invokeCheckPattern($this->watcher, 'file.php.bak'));
     }
 
+    public function testCreateRecursiveIteratorWithDefaultFlags(): void
+    {
+        $iterator = $this->invokeCreateRecursiveIterator(
+            $this->watcher,
+            '/tmp',
+            \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS,
+            \RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $this->assertInstanceOf(\RecursiveIteratorIterator::class, $iterator);
+        $this->assertInstanceOf(\RecursiveDirectoryIterator::class, $iterator->getInnerIterator());
+    }
+
+    public function testCreateRecursiveIteratorWithSelfFirstMode(): void
+    {
+        $iterator = $this->invokeCreateRecursiveIterator(
+            $this->watcher,
+            '/tmp',
+            \FilesystemIterator::SKIP_DOTS,
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        $this->assertInstanceOf(\RecursiveIteratorIterator::class, $iterator);
+        /* Verifying the mode indirectly: SELF_FIRST yields directories too,
+           while LEAVES_ONLY skips them — both constructors accept the flag. */
+        $this->assertInstanceOf(\RecursiveDirectoryIterator::class, $iterator->getInnerIterator());
+    }
+
+    public function testCreateRecursiveIteratorThrowsForNonExistentDirectory(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        $this->invokeCreateRecursiveIterator(
+            $this->watcher,
+            '/non/existent/path/xyz',
+            \FilesystemIterator::SKIP_DOTS,
+            \RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+    }
+
     private function invokeCheckPattern(FileMonitorWatcher $watcher, string $filename): bool
     {
         $reflection = new \ReflectionMethod(FileMonitorWatcher::class, 'checkPattern');
 
         return $reflection->invoke($watcher, $filename);
+    }
+
+    private function invokeCreateRecursiveIterator(FileMonitorWatcher $watcher, string $dir, int $flags, int $mode): \RecursiveIteratorIterator
+    {
+        $reflection = new \ReflectionMethod(FileMonitorWatcher::class, 'createRecursiveIterator');
+
+        /** @var \RecursiveIteratorIterator */
+        return $reflection->invoke($watcher, $dir, $flags, $mode);
     }
 
     /** @param string[] $filePattern */


### PR DESCRIPTION
## Description

Closes #285

Both `PollingMonitorWatcher` and `InotifyMonitorWatcher` built the same `RecursiveDirectoryIterator` + `RecursiveIteratorIterator` traversal with different flags. This duplication meant any behavioural change (skip dot-dirs, follow symlinks, etc.) had to be made in two places.

## Changes

- **FileMonitorWatcher.php** — added `final protected createRecursiveIterator(string $dir, int $flags, int $mode): RecursiveIteratorIterator`
- **PollingMonitorWatcher.php** — replaced inline `new RecursiveDirectoryIterator` + `new RecursiveIteratorIterator` with $this->createRecursiveIterator()
- **InotifyMonitorWatcher.php** — same refactor
- **FileMonitorWatcherTest.php** — added 3 unit tests for the new method

## Verification

- [x] `vendor/bin/phpunit` — 1041 tests, 0 failures, 8 skipped
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — 0 files to fix
- [x] `vendor/bin/phpstan` — No errors
- [x] `vendor/bin/rector process --dry-run` — OK

## Acceptance criteria

- [x] `RecursiveDirectoryIterator` setup exists in **exactly one location**
- [x] Both watchers consume the shared traversal
- [x] Existing tests pass
- [x] No behavioural change observable to users