### PR TITLE
[Docs] Resolve Utils @internal vs CHANGELOG public-API contradiction (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `README.md` RebootStrategyInterface example — wrong FQCN caused copy-paste to fail ([#289](https://github.com/crazy-goat/workerman-bundle/issues/289))
 
+### Docs
+
+- Resolve `@internal` vs public-API contradiction in `Utils` class — `Utils::reload()` is now explicitly documented as a public API for programmatic graceful worker reload. Removed `@internal` annotation, added PHPDoc, and documented usage in README ([#290](https://github.com/crazy-goat/workerman-bundle/issues/290))
+
 ## [0.20.0] - 2026-05-26
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ PID      Worker          CID       Trans   Protocol        ipv4   ipv6   Recv-Q 
 
 > **Note:** If you have the `grpc` PHP extension installed, you must set the environment variable `GRPC_ENABLE_FORK_SUPPORT=1` before starting the server. The grpc extension spawns background threads that deadlock in forked child processes (e.g. scheduler tasks) unless fork support is explicitly enabled. See [grpc/grpc#31241](https://github.com/grpc/grpc/issues/31241) for details.
 
+### Programmatic reload
+
+You can trigger a worker reload from your application code using `Utils::reload()`:
+
+```php
+<?php
+
+use CrazyGoat\WorkermanBundle\Utils;
+
+// Reload only the current worker process
+Utils::reload();
+
+// Reload all worker processes
+Utils::reload(reloadAllWorkers: true);
+```
+
+This sends a `SIGUSR1` signal to the worker (or parent) process. It is equivalent to running `bin/console workerman:server reload` but can be called from any context — controllers, services, scheduled tasks, or deploy hooks.
+
+> **Note:** `Utils::reload()` requires the `pcntl` and `posix` PHP extensions. Both are always available in the Workerman runtime process.
+
 ## Reload strategies
 Because of the asynchronous nature of the server, the workers reuse loaded resources on each request. This means that in some cases we need to restart workers.  
 For example, after an exception is thrown, to prevent services from being in an unrecoverable state. Or every time you change the code in the IDE.  

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle;
 
 /**
- * @internal
+ * Utility methods for Workerman bundle runtime operations.
+ *
+ * This class is not intended to be instantiated (private constructor, final).
+ * All methods are static helpers for process introspection and signalling.
  */
 final class Utils
 {
@@ -45,6 +48,19 @@ final class Utils
         return \DIRECTORY_SEPARATOR !== '/';
     }
 
+    /**
+     * Gracefully reload worker processes by sending SIGUSR1.
+     *
+     * Call this method from application code to trigger a hot reload of all
+     * worker processes. This is useful after deploying new code or when a
+     * runtime condition (e.g., memory pressure, config change) requires a
+     * clean worker state.
+     *
+     * @param bool $reloadAllWorkers When true, SIGUSR1 is sent to the parent
+     *                               process, which reloads all workers. When
+     *                               false (default), only the current process
+     *                               is signalled.
+     */
     public static function reload(bool $reloadAllWorkers = false): void
     {
         posix_kill($reloadAllWorkers ? posix_getppid() : posix_getpid(), SIGUSR1);


### PR DESCRIPTION
## Description

Resolves #290 by removing the `@internal` annotation from `Utils` and explicitly documenting it as a public API.

## Changes

- **`src/Utils.php`**: Removed `@internal` class annotation, added class-level PHPDoc and explicit PHPDoc on `Utils::reload()`
- **`README.md`**: Added "Programmatic reload" section documenting `Utils::reload()` usage with code example
- **`CHANGELOG.md`**: Added `[Unreleased] Docs` entry recording the resolution

## Rationale

`Utils::reload()` was introduced in 0.17.0 as "the canonical name for graceful worker restart" (CHANGELOG) and `UPGRADE.md` explicitly directs users to migrate from `reboot()` to `reload()`. The class being `final` with a private constructor is consistent with a static-utility public API pattern. The `@internal` annotation directly contradicted these signals.

## Verification

- `vendor/bin/phpunit tests/UtilsTest.php tests/UtilsE2ETest.php` — all pass
- `vendor/bin/phpstan analyse src/Utils.php --level 9` — no errors