### PR TITLE
[Code Quality] Extract configureHandler from ServerWorker onWorkerStart closure (#369)

### DIFF
--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -11,8 +11,8 @@ use CrazyGoat\WorkermanBundle\Http\StaticFileHandlerInterface;
 use CrazyGoat\WorkermanBundle\KernelFactory;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Utils;
-use Workerman\Protocols\Http;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 final readonly class ServerWorker

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -61,6 +61,8 @@ final readonly class ServerWorker
     /**
      * Boot kernel, resolve the request handler and middlewares, and configure the handler.
      *
+     * @param mixed[] $serverConfig
+     *
      * @return callable The fully configured request handler
      */
     private function configureHandler(

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -12,6 +12,7 @@ use CrazyGoat\WorkermanBundle\KernelFactory;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Utils;
 use Workerman\Protocols\Http;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Workerman\Worker;
 
 final readonly class ServerWorker
@@ -52,24 +53,43 @@ final readonly class ServerWorker
             $worker->log(sprintf('%s "%s" started', $worker->name, $serverConfig['name']));
             $kernel = $kernelFactory->createKernel();
             $kernel->boot();
-            $callable = $kernel->getContainer()->get('workerman.http_request_handler');
-            $middlewares = array_map(function (string $middleware) use ($kernel): MiddlewareInterface {
-                $service = $kernel->getContainer()->get($middleware);
-                if (!$service instanceof MiddlewareInterface) {
-                    throw new InvalidMiddlewareException(sprintf('Service "%s" must implement "%s"', $middleware, MiddlewareInterface::class));
-                }
-                return $service;
-            }, $serverConfig['middlewares'] ?? []);
-            assert(is_callable($callable));
-            if ($callable instanceof StaticFileHandlerInterface) {
-                $callable->withStaticFileConfig($serverConfig['static_files'] ?? []);
-                $callable->withRootDirectory($rootDir);
-            }
-            if ($callable instanceof MiddlewareDispatchInterface && $middlewares !== []) {
-                $callable->withMiddlewares(...$middlewares);
-            }
-            $worker->onMessage = $callable;
+
+            $worker->onMessage = $this->configureHandler($kernel, $serverConfig, $rootDir);
         };
+    }
+
+    /**
+     * Boot kernel, resolve the request handler and middlewares, and configure the handler.
+     *
+     * @return callable The fully configured request handler
+     */
+    private function configureHandler(
+        KernelInterface $kernel,
+        array           $serverConfig,
+        ?string         $rootDir,
+    ): callable {
+        $callable = $kernel->getContainer()->get('workerman.http_request_handler');
+        assert(is_callable($callable));
+
+        $middlewares = array_map(function (string $middleware) use ($kernel): MiddlewareInterface {
+            $service = $kernel->getContainer()->get($middleware);
+            if (!$service instanceof MiddlewareInterface) {
+                throw new InvalidMiddlewareException(sprintf('Service "%s" must implement "%s"', $middleware, MiddlewareInterface::class));
+            }
+
+            return $service;
+        }, $serverConfig['middlewares'] ?? []);
+
+        if ($callable instanceof StaticFileHandlerInterface) {
+            $callable->withStaticFileConfig($serverConfig['static_files'] ?? []);
+            $callable->withRootDirectory($rootDir);
+        }
+
+        if ($callable instanceof MiddlewareDispatchInterface && $middlewares !== []) {
+            $callable->withMiddlewares(...$middlewares);
+        }
+
+        return $callable;
     }
 
     /**

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test;
 
+use CrazyGoat\WorkermanBundle\Exception\InvalidMiddlewareException;
+use CrazyGoat\WorkermanBundle\Http\MiddlewareDispatchInterface;
+use CrazyGoat\WorkermanBundle\Http\StaticFileHandlerInterface;
 use CrazyGoat\WorkermanBundle\KernelFactory;
+use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Worker\ServerWorker;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class ServerWorkerTest extends TestCase
@@ -198,6 +203,152 @@ final class ServerWorkerTest extends TestCase
         );
 
         $this->assertInstanceOf(ServerWorker::class, $serverWorker);
+    }
+
+    public function testConfigureHandlerReturnsCallable(): void
+    {
+        $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withStaticFileConfig', 'withRootDirectory'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $handler->method('withStaticFileConfig')->willReturnSelf();
+        $handler->method('withRootDirectory')->willReturnSelf();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('workerman.http_request_handler')->willReturn($handler);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $serverWorker = new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            ['name' => 'test', 'listen' => 'http://127.0.0.1:8080'],
+        );
+
+        $result = $this->invokeConfigureHandler($serverWorker, $kernel, [], null);
+
+        $this->assertSame($handler, $result);
+    }
+
+    public function testConfigureHandlerResolvesMiddlewares(): void
+    {
+        $middleware = $this->createMock(MiddlewareInterface::class);
+
+        $handler = $this->getMockBuilder(MiddlewareDispatchInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withMiddlewares'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $handler->expects($this->once())->method('withMiddlewares')->with($middleware);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->exactly(2))->method('get')->willReturnMap([
+            ['workerman.http_request_handler', $handler],
+            ['app.middleware.foo', $middleware],
+        ]);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $serverWorker = new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            ['name' => 'test', 'listen' => 'http://127.0.0.1:8080'],
+        );
+
+        $result = $this->invokeConfigureHandler(
+            $serverWorker,
+            $kernel,
+            ['middlewares' => ['app.middleware.foo']],
+            null,
+        );
+
+        $this->assertSame($handler, $result);
+    }
+
+    public function testConfigureHandlerThrowsForInvalidMiddleware(): void
+    {
+        $this->expectException(InvalidMiddlewareException::class);
+        $this->expectExceptionMessage('Service "app.middleware.invalid" must implement');
+
+        $invalidService = new \stdClass();
+
+        $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withStaticFileConfig', 'withRootDirectory'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->exactly(2))->method('get')->willReturnMap([
+            ['workerman.http_request_handler', $handler],
+            ['app.middleware.invalid', $invalidService],
+        ]);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $serverWorker = new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            ['name' => 'test', 'listen' => 'http://127.0.0.1:8080'],
+        );
+
+        $this->invokeConfigureHandler(
+            $serverWorker,
+            $kernel,
+            ['middlewares' => ['app.middleware.invalid']],
+            null,
+        );
+    }
+
+    public function testConfigureHandlerConfiguresStaticFiles(): void
+    {
+        $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withStaticFileConfig', 'withRootDirectory'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $handler->expects($this->once())->method('withStaticFileConfig')
+            ->with(['allowed_extensions' => ['css', 'js']])
+            ->willReturnSelf();
+        $handler->expects($this->once())->method('withRootDirectory')
+            ->with('/path/to/public')
+            ->willReturnSelf();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('workerman.http_request_handler')->willReturn($handler);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $serverWorker = new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            ['name' => 'test', 'listen' => 'http://127.0.0.1:8080'],
+        );
+
+        $result = $this->invokeConfigureHandler(
+            $serverWorker,
+            $kernel,
+            ['static_files' => ['allowed_extensions' => ['css', 'js']]],
+            '/path/to/public',
+        );
+
+        $this->assertSame($handler, $result);
+    }
+
+    private function invokeConfigureHandler(ServerWorker $serverWorker, KernelInterface $kernel, array $serverConfig, ?string $rootDir): mixed
+    {
+        $reflection = new \ReflectionMethod(ServerWorker::class, 'configureHandler');
+
+        return $reflection->invoke($serverWorker, $kernel, $serverConfig, $rootDir);
     }
 
     private function generateSelfSignedCert(string $certFile, string $keyFile): void

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -344,6 +344,9 @@ final class ServerWorkerTest extends TestCase
         $this->assertSame($handler, $result);
     }
 
+    /**
+     * @param mixed[] $serverConfig
+     */
     private function invokeConfigureHandler(ServerWorker $serverWorker, KernelInterface $kernel, array $serverConfig, ?string $rootDir): mixed
     {
         $reflection = new \ReflectionMethod(ServerWorker::class, 'configureHandler');


### PR DESCRIPTION
## Summary

Extracts middleware resolution + handler decoration from the  closure in  into a dedicated  method. The closure now acts as a thin orchestrator (~10 lines), satisfying the acceptance criteria from issue #369.

## Changes

- **src/Worker/ServerWorker.php**: Added private  method; the  closure now calls it instead of inlining the logic.
- **tests/ServerWorkerTest.php**: Added 4 new tests covering the extracted method via reflection:
  - Returns the handler from the container
  - Resolves middlewares and passes them to the handler
  - throws `InvalidMiddlewareException` for non-MiddlewareInterface services
  - Configures static file settings on the handler

## Acceptance criteria

- [x] The `onWorkerStart` closure is shorter than ~10 lines and reads as orchestration only
- [x] Middleware resolution and the `InvalidMiddlewareException` branch are exercised by direct tests of the extracted method
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change observable to users

Closes #369