### PR TITLE
Security: Validate PHAR alias before stub generation (#259)

### DIFF
--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -149,8 +149,15 @@ final readonly class PharBuilder
      *   __RUNTIME_CLASS__ — Workerman Runtime class FQCN
      *   __APP_ENV__       — default environment name
      */
+    /**
+     * Valid characters for PHAR aliases: alphanumeric, dot, underscore, hyphen.
+     */
+    private const ALLOWED_ALIAS_PATTERN = '/^[A-Za-z0-9._-]+$/';
+
     public function generateStub(array $buildConfig, string $pharAlias = 'app.phar'): string
     {
+        $this->validatePharAlias($pharAlias);
+
         $runtimeEnv = \CrazyGoat\WorkermanBundle\Runtime::class;
         $kernelClass = \is_string($buildConfig['kernel_class'] ?? null) && $buildConfig['kernel_class'] !== ''
             ? $buildConfig['kernel_class']
@@ -169,5 +176,20 @@ final readonly class PharBuilder
             '__RUNTIME_CLASS__' => $runtimeEnv,
             '__APP_ENV__'       => $this->environment,
         ]);
+    }
+
+    /**
+     * Validate that the PHAR alias contains only safe characters.
+     *
+     * @throws \RuntimeException if the alias contains invalid characters
+     */
+    private function validatePharAlias(string $pharAlias): void
+    {
+        if (preg_match(self::ALLOWED_ALIAS_PATTERN, $pharAlias) !== 1) {
+            throw new \RuntimeException(sprintf(
+                'PHAR alias "%s" contains invalid characters. Allowed: A-Z, a-z, 0-9, dot, underscore, hyphen.',
+                $pharAlias,
+            ));
+        }
     }
 }

--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -141,6 +141,11 @@ final readonly class PharBuilder
     }
 
     /**
+     * Valid characters for PHAR aliases: alphanumeric, dot, underscore, hyphen.
+     */
+    private const ALLOWED_ALIAS_PATTERN = '/^[A-Za-z0-9._-]+$/';
+
+    /**
      * @param mixed[] $buildConfig
      *
      * Placeholders replaced in the stub template:
@@ -149,11 +154,6 @@ final readonly class PharBuilder
      *   __RUNTIME_CLASS__ — Workerman Runtime class FQCN
      *   __APP_ENV__       — default environment name
      */
-    /**
-     * Valid characters for PHAR aliases: alphanumeric, dot, underscore, hyphen.
-     */
-    private const ALLOWED_ALIAS_PATTERN = '/^[A-Za-z0-9._-]+$/';
-
     public function generateStub(array $buildConfig, string $pharAlias = 'app.phar'): string
     {
         $this->validatePharAlias($pharAlias);
@@ -185,6 +185,10 @@ final readonly class PharBuilder
      */
     private function validatePharAlias(string $pharAlias): void
     {
+        if ($pharAlias === '') {
+            throw new \RuntimeException('PHAR alias must not be empty.');
+        }
+
         if (preg_match(self::ALLOWED_ALIAS_PATTERN, $pharAlias) !== 1) {
             throw new \RuntimeException(sprintf(
                 'PHAR alias "%s" contains invalid characters. Allowed: A-Z, a-z, 0-9, dot, underscore, hyphen.',

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -172,6 +172,15 @@ final class PharBuilderTest extends TestCase
     }
 
     /** @dataProvider provideValidAliases */
+    public function testGenerateStubRejectsEmptyAlias(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('must not be empty');
+
+        (new PharBuilder('/p', 'test'))->generateStub(['kernel_class' => 'App\\Kernel'], '');
+    }
+
+    /** @dataProvider provideValidAliases */
     public function testGenerateStubAcceptsValidAliases(string $alias): void
     {
         $stub = (new PharBuilder('/p', 'test'))->generateStub(['kernel_class' => 'App\\Kernel'], $alias);

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -171,7 +171,6 @@ final class PharBuilderTest extends TestCase
         yield 'null byte' => ["foo\0bar.phar"];
     }
 
-    /** @dataProvider provideValidAliases */
     public function testGenerateStubRejectsEmptyAlias(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -145,4 +145,66 @@ final class PharBuilderTest extends TestCase
         self::assertStringContainsString('__HALT_COMPILER();', $stub);
         self::assertStringNotContainsString('@mkdir', $stub);
     }
+
+    /** @return iterable<array{string}> */
+    public static function provideValidAliases(): iterable
+    {
+        yield 'simple name' => ['app.phar'];
+        yield 'with version' => ['my-app-1.2.3.phar'];
+        yield 'underscores' => ['my_app_v2.phar'];
+        yield 'just name' => ['app'];
+        yield 'numeric' => ['123.phar'];
+        yield 'mixed' => ['Release_2.0-beta.phar'];
+    }
+
+    /** @return iterable<array{string}> */
+    public static function provideInvalidAliases(): iterable
+    {
+        yield 'single quote' => ["foo'bar.phar"];
+        yield 'backtick' => ['foo`bar.phar'];
+        yield 'space' => ['foo bar.phar'];
+        yield 'dollar brace' => ['foo${bar}.phar'];
+        yield 'semicolon' => ['foo;bar.phar'];
+        yield 'double quote' => ['foo"bar.phar'];
+        yield 'parenthesis' => ['foo(bar).phar'];
+        yield 'newline' => ["foo\nbar.phar"];
+        yield 'null byte' => ["foo\0bar.phar"];
+    }
+
+    /** @dataProvider provideValidAliases */
+    public function testGenerateStubAcceptsValidAliases(string $alias): void
+    {
+        $stub = (new PharBuilder('/p', 'test'))->generateStub(['kernel_class' => 'App\\Kernel'], $alias);
+
+        self::assertStringContainsString("Phar::mapPhar('{$alias}')", $stub);
+        self::assertStringContainsString("phar://{$alias}/vendor/autoload.php", $stub);
+    }
+
+    /** @dataProvider provideInvalidAliases */
+    public function testGenerateStubRejectsInvalidAliases(string $alias): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contains invalid characters');
+
+        (new PharBuilder('/p', 'test'))->generateStub(['kernel_class' => 'App\\Kernel'], $alias);
+    }
+
+    /** @dataProvider provideInvalidAliases */
+    public function testBuildRejectsInvalidAliases(string $alias): void
+    {
+        if ((bool) ini_get('phar.readonly')) {
+            self::markTestSkipped('phar.readonly is On — cannot build PHARs.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contains invalid characters');
+
+        // Path whose basename contains invalid chars; build() derives alias from it
+        $badPath = $this->tempDir . '/build/' . $alias;
+        (new PharBuilder($this->tempDir, 'test'))->build([
+            'kernel_class' => 'App\\Kernel',
+            'exclude_patterns' => [],
+            'exclude_files' => [],
+        ], $badPath);
+    }
 }


### PR DESCRIPTION
## Summary

Validates `$pharAlias` against `/^[A-Za-z0-9._-]+$/` before interpolating it into the generated PHAR stub PHP source. Prevents code injection via pathnames containing single quotes, backticks, spaces, double quotes, semicolons, etc.

## Changes

- **`src/Phar/PharBuilder.php`**: Added `validatePharAlias()` and `ALLOWED_ALIAS_PATTERN` constant. Called at the top of `generateStub()`. Throws `\RuntimeException` with a clear message when the alias is invalid.
- **`tests/Phar/PharBuilderTest.php`**: Positive test for valid aliases, negative test for invalid aliases, and end-to-end test that `build()` rejects bad paths.

## Verification

- `vendor/bin/phpunit` — 1101 tests, 2391 assertions, all pass

Closes #259
