### PR TITLE
[Docs] Clarify bin/console refers to application console, not bundle's bin/ (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - Resolve `@internal` vs public-API contradiction in `Utils` class — `Utils::reload()` is now explicitly documented as a public API for programmatic graceful worker reload. Removed `@internal` annotation, added PHPDoc, and documented usage in README ([#290](https://github.com/crazy-goat/workerman-bundle/issues/290))
+- Disambiguate `bin/console` in README — clarify it refers to the application's console, not the bundle's `bin/` directory; add `bin/README.md` documenting the bundle's development scripts ([#282](https://github.com/crazy-goat/workerman-bundle/issues/282))
 
 ## [0.20.0] - 2026-05-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ All pull requests must pass the following checks before merging:
 
 A pre-push git hook is automatically installed via Composer's post-install scripts. It runs `composer lint` before each push to catch issues early.
 
+See [`bin/README.md`](bin/README.md) for details on the hook script.
+
 **To skip the hook** (for emergency pushes):
 ```bash
 git push --no-verify

--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ All top-level `workerman` configuration options:
 
 ### Start application
 
-Using the Symfony console command:
+Using the Symfony console command (the `bin/console` below refers to **your application's** Symfony console, **not** the `bin/` directory shipped by this bundle):
 ```bash
 $ bin/console workerman:server start
 $ bin/console workerman:server start -d   # daemon mode
 ```
+
+> **Note:** All `bin/console workerman:*` commands throughout this document refer to your application's Symfony console, not the scripts in this bundle's `bin/` directory. See [`bin/README.md`](bin/README.md) for the bundle's own development scripts.
 
 Or using the runtime directly:
 ```bash

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,30 @@
+# Bin Directory
+
+This directory contains development and contribution scripts for this bundle.
+It is **not** the Symfony console you use to run the Workerman server.
+
+For the Workerman server commands, use your **application's** `bin/console`
+(e.g., `bin/console workerman:server start`).
+
+## Scripts
+
+### `install-git-hook.php`
+
+Installs a pre-push git hook that runs `composer lint` before each push.
+The hook is automatically installed by Composer via the `post-install-cmd`
+and `post-update-cmd` scripts.
+
+**Manual reinstall:**
+```bash
+php bin/install-git-hook.php
+```
+
+**Remove:**
+```bash
+rm .git/hooks/pre-push
+```
+
+**Skip on push:**
+```bash
+git push --no-verify
+```

--- a/tests/BinDirectoryTest.php
+++ b/tests/BinDirectoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class BinDirectoryTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = \dirname(__DIR__);
+    }
+
+    public function testBinReadmeExists(): void
+    {
+        $this->assertFileExists($this->projectDir . '/bin/README.md');
+    }
+
+    public function testBinReadmeDocumentsInstallGitHook(): void
+    {
+        $content = file_get_contents($this->projectDir . '/bin/README.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('install-git-hook.php', $content);
+    }
+
+    public function testReadmeDisambiguatesBinConsole(): void
+    {
+        $content = file_get_contents($this->projectDir . '/README.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('refers to **your application\'s** Symfony console', $content);
+        $this->assertStringContainsString('directory shipped by this bundle', $content);
+    }
+
+    public function testReadmeLinksToBinReadme(): void
+    {
+        $content = file_get_contents($this->projectDir . '/README.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('bin/README.md', $content);
+    }
+
+    public function testContributingLinksToBinReadme(): void
+    {
+        $content = file_get_contents($this->projectDir . '/CONTRIBUTING.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('bin/README.md', $content);
+    }
+}


### PR DESCRIPTION
## Description

Closes #282

The README's `bin/console` references are ambiguous — newcomers may run the bundle's `bin/` scripts thinking they are the user-facing CLI.

## Changes

- **`README.md`**: Added disambiguation note under "Start application" clarifying that `bin/console` refers to the user's application Symfony console, not files in this bundle's `bin/` directory. Added a callout box cross-linking to `bin/README.md`.
- **`bin/README.md`** (new): Documents each script in the `bin/` directory, starting with `install-git-hook.php`. Explains that `bin/` is for development/contribution, not for running the Workerman server.
- **`CONTRIBUTING.md`**: Cross-links to `bin/README.md` from the "Pre-Push Hook" section.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] > Docs`.
- **`tests/BinDirectoryTest.php`** (new): Verifies `bin/README.md` exists and documents the hook, README disambiguates `bin/console`, and CONTRIBUTING links to `bin/README.md`.