### PR TITLE
[Performance] Cache normalizeHeaderName results and fix irregular header acronyms (ETag, Content-MD5)

### DIFF
--- a/src/Http/Response/ResponseConverter.php
+++ b/src/Http/Response/ResponseConverter.php
@@ -51,13 +51,31 @@ final readonly class ResponseConverter
     /**
      * Normalizes a header name to proper case (e.g., "content-type" → "Content-Type").
      *
-     * NOTE: ucfirst-based normalization has known limitations with acronyms:
-     * - "etag" → "Etag" (not "ETag"), "content-md5" → "Content-Md5" (not "Content-MD5")
-     * Per RFC 9110, HTTP header names are case-insensitive, so this is technically valid.
-     * This approach is still strictly better than the old hardcoded 6-header map.
+     * Results are cached in a static lookup table so each unique header name is
+     * normalised at most once per worker lifetime -- the hot path then becomes O(1).
+     *
+     * A corrections table handles irregular acronyms that ucfirst cannot produce:
+     *   "etag"             → "ETag"
+     *   "content-md5"      → "Content-MD5"
+     *   "www-authenticate" → "WWW-Authenticate"
+     *   "dnt"              → "DNT"
+     *
+     * Per RFC 9110, HTTP header names are case-insensitive, so the uncorrected
+     * forms would still be valid; the corrections just match common usage.
      */
     private function normalizeHeaderName(string $name): string
     {
-        return implode('-', array_map(ucfirst(...), explode('-', $name)));
+        static $cache = [];
+        static $corrections = [
+            'etag' => 'ETag',
+            'content-md5' => 'Content-MD5',
+            'www-authenticate' => 'WWW-Authenticate',
+            'dnt' => 'DNT',
+        ];
+
+        $lower = strtolower($name);
+
+        return $cache[$lower] ?? $cache[$lower] = $corrections[$lower]
+            ?? implode('-', array_map(ucfirst(...), explode('-', $name)));
     }
 }

--- a/tests/ResponseConverterTest.php
+++ b/tests/ResponseConverterTest.php
@@ -113,4 +113,87 @@ final class ResponseConverterTest extends TestCase
         $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
     }
+
+    public function testConvertNormalizesIrregularHeaderNames(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'etag' => '"abc123"',
+            'content-md5' => 'deadbeef',
+            'www-authenticate' => 'Bearer',
+            'dnt' => '1',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $this->assertSame(['"abc123"'], $workermanResponse->getHeader('ETag'));
+        $this->assertSame(['deadbeef'], $workermanResponse->getHeader('Content-MD5'));
+        $this->assertSame(['Bearer'], $workermanResponse->getHeader('WWW-Authenticate'));
+        $this->assertSame(['1'], $workermanResponse->getHeader('DNT'));
+    }
+
+    public function testConvertNormalizesIrregularHeadersConsistentlyOnRepeatedCalls(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response1 = new Response('a', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'etag' => '"v1"',
+        ]);
+        $response2 = new Response('b', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'etag' => '"v2"',
+        ]);
+
+        $r1 = $converter->convert($response1, $this->connection);
+        $r2 = $converter->convert($response2, $this->connection);
+
+        // Both calls hit the static cache on the second invocation
+        $this->assertSame(['"v1"'], $r1->getHeader('ETag'));
+        $this->assertSame(['"v2"'], $r2->getHeader('ETag'));
+    }
+
+    public function testConvertPreservesRegularHeaderCasingAfterCaching(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        // First call populates the cache
+        $response1 = new Response('a', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'content-type' => 'text/html',
+            'x-custom-one' => 'first',
+        ]);
+        $converter->convert($response1, $this->connection);
+
+        // Second call on same instance hits cache entries
+        $response2 = new Response('b', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'content-type' => 'application/json',
+            'x-custom-two' => 'second',
+        ]);
+        $workermanResponse = $converter->convert($response2, $this->connection);
+
+        $this->assertSame(['application/json'], $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame(['second'], $workermanResponse->getHeader('X-Custom-Two'));
+    }
+
+    public function testConvertNormalizesMixedRegularAndIrregularHeaders(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'content-type' => 'text/plain',
+            'etag' => '"abc"',
+            'x-custom' => 'value',
+            'dnt' => '0',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $this->assertSame(['text/plain'], $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame(['"abc"'], $workermanResponse->getHeader('ETag'));
+        $this->assertSame(['value'], $workermanResponse->getHeader('X-Custom'));
+        $this->assertSame(['0'], $workermanResponse->getHeader('DNT'));
+    }
 }


### PR DESCRIPTION
## Summary

Two birds, one stone: performance optimization **#287** + code-quality fix **#354**.

### What changed in `normalizeHeaderName()`

**Before:** Every response header went through `explode()` + `array_map(ucfirst())` + `implode()` — roughly 3–5 string allocations per header, recomputed from scratch on every response.

**After:** A `static` lookup cache stores the normalized form keyed by lowercase input. First request pays the cost; subsequent requests are O(1) — at most 1 normalization per unique header name across the entire worker lifetime. The cache is bounded by the cardinality of header names (a finite, low-cardinality set).

### Irregular header corrections

| Input | Before (ucfirst) | After |
|---|---|---|
| `etag` | `Etag` | **`ETag`** |
| `content-md5` | `Content-Md5` | **`Content-MD5`** |
| `www-authenticate` | `Www-Authenticate` | **`WWW-Authenticate`** |
| `dnt` | `Dnt` | **`DNT`** |

Per RFC 9110, HTTP header names are case-insensitive, so the old forms were valid — the corrections just match common usage.

### Tests added

- `testConvertNormalizesIrregularHeaderNames` — verifies each correction produces the canonical form
- `testConvertNormalizesIrregularHeadersConsistentlyOnRepeatedCalls` — confirms cache returns correct value for different values under the same header name across multiple `convert()` calls
- `testConvertPreservesRegularHeaderCasingAfterCaching` — proves cache population does not affect regular headers
- `testConvertNormalizesMixedRegularAndIrregularHeaders` — ensures regular + irregular headers coexist correctly

No behavioural change for headers that already canonicalise correctly.

Closes #287
Closes #354