### PR TITLE
[Security] Route exception logging in HttpRequestHandler through PSR-3 logger instead of error_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Route exception logging in `HttpRequestHandler` through the injected PSR-3 logger instead of `error_log()` to prevent sensitive data leaking to stderr; `error_log()` retained as fallback when no logger is available ([#296](https://github.com/crazy-goat/workerman-bundle/issues/296))
+
 ### Performance
 
 - Cache PID file handles in `SchedulerWorker` to avoid `fopen`/`fclose` blocking syscalls in the event loop on every scheduled task fire — handles are opened once per PID file and reused across the worker's lifetime ([#297](https://github.com/crazy-goat/workerman-bundle/issues/297))

--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -70,6 +70,7 @@ final class WorkermanCompilerPass implements CompilerPassInterface
             ->setArguments([
                 new Reference('workerman.symfony_controller'),
                 new Reference('workerman.reboot_strategy'),
+                new Reference('logger'),
             ]);
 
         $container

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -9,6 +9,7 @@ use CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Utils;
+use Psr\Log\LoggerInterface;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
 
@@ -33,6 +34,7 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
     public function __construct(
         private readonly SymfonyController         $controller,
         private readonly RebootStrategyInterface   $rebootStrategy,
+        private readonly ?LoggerInterface          $logger = null,
     ) {
     }
 
@@ -119,13 +121,22 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
         try {
             $this->controller->terminateIfNeeded();
         } catch (\Throwable $e) {
-            error_log(sprintf(
-                '%s: %s in %s:%d',
-                $errorPrefix,
-                $e->getMessage(),
-                $e->getFile(),
-                $e->getLine(),
-            ));
+            if ($this->logger instanceof LoggerInterface) {
+                $this->logger->error($errorPrefix, [
+                    'exception' => $e,
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+            } else {
+                error_log(sprintf(
+                    '%s: %s in %s:%d',
+                    $errorPrefix,
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine(),
+                ));
+            }
         }
     }
 

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -12,6 +12,7 @@ use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Test\App\TestMiddleware;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
@@ -616,7 +617,7 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertSame(1, $this->kernel->terminateCount);
     }
 
-    public function testDoTerminateDoesNotThrowOnControllerException(): void
+    public function testDoTerminateLogsThroughLoggerWhenAvailable(): void
     {
         $throwingKernel = new class implements KernelInterface, TerminableInterface {
             public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
@@ -695,7 +696,109 @@ final class HttpRequestHandlerTest extends TestCase
         };
 
         $controller = new SymfonyController($throwingKernel, $this->responseConverter);
-        // Perform one invocation so terminateIfNeeded has a request/response to work with
+        $tempConn = new MockTcpConnection();
+        $controller(new Request(self::HTTP11), $tempConn);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'Kernel termination failed',
+                $this->callback(fn(array $context): bool => isset($context['exception'])
+                    && $context['exception']->getMessage() === 'Terminate failed'
+                    && isset($context['message'])
+                    && isset($context['file'])
+                    && isset($context['line'])),
+            );
+
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, $logger);
+
+        $reflection = new \ReflectionClass($handler);
+        $method = $reflection->getMethod('doTerminate');
+        $method->invoke($handler);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDoTerminateFallsBackToErrorLogWhenNoLogger(): void
+    {
+        $throwingKernel = new class implements KernelInterface, TerminableInterface {
+            public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
+            {
+                throw new \RuntimeException('Terminate failed');
+            }
+            public function boot(): void
+            {
+            }
+            public function shutdown(): void
+            {
+            }
+            public function registerBundles(): iterable
+            {
+                return [];
+            }
+            public function registerContainerConfiguration(\Symfony\Component\Config\Loader\LoaderInterface $loader): void
+            {
+            }
+            public function handle(\Symfony\Component\HttpFoundation\Request $request, int $type = 1, bool $catch = true): \Symfony\Component\HttpFoundation\Response
+            {
+                return new SymfonyResponse('OK');
+            }
+            public function getBundles(): array
+            {
+                return [];
+            }
+            public function getBundle(string $name): \Symfony\Component\HttpKernel\Bundle\BundleInterface
+            {
+                throw new \RuntimeException('Not implemented');
+            }
+            public function locateResource(string $name): string
+            {
+                return '';
+            }
+            public function getEnvironment(): string
+            {
+                return 'test';
+            }
+            public function isDebug(): bool
+            {
+                return true;
+            }
+            public function getProjectDir(): string
+            {
+                return '/tmp';
+            }
+            public function getCacheDir(): string
+            {
+                return '/tmp/cache';
+            }
+            public function getBuildDir(): string
+            {
+                return '/tmp/build';
+            }
+            public function getShareDir(): ?string
+            {
+                return null;
+            }
+            public function getLogDir(): string
+            {
+                return '/tmp/log';
+            }
+            public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
+            {
+                throw new \RuntimeException('Not implemented');
+            }
+            public function getStartTime(): float
+            {
+                return 0.0;
+            }
+            public function getCharset(): string
+            {
+                return 'UTF-8';
+            }
+        };
+
+        $controller = new SymfonyController($throwingKernel, $this->responseConverter);
         $tempConn = new MockTcpConnection();
         $controller(new Request(self::HTTP11), $tempConn);
 
@@ -704,7 +807,7 @@ final class HttpRequestHandlerTest extends TestCase
         $reflection = new \ReflectionClass($handler);
         $method = $reflection->getMethod('doTerminate');
 
-        // Capture error_log output and verify it contains the expected message
+        // Capture error_log output and verify fallback
         $logFile = tempnam(sys_get_temp_dir(), 'test_terminate_');
         ini_set('error_log', $logFile);
         try {
@@ -721,11 +824,8 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertStringContainsString(
             'Kernel termination failed: Terminate failed',
             $logContent,
-            'The error_log should contain the terminate failure message',
+            'The error_log should contain the terminate failure message when no logger is provided',
         );
-
-        // The kernel's terminate was called but threw — that's OK, we verified no uncaught exception
-        $this->addToAssertionCount(1);
     }
 
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #296

Changes exception logging in `HttpRequestHandler::doTerminate()` from `error_log()` to the injected PSR-3 `LoggerInterface`, with `error_log()` retained as a fallback when no logger is available.

## Changes

1. **`src/Http/HttpRequestHandler.php`** — Added optional `?LoggerInterface  = null` constructor parameter; replaced `error_log()` in `doTerminate()` with PSR-3 logger call + fallback.

2. **`src/DependencyInjection/WorkermanCompilerPass.php`** — Wired the `logger` service to HttpRequestHandler.

3. **`tests/HttpRequestHandlerTest.php`** — Replaced `testDoTerminateDoesNotThrowOnControllerException` with two tests:
   - `testDoTerminateLogsThroughLoggerWhenAvailable` — verifies logger error() is called with expected context
   - `testDoTerminateFallsBackToErrorLogWhenNoLogger` — verifies fallback to error_log() when logger is null

4. **`CHANGELOG.md`** — Added Security entry for Unreleased.

## Acceptance criteria

- [x] Exception logging is routed through the injected logger
- [x] `error_log()` is kept as last-resort fallback when logger is null
- [x] Positive test: exceptions are logged with expected metadata via the logger
- [x] Documented behaviour change in CHANGELOG
- [x] Existing tests pass (`vendor/bin/phpunit`): 1205 tests, 2561 assertions, 7 pre-existing failures (unrelated: live server tests, process tests)