### PR TITLE
[Docs] Expand composer.json keywords and description for Packagist discoverability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,17 @@
 {
     "name": "crazy-goat/workerman-bundle",
-    "description": "Workerman runtime for symfony applications",
+    "description": "Symfony bundle providing a Workerman runtime for high-performance long-running HTTP servers, with built-in task scheduler, process supervisor, PHAR packaging, and event-loop integration.",
     "keywords": [
         "workerman",
         "symfony",
+        "bundle",
         "runtime",
+        "http server",
+        "long-running",
+        "scheduler",
+        "supervisor",
+        "phar",
+        "event loop",
         "php-runtime"
     ],
     "homepage": "https://github.com/crazy-goat/workerman-bundle",

--- a/tests/ComposerConfigTest.php
+++ b/tests/ComposerConfigTest.php
@@ -80,4 +80,38 @@ final class ComposerConfigTest extends TestCase
             'Known advisory for symfony/runtime 7.2.* must be in audit ignore list',
         );
     }
+
+    public function testDescriptionMentionsMajorCapabilities(): void
+    {
+        self::assertArrayHasKey('description', $this->composerConfig);
+
+        $description = $this->composerConfig['description'];
+        self::assertIsString($description);
+
+        $requiredTerms = ['workerman', 'symfony', 'bundle', 'http', 'long-running'];
+        foreach ($requiredTerms as $term) {
+            self::assertStringContainsStringIgnoringCase(
+                $term,
+                $description,
+                sprintf('Description must mention "%s"', $term),
+            );
+        }
+    }
+
+    public function testKeywordsContainRequiredTerms(): void
+    {
+        self::assertArrayHasKey('keywords', $this->composerConfig);
+        self::assertIsArray($this->composerConfig['keywords']);
+
+        $keywords = $this->composerConfig['keywords'];
+        $requiredKeywords = ['workerman', 'symfony', 'bundle', 'http server', 'long-running', 'scheduler', 'supervisor', 'phar', 'event loop'];
+
+        foreach ($requiredKeywords as $keyword) {
+            self::assertContains(
+                $keyword,
+                $keywords,
+                sprintf('keywords must contain "%s"', $keyword),
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description

Closes #299

Expands `composer.json` keywords and tightens description so the package is discoverable on Packagist for relevant search terms (http server, scheduler, supervisor, phar, long-running).

## Changes

- **composer.json**: Added keywords `bundle`, `http server`, `long-running`, `scheduler`, `supervisor`, `phar`, `event loop`. Rewrote description to mention all major capabilities in one sentence.
- **tests/ComposerConfigTest.php**: Added `testDescriptionMentionsMajorCapabilities` (verifies key terms in description) and `testKeywordsContainRequiredTerms` (verifies all required keywords are present).

## Acceptance criteria

- [x] `composer.json` has a `keywords` array covering the listed terms.
- [x] Description mentions the major capabilities the keywords advertise.
- [x] Tests verify both changes.
- [x] No behavioural change.