### PR TITLE
[Docs] Exclude docs/superpowers/ planning artifacts from Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 /tests export-ignore
 /phpunit.xml export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/docs/superpowers export-ignore


### PR DESCRIPTION
## Description

Closes #298

`docs/superpowers/` contains internal planning artifacts (RFCs, implementation plans, design specs) that are not intended for end users. Although the directory is listed in `.gitignore` for local copies, it was still shipped in Composer tarballs because it was not listed in `.gitattributes` `export-ignore`.

## Changes

- Added `/docs/superpowers export-ignore` to `.gitattributes`

## Verification

```
git archive HEAD | tar -tv | grep superpowers  # returns nothing ✓
```

## Acceptance criteria

- [x] `.gitattributes` contains an `export-ignore` rule covering `docs/superpowers/`
- [x] `git archive HEAD` no longer includes `docs/superpowers/` files
- [x] No remaining contradiction between the directory being internal-only and shipping in published packages