### PR TITLE
fix(security): create runtime directories with explicit restrictive mode 0700 (#270)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -149,6 +149,25 @@ to plain HTTP via a redirect:
 This defense is always active when `allow_insecure` is enabled, regardless of whether a checksum
 is configured.
 
+## Runtime Directory Permissions
+
+Runtime directories (PID file, log files, stdout files) are created with mode `0700` (owner-only access). This prevents other users on multi-user systems from reading process-control artifacts such as PID files and status files.
+
+### When this matters
+
+- **Multi-user hosts**: Shared CI runners, containers with multiple service accounts, or any environment where the process user should not be able to read another user's runtime files.
+- **PID file protection**: An attacker who can read the PID file can signal the workerman master process.
+- **Status file protection**: Status files contain internal process state that should not be visible to other users.
+
+### Behaviour
+
+- Runtime directories are created automatically with `0700` permissions when they do not exist.
+- If the directory already exists, its permissions are not modified — ensure it was created with appropriate restrictive permissions if it was pre-created.
+- To verify permissions on a running system:
+  ```bash
+  stat -c '%a %n' var/run/ var/log/
+  ```
+
 ## SFX Checksum Requirement
 
 The build **fails** if no SHA-256 checksum is configured, unless `--unsafe-no-checksum` is explicitly

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -151,18 +151,15 @@ final readonly class Runner implements RunnerInterface
         assert(is_int($maxPackageSize));
 
         $pidDir = dirname($pidFile);
-        if (!is_dir($pidDir)) {
-            if (!mkdir(directory: $pidDir, recursive: true) && !is_dir($pidDir)) {
-                throw new \RuntimeException(\sprintf('Unable to create directory "%s".', $pidDir));
-            }
-            chmod($pidDir, 0700);
+        if (!is_dir($pidDir) && (!mkdir(directory: $pidDir, permissions: 0700, recursive: true) && !is_dir($pidDir))) {
+            throw new \RuntimeException(\sprintf('Unable to create directory "%s".', $pidDir));
         }
 
         foreach ([
             dirname($logFile),
             dirname($stdoutFile),
         ] as $runtimeDir) {
-            if (!is_dir($runtimeDir) && !mkdir(directory: $runtimeDir, recursive: true) && !is_dir($runtimeDir)) {
+            if (!is_dir($runtimeDir) && !mkdir(directory: $runtimeDir, permissions: 0700, recursive: true) && !is_dir($runtimeDir)) {
                 throw new \RuntimeException(\sprintf('Unable to create directory "%s".', $runtimeDir));
             }
         }

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -823,6 +823,56 @@ final class RunnerTest extends TestCase
         }
     }
 
+    public function testApplyWorkermanConfigCreatesDirectoriesWithMode0700(): void
+    {
+        $saved = $this->saveWorkerState();
+        $tmpDir = sys_get_temp_dir() . '/workerman_runner_test_' . uniqid();
+        if (!is_dir($tmpDir)) {
+            mkdir($tmpDir, 0700, true);
+        }
+
+        try {
+            $kernel = $this->createMock(KernelInterface::class);
+            $kernelFactory = new KernelFactory(fn(): KernelInterface => $kernel, []);
+            $runner = new Runner($kernelFactory);
+
+            $config = [
+                'pid_file' => $tmpDir . '/run/workerman.pid',
+                'log_file' => $tmpDir . '/log/workerman.log',
+                'stdout_file' => $tmpDir . '/log/workerman.stdout.log',
+                'stop_timeout' => 5,
+                'max_package_size' => 10 * 1024 * 1024,
+            ];
+
+            $this->invokeRunnerMethod($runner, 'applyWorkermanConfig', $config);
+
+            $this->assertTrue(is_dir($tmpDir . '/run'), 'PID directory must exist');
+            $this->assertTrue(is_dir($tmpDir . '/log'), 'Log directory must exist');
+
+            $pidDirPerms = fileperms($tmpDir . '/run') & 0777;
+            $logDirPerms = fileperms($tmpDir . '/log') & 0777;
+
+            $this->assertSame(0700, $pidDirPerms, 'PID directory must have mode 0700');
+            $this->assertSame(0700, $logDirPerms, 'Log directory must have mode 0700');
+        } finally {
+            $this->restoreWorkerState($saved);
+            $this->removeDir($tmpDir);
+        }
+    }
+
+    public function testApplyWorkermanConfigUsesExplicitMode0700(): void
+    {
+        $sourceFile = self::RUNNER_SOURCE;
+        $content = file_get_contents($sourceFile);
+        $this->assertNotFalse($content);
+
+        $this->assertStringContainsString(
+            'permissions: 0700',
+            $content,
+            'All mkdir calls must use explicit permissions 0700 to prevent overly permissive runtime directories',
+        );
+    }
+
     public function testResolveRuntimePathStructuralPharRewritingExists(): void
     {
         $sourceFile = self::RUNNER_SOURCE;


### PR DESCRIPTION
## Description

Fixes #270

Runtime directories for PID files, log files, and stdout files were created without an explicit mode, defaulting to `0777 & ~umask` (typically `0755`). On multi-user hosts, other accounts could read process-control artifacts (PID files, status files).

## Changes

- **src/Runner.php**: Replaced `chmod($pidDir, 0700)` post-creation with `permissions: 0700` on the `mkdir()` call; added `permissions: 0700` to the log/stdout directory loop that had no mode restriction at all.
- **tests/RunnerTest.php**: Added two tests:
  - `testApplyWorkermanConfigCreatesDirectoriesWithMode0700` — verifies created directories have mode 0700 via `fileperms()`
  - `testApplyWorkermanConfigUsesExplicitMode0700` — structural test ensuring source contains `permissions: 0700`
- **docs/security.md**: Added 'Runtime Directory Permissions' section with guidance for multi-user hosts.

## Acceptance criteria

- [x] Defense in place at `src/Runner.php`
- [x] Negative test: created runtime directory has mode 0700 (verified via `stat` / `fileperms()`)
- [x] Positive test: `testApplyWorkermanConfigSetsWorkerStaticProperties` still passes (server starts and writes status files normally)
- [x] Documented in `docs/security.md`
- [x] Existing tests pass