### PR TITLE
fix: remove PharHelper::getProjectDir thin rtrim wrapper (#316)

### DIFF
--- a/src/PharHelper.php
+++ b/src/PharHelper.php
@@ -43,16 +43,6 @@ final class PharHelper
     }
 
     /**
-     * Returns the project directory (always inside the PHAR in PHAR mode).
-     *
-     * @param string $projectDir The project root directory (kernel.project_dir)
-     */
-    public static function getProjectDir(string $projectDir): string
-    {
-        return rtrim($projectDir, '/');
-    }
-
-    /**
      * Resolve a path relative to project_dir, replacing the project_dir
      * prefix with runtime_dir when in PHAR mode.
      *
@@ -61,7 +51,7 @@ final class PharHelper
      */
     public static function resolveRuntimePath(string $path, string $projectDir): string
     {
-        $projectDir = self::getProjectDir($projectDir);
+        $projectDir = rtrim($projectDir, '/');
         $runtimeDir = self::getRuntimeDir($projectDir);
 
         if ($runtimeDir !== $projectDir && str_starts_with($path, $projectDir)) {

--- a/tests/PharHelperTest.php
+++ b/tests/PharHelperTest.php
@@ -43,16 +43,6 @@ final class PharHelperTest extends TestCase
         self::assertSame('/custom/runtime', PharHelper::getRuntimeDir('/app'));
     }
 
-    public function testGetProjectDirReturnsProjectDir(): void
-    {
-        self::assertSame('/app', PharHelper::getProjectDir('/app'));
-    }
-
-    public function testGetProjectDirTrimsTrailingSlash(): void
-    {
-        self::assertSame('/app', PharHelper::getProjectDir('/app/'));
-    }
-
     public function testResolveRuntimePathReturnsPathUnchangedInNormalMode(): void
     {
         self::assertSame(


### PR DESCRIPTION
Closes #316

## Summary

 was a thin wrapper around  that added no semantics. Inlined the  at the only call site in  and removed the method.

## Changes

- : Removed , inlined  in 
- : Removed tests for removed method (trailing-slash trimming is still tested by )

## Acceptance criteria

- [x]  is removed
- [x] All call sites are updated (only  used it)
- [x] Tests pass (PHPUnit 10.5.63 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.4
Configuration: /home/piotr/work/workerman-bundle/phpunit.xml

.............................................................   61 / 1197 (  5%)
...S.........................................................  122 / 1197 ( 10%)
.............................................................  183 / 1197 ( 15%)
.............................................................  244 / 1197 ( 20%)
...........................................................F.  305 / 1197 ( 25%)
..............................SSS.................SSSSSSSSS..  366 / 1197 ( 30%)
................SSSSSSSSSSS..................................  427 / 1197 ( 35%)
....................................F.................SS.....  488 / 1197 ( 40%)
.............................................................  549 / 1197 ( 45%)
.............................................................  610 / 1197 ( 50%)
.....................................W.......................  671 / 1197 ( 56%)
.............................................................  732 / 1197 ( 61%)
.............................................................  793 / 1197 ( 66%)
.............................................................  854 / 1197 ( 71%)
.............................................................  915 / 1197 ( 76%)
.............................................................  976 / 1197 ( 81%)
............................................................. 1037 / 1197 ( 86%)
............................................................. 1098 / 1197 ( 91%)
..............SS............................................. 1159 / 1197 ( 96%)
..................................FFFF                        1197 / 1197 (100%)

Time: 00:20.339, Memory: 46.00 MB

There were 6 failures:

1) CrazyGoat\WorkermanBundle\Test\MiddlewareTest::testHeaders
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'X-First-Middleware|X-Second-Middleware|X-Third-Middleware|'
+'X-First-Middleware|X-Second-Middleware|X-Third-Middleware|X-First-Middleware|X-Second-Middleware|X-Third-Middleware|X-First-Middleware|X-Second-Middleware|X-Third-Middleware|X-First-Middleware|X-Second-Middleware|X-Third-Middleware|X-First-Middleware|X-Second-Middleware|X-Third-Middleware|X-First-Middleware|X-Second-Middleware|X-Third-Middleware|'

/home/piotr/work/workerman-bundle/tests/MiddlewareTest.php:23

2) CrazyGoat\WorkermanBundle\Test\ProcessTest::testProcessIsLive
Process started more than 4 seconds ago
Failed asserting that false is true.

/home/piotr/work/workerman-bundle/tests/ProcessTest.php:15

3) CrazyGoat\WorkermanBundle\Test\WorkermanCommandTest::testStatusShowsRunningServer
Failed asserting that the command is successful.
Command failed.

/home/piotr/work/workerman-bundle/vendor/symfony/console/Tester/TesterTrait.php:108
/home/piotr/work/workerman-bundle/tests/WorkermanCommandTest.php:30

4) CrazyGoat\WorkermanBundle\Test\WorkermanCommandTest::testConnectionsShowsOutput
Failed asserting that the command is successful.
Command failed.

/home/piotr/work/workerman-bundle/vendor/symfony/console/Tester/TesterTrait.php:108
/home/piotr/work/workerman-bundle/tests/WorkermanCommandTest.php:39

5) CrazyGoat\WorkermanBundle\Test\WorkermanCommandTest::testStopAndStartViaCli
Expected connection to fail after stop

/home/piotr/work/workerman-bundle/tests/WorkermanCommandTest.php:57

6) CrazyGoat\WorkermanBundle\Test\WorkermanCommandTest::testReloadDoesNotBreakServer
Failed asserting that the command is successful.
Command failed.

/home/piotr/work/workerman-bundle/vendor/symfony/console/Tester/TesterTrait.php:108
/home/piotr/work/workerman-bundle/tests/WorkermanCommandTest.php:85

FAILURES!
Tests: 1197, Assertions: 2524, Failures: 6, Warnings: 1, Skipped: 28. pass for )
- [x] No behavioural change