### PR TITLE
[Docs] Fix RebootStrategyInterface FQCN in README example (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `README.md` RebootStrategyInterface example — wrong FQCN caused copy-paste to fail ([#289](https://github.com/crazy-goat/workerman-bundle/issues/289))
+
 ## [0.20.0] - 2026-05-26
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can create reload strategy with your own logic by implementing the RebootStr
 ```php
 <?php
 
-use CrazyGoat\WorkermanBundle\Reboot\RebootStrategyInterface;
+use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('workerman.reboot_strategy')]


### PR DESCRIPTION
## What changed

Fixed the  FQCN in the README's "Custom reboot strategy" example.

- **Before:** `CrazyGoat\WorkermanBundle\Reboot\RebootStrategyInterface` — class/interface not found
- **After:** `CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface` — resolves correctly

## Why

Copy-pasting the README example fails immediately with "class/interface not found". This is the single most painful documentation bug for users implementing a custom reboot strategy.

## Acceptance criteria

- [x] `README.md:186` imports the correct FQCN
- [x] All other FQCNs in the same example are verified against `src/`
- [x] CHANGELOG entry added noting the fixed example
- [x] Existing tests pass (`vendor/bin/phpunit`)

Closes #289