### PR TITLE
fix(security): restrict PHAR stub runtime directory to 0700

### DIFF
--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -31,8 +31,10 @@ php bin/console workerman:build:bin
 ```yaml
 # config/packages/workerman.yaml
 workerman:
-    # Writable runtime directory (defaults to project_dir)
-    # In PHAR mode, automatically set to directory containing the PHAR
+    # Writable runtime directory (defaults to project_dir).
+    # In PHAR mode, automatically set to directory containing the PHAR.
+    # Runtime directories are created with restrictive permissions (0700)
+    # to protect process-control artifacts on multi-user systems.
     runtime_dir: '%kernel.project_dir%'
 
     build:
@@ -130,7 +132,7 @@ The build command creates a PHAR archive containing your entire Symfony applicat
 
 1. Detects the runtime directory (outside the PHAR)
 2. Sets `APP_CACHE_DIR` and `APP_LOG_DIR` to writable paths
-3. Creates `var/cache`, `var/log`, `var/run` directories
+3. Creates `var/cache`, `var/log`, `var/run` directories with restrictive permissions (0700)
 4. Loads `.env` from outside the PHAR (if present)
 5. Boots Symfony Console for full CLI access
 

--- a/resources/phar-stub.tpl
+++ b/resources/phar-stub.tpl
@@ -14,7 +14,7 @@ $_ENV['APP_LOG_DIR'] = $runtimeDir . '/var/log';
 
 foreach (['/var/cache', '/var/log', '/var/run'] as $sub) {
     $dir = $runtimeDir . $sub;
-    if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+    if (!is_dir($dir) && !mkdir($dir, 0700, true) && !is_dir($dir)) {
         fwrite(STDERR, sprintf('Unable to create runtime directory "%s". Set WORKERMAN_RUNTIME_DIR to a writable path.' . PHP_EOL, $dir));
         exit(1);
     }

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -144,6 +144,8 @@ final class PharBuilderTest extends TestCase
         self::assertStringContainsString('phar://app.phar/vendor/autoload.php', $stub);
         self::assertStringContainsString('__HALT_COMPILER();', $stub);
         self::assertStringNotContainsString('@mkdir', $stub);
+        self::assertStringContainsString('mkdir($dir, 0700, true)', $stub);
+        self::assertStringNotContainsString('mkdir($dir, 0755', $stub);
     }
 
     /** @return iterable<array{string}> */


### PR DESCRIPTION
## Description

Changes the PHAR stub runtime directory permissions from world-readable (0755) to owner-only (0700) to protect process-control artifacts (PID files, status files) on multi-user systems.

## Changes

- `resources/phar-stub.tpl`: `mkdir(, 0755, true)` → `mkdir(, 0700, true)`
- `tests/Phar/PharBuilderTest.php`: Added assertions verifying the stub generates 0700 (and not 0755)
- `docs/build-packaging.md`: Documented restrictive permission behavior

## Acceptance criteria

- [x] Defense in place at stub template
- [x] Built PHAR creates runtime directory with mode 0700 by default
- [x] Positive test: stub generation test verifies 0700 mode
- [x] Documented in docs/build-packaging.md
- [x] Existing tests pass

Closes #274