### PR TITLE
[Code Quality] Make TaskErrorEvent immutable by removing unused setError

### DIFF
--- a/src/Event/TaskErrorEvent.php
+++ b/src/Event/TaskErrorEvent.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class TaskErrorEvent extends Event
 {
     public function __construct(
-        private \Throwable $error,
+        private readonly \Throwable $error,
         private readonly string $serviceClass,
         private readonly string $taskName,
     ) {
@@ -28,10 +28,5 @@ final class TaskErrorEvent extends Event
     public function getError(): \Throwable
     {
         return $this->error;
-    }
-
-    public function setError(\Throwable $error): void
-    {
-        $this->error = $error;
     }
 }

--- a/tests/Event/TaskErrorEventTest.php
+++ b/tests/Event/TaskErrorEventTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Event;
+
+use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
+use PHPUnit\Framework\TestCase;
+
+final class TaskErrorEventTest extends TestCase
+{
+    public function testConstructAndGetters(): void
+    {
+        $exception = new \RuntimeException('test error');
+        $event = new TaskErrorEvent($exception, 'App\Service\MyService', 'my_task');
+
+        self::assertSame($exception, $event->getError());
+        self::assertSame('App\Service\MyService', $event->getServiceClass());
+        self::assertSame('my_task', $event->getTaskName());
+    }
+
+    public function testEventIsImmutable(): void
+    {
+        $reflection = new \ReflectionClass(TaskErrorEvent::class);
+
+        self::assertFalse(
+            $reflection->hasMethod('setError'),
+            'TaskErrorEvent should not have a setError mutator',
+        );
+
+        $property = $reflection->getProperty('error');
+        self::assertTrue($property->isReadOnly());
+    }
+}


### PR DESCRIPTION
Closes #338

## Changes
- Made `$error` property `readonly` in constructor
- Removed unused `setError()` mutator method

## Testing
- Added `tests/Event/TaskErrorEventTest.php` covering:
  - Constructor and getters
  - Immutability (`setError` method removed, `$error` property is readonly)

All existing tests continue to pass.