### PR TITLE
refactor: extract shared handler/listener base to eliminate duplication (#275, #278)

### DIFF
--- a/src/Handler/ServiceErrorListenerTrait.php
+++ b/src/Handler/ServiceErrorListenerTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Handler;
+
+/**
+ * Shared onException body for TaskErrorListener and ProcessErrorListener.
+ *
+ * Both listeners log a critical message with the same structure, differing
+ * only in the placeholder label ("task" vs "process") and the event type.
+ *
+ * @internal
+ */
+trait ServiceErrorListenerTrait
+{
+    /**
+     * @param string $format  Log message format with "{label}" and "{message}" placeholders
+     * @param string $label   Context key for the name (e.g. "task" or "process")
+     * @param string $name    Value for the named context key
+     * @param string $errorMessage The error message text
+     */
+    private function logServiceError(
+        string $format,
+        string $label,
+        string $name,
+        string $errorMessage,
+        \Throwable $exception,
+    ): void {
+        $this->logger->critical($format, [
+            'exception' => $exception,
+            $label => $name,
+            'message' => $errorMessage,
+        ]);
+    }
+}

--- a/src/Handler/ServiceHandlerTrait.php
+++ b/src/Handler/ServiceHandlerTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Handler;
+
+use CrazyGoat\WorkermanBundle\Util\ServiceMethod;
+
+/**
+ * Shared __invoke body for TaskHandler and ProcessHandler.
+ *
+ * Both classes have identical dispatch+invoke logic that differs only
+ * in the dispatched event classes. This trait owns that common flow.
+ *
+ * @internal
+ */
+trait ServiceHandlerTrait
+{
+    /**
+     * @param class-string $startEventClass FQCN of the start event (e.g. TaskStartEvent::class)
+     * @param class-string $errorEventClass FQCN of the error event (e.g. TaskErrorEvent::class)
+     */
+    private function dispatchAndInvoke(
+        ServiceMethod $serviceMethod,
+        string $name,
+        string $startEventClass,
+        string $errorEventClass,
+    ): void {
+        $serviceInstance = $this->locator->get($serviceMethod->serviceId);
+        \assert(\is_object($serviceInstance));
+
+        $this->eventDispatcher->dispatch(new $startEventClass($serviceInstance::class, $name));
+
+        try {
+            if (!\method_exists($serviceInstance, $serviceMethod->method)) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Method "%s" does not exist on service "%s" (class "%s").', $serviceMethod->method, $serviceMethod->serviceId, $serviceInstance::class),
+                );
+            }
+            $serviceInstance->{$serviceMethod->method}();
+        } catch (\Throwable $e) {
+            $this->eventDispatcher->dispatch(new $errorEventClass($e, $serviceInstance::class, $name));
+        }
+    }
+}

--- a/src/Scheduler/TaskErrorListener.php
+++ b/src/Scheduler/TaskErrorListener.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Scheduler;
 
 use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
+use CrazyGoat\WorkermanBundle\Handler\ServiceErrorListenerTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class TaskErrorListener implements EventSubscriberInterface
 {
+    use ServiceErrorListenerTrait;
+
     public function __construct(private LoggerInterface $logger)
     {
     }
@@ -23,10 +26,12 @@ final readonly class TaskErrorListener implements EventSubscriberInterface
 
     public function onException(TaskErrorEvent $event): void
     {
-        $this->logger->critical('Error thrown while executing task "{task}". Message: "{message}"', [
-            'exception' => $event->getError(),
-            'task' => $event->getTaskName(),
-            'message' => $event->getError()->getMessage(),
-        ]);
+        $this->logServiceError(
+            'Error thrown while executing task "{task}". Message: "{message}"',
+            'task',
+            $event->getTaskName(),
+            $event->getError()->getMessage(),
+            $event->getError(),
+        );
     }
 }

--- a/src/Scheduler/TaskHandler.php
+++ b/src/Scheduler/TaskHandler.php
@@ -6,12 +6,15 @@ namespace CrazyGoat\WorkermanBundle\Scheduler;
 
 use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\TaskStartEvent;
+use CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait;
 use CrazyGoat\WorkermanBundle\Util\ServiceMethod;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final readonly class TaskHandler
 {
+    use ServiceHandlerTrait;
+
     public function __construct(
         private ContainerInterface $locator,
         private EventDispatcherInterface $eventDispatcher,
@@ -20,20 +23,6 @@ final readonly class TaskHandler
 
     public function __invoke(ServiceMethod $serviceMethod, string $taskName): void
     {
-        $serviceInstance = $this->locator->get($serviceMethod->serviceId);
-        assert(is_object($serviceInstance));
-
-        $this->eventDispatcher->dispatch(new TaskStartEvent($serviceInstance::class, $taskName));
-
-        try {
-            if (!method_exists($serviceInstance, $serviceMethod->method)) {
-                throw new \InvalidArgumentException(
-                    sprintf('Method "%s" does not exist on service "%s" (class "%s").', $serviceMethod->method, $serviceMethod->serviceId, $serviceInstance::class),
-                );
-            }
-            $serviceInstance->{$serviceMethod->method}();
-        } catch (\Throwable $e) {
-            $this->eventDispatcher->dispatch(new TaskErrorEvent($e, $serviceInstance::class, $taskName));
-        }
+        $this->dispatchAndInvoke($serviceMethod, $taskName, TaskStartEvent::class, TaskErrorEvent::class);
     }
 }

--- a/src/Supervisor/ProcessErrorListener.php
+++ b/src/Supervisor/ProcessErrorListener.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Supervisor;
 
 use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
+use CrazyGoat\WorkermanBundle\Handler\ServiceErrorListenerTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ProcessErrorListener implements EventSubscriberInterface
 {
+    use ServiceErrorListenerTrait;
+
     public function __construct(private LoggerInterface $logger)
     {
     }
@@ -23,10 +26,12 @@ final readonly class ProcessErrorListener implements EventSubscriberInterface
 
     public function onException(ProcessErrorEvent $event): void
     {
-        $this->logger->critical('Error thrown while executing process "{process}". Message: "{message}"', [
-            'exception' => $event->getError(),
-            'process' => $event->getProcessName(),
-            'message' => $event->getError()->getMessage(),
-        ]);
+        $this->logServiceError(
+            'Error thrown while executing process "{process}". Message: "{message}"',
+            'process',
+            $event->getProcessName(),
+            $event->getError()->getMessage(),
+            $event->getError(),
+        );
     }
 }

--- a/src/Supervisor/ProcessHandler.php
+++ b/src/Supervisor/ProcessHandler.php
@@ -6,12 +6,15 @@ namespace CrazyGoat\WorkermanBundle\Supervisor;
 
 use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\ProcessStartEvent;
+use CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait;
 use CrazyGoat\WorkermanBundle\Util\ServiceMethod;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final readonly class ProcessHandler
 {
+    use ServiceHandlerTrait;
+
     public function __construct(
         private ContainerInterface $locator,
         private EventDispatcherInterface $eventDispatcher,
@@ -20,20 +23,6 @@ final readonly class ProcessHandler
 
     public function __invoke(ServiceMethod $serviceMethod, string $processName): void
     {
-        $serviceInstance = $this->locator->get($serviceMethod->serviceId);
-        assert(is_object($serviceInstance));
-
-        $this->eventDispatcher->dispatch(new ProcessStartEvent($serviceInstance::class, $processName));
-
-        try {
-            if (!method_exists($serviceInstance, $serviceMethod->method)) {
-                throw new \InvalidArgumentException(
-                    sprintf('Method "%s" does not exist on service "%s" (class "%s").', $serviceMethod->method, $serviceMethod->serviceId, $serviceInstance::class),
-                );
-            }
-            $serviceInstance->{$serviceMethod->method}();
-        } catch (\Throwable $e) {
-            $this->eventDispatcher->dispatch(new ProcessErrorEvent($e, $serviceInstance::class, $processName));
-        }
+        $this->dispatchAndInvoke($serviceMethod, $processName, ProcessStartEvent::class, ProcessErrorEvent::class);
     }
 }


### PR DESCRIPTION
Extract the identical __invoke bodies of TaskHandler and ProcessHandler
into ServiceHandlerTrait::dispatchAndInvoke(), parameterised by event
class names. Extract the identical onException bodies of
TaskErrorListener and ProcessErrorListener into
ServiceErrorListenerTrait::logServiceError(), parameterised by label.

Concrete classes remain final readonly — traits compose naturally with
that constraint.

Closes #275
Closes #278
