### PR TITLE
[Security] Validate kernel_class before PHAR stub generation (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Validate `kernel_class` in PHAR stub generation — reject invalid PHP class names to prevent code injection ([#263](https://github.com/crazy-goat/workerman-bundle/issues/263))
+
 ### Fixed
 
 - Fix `README.md` RebootStrategyInterface example — wrong FQCN caused copy-paste to fail ([#289](https://github.com/crazy-goat/workerman-bundle/issues/289))

--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -49,6 +49,13 @@ final readonly class PharBuilder
         }
 
         $pharFilename = basename($pharPath);
+        $this->validatePharAlias($pharFilename);
+
+        $kernelClass = \is_string($buildConfig['kernel_class'] ?? null) && $buildConfig['kernel_class'] !== ''
+            ? $buildConfig['kernel_class']
+            : 'App\\Kernel';
+        $this->validateKernelClass($kernelClass);
+
         $phar = new \Phar($pharPath, 0, $pharFilename);
         $phar->startBuffering();
 

--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -146,6 +146,11 @@ final readonly class PharBuilder
     private const ALLOWED_ALIAS_PATTERN = '/^[A-Za-z0-9._-]+$/';
 
     /**
+     * Valid PHP fully-qualified class name pattern.
+     */
+    private const ALLOWED_KERNEL_CLASS_PATTERN = '/^(\\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)+(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/';
+
+    /**
      * @param mixed[] $buildConfig
      *
      * Placeholders replaced in the stub template:
@@ -162,6 +167,8 @@ final readonly class PharBuilder
         $kernelClass = \is_string($buildConfig['kernel_class'] ?? null) && $buildConfig['kernel_class'] !== ''
             ? $buildConfig['kernel_class']
             : 'App\\Kernel';
+
+        $this->validateKernelClass($kernelClass);
 
         $templatePath = __DIR__ . '/../../resources/phar-stub.tpl';
         $template = file_get_contents($templatePath);
@@ -193,6 +200,25 @@ final readonly class PharBuilder
             throw new \RuntimeException(sprintf(
                 'PHAR alias "%s" contains invalid characters. Allowed: A-Z, a-z, 0-9, dot, underscore, hyphen.',
                 $pharAlias,
+            ));
+        }
+    }
+
+    /**
+     * Validate that the kernel class is a syntactically valid PHP FQCN.
+     *
+     * @throws \RuntimeException if the class name contains invalid characters
+     */
+    private function validateKernelClass(string $kernelClass): void
+    {
+        if ($kernelClass === '') {
+            throw new \RuntimeException('Kernel class must not be empty.');
+        }
+
+        if (preg_match(self::ALLOWED_KERNEL_CLASS_PATTERN, $kernelClass) !== 1) {
+            throw new \RuntimeException(sprintf(
+                'Kernel class "%s" is not a valid PHP class name. Only letters, numbers, underscores, backslashes, and bytes 0x80-0xff are allowed.',
+                $kernelClass,
             ));
         }
     }

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -215,4 +215,82 @@ final class PharBuilderTest extends TestCase
             'exclude_files' => [],
         ], $badPath);
     }
+
+    /** @return iterable<array{string}> */
+    public static function provideValidKernelClasses(): iterable
+    {
+        yield 'simple class' => ['App\\Kernel'];
+        yield 'with leading backslash' => ['\\App\\Kernel'];
+        yield 'multi-level namespace' => ['App\\Http\\Kernel'];
+        yield 'single class name' => ['Kernel'];
+        yield 'with underscores' => ['My_App\\Kernel_V2'];
+        yield 'numeric suffix' => ['App\\Kernel2024'];
+        yield 'root namespace single' => ['\\Kernel'];
+    }
+
+    /** @return iterable<array{string}> */
+    public static function provideInvalidKernelClasses(): iterable
+    {
+        yield 'semicolon' => ['App\\Kernel;'];
+        yield 'single quote' => ["App\\Ker'nel"];
+        yield 'double quote' => ['App\\Ker"nel'];
+        yield 'parenthesis' => ['App\\Kernel()'];
+        yield 'space' => ['App\\ Kernel'];
+        yield 'dollar brace' => ['App\\${Kernel}'];
+        yield 'backtick' => ['App\\Ker`nel'];
+        yield 'angle brackets' => ['App\\Ker<nel>'];
+        yield 'pipe' => ['App\\Ker|nel'];
+        yield 'question mark' => ['App\\Ker?nel'];
+        yield 'leading digit' => ['1App\\Kernel'];
+    }
+
+    /** @dataProvider provideValidKernelClasses */
+    public function testGenerateStubAcceptsValidKernelClasses(string $kernelClass): void
+    {
+        $stub = (new PharBuilder('/p', 'test'))->generateStub([
+            'kernel_class' => $kernelClass,
+        ]);
+
+        self::assertStringContainsString('new ' . $kernelClass . '(', $stub);
+    }
+
+    /** @dataProvider provideInvalidKernelClasses */
+    public function testGenerateStubRejectsInvalidKernelClasses(string $kernelClass): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not a valid PHP class name');
+
+        (new PharBuilder('/p', 'test'))->generateStub([
+            'kernel_class' => $kernelClass,
+        ]);
+    }
+
+    /** @dataProvider provideInvalidKernelClasses */
+    public function testBuildRejectsInvalidKernelClasses(string $kernelClass): void
+    {
+        if ((bool) ini_get('phar.readonly')) {
+            self::markTestSkipped('phar.readonly is On — cannot build PHARs.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Kernel class');
+
+        mkdir($this->tempDir . '/src', 0755, true);
+        mkdir($this->tempDir . '/vendor', 0755, true);
+        file_put_contents($this->tempDir . '/vendor/autoload.php', '<?php');
+
+        $pharPath = $this->tempDir . '/build/test.phar';
+        (new PharBuilder($this->tempDir, 'test'))->build([
+            'kernel_class' => $kernelClass,
+            'exclude_patterns' => [],
+            'exclude_files' => [],
+        ], $pharPath);
+    }
+
+    public function testGenerateStubUsesDefaultKernelClassWhenNotConfigured(): void
+    {
+        $stub = (new PharBuilder('/p', 'test'))->generateStub([]);
+
+        self::assertStringContainsString('new App\\Kernel(', $stub);
+    }
 }


### PR DESCRIPTION
## Summary

The `kernel_class` build configuration value is interpolated directly into the generated PHAR stub source code at `new {kernelClass}(...)` (see `resources/phar-stub.tpl:35`). Although typically operator-controlled, there was no validation that the value is a syntactically valid PHP class name.

## Changes

1. **`src/Phar/PharBuilder.php`**: Added `ALLOWED_KERNEL_CLASS_PATTERN` constant and `validateKernelClass()` method. The pattern validates PHP FQCNs with optional leading backslash, namespace separators, underscores, and extended bytes (0x80-0xff). Called from `generateStub()` before template interpolation.

2. **`tests/Phar/PharBuilderTest.php`**: Added test coverage:
   - `testGenerateStubAcceptsValidKernelClasses` — verifies valid FQCNs like `App\\Kernel`, `\\App\\Kernel`, `App\\Http\\Kernel`, etc.
   - `testGenerateStubRejectsInvalidKernelClasses` — verifies rejection of semicolons, quotes, parentheses, spaces, etc.
   - `testBuildRejectsInvalidKernelClasses` — verifies the `build()` method also rejects invalid class names
   - `testGenerateStubUsesDefaultKernelClassWhenNotConfigured` — verifies fallback to `App\\Kernel` when no config provided

## Acceptance criteria

- [x] Defense in place at `src/Phar/PharBuilder.php`
- [x] Negative test: kernel_class containing whitespace, parentheses, or semicolons is rejected
- [x] Positive test: standard FQCNs (with or without leading backslash) still work
- [x] Documented in `CHANGELOG.md`
- [x] Existing tests pass (1163 tests, 2475 assertions)

Closes #263