### PR TITLE
[Tests] Add event ordering and __invoke fallback tests to TaskHandler and ProcessHandler

### DIFF
--- a/tests/EventDispatcher/RecordingEventDispatcher.php
+++ b/tests/EventDispatcher/RecordingEventDispatcher.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\EventDispatcher;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class RecordingEventDispatcher implements EventDispatcherInterface
+{
+    /** @var list<object> */
+    public array $events = [];
+
+    public function dispatch(object $event, ?string $eventName = null): object
+    {
+        $this->events[] = $event;
+
+        return $event;
+    }
+}

--- a/tests/Scheduler/TaskHandlerTest.php
+++ b/tests/Scheduler/TaskHandlerTest.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\WorkermanBundle\Test\Scheduler;
 use CrazyGoat\WorkermanBundle\Event\TaskErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\TaskStartEvent;
 use CrazyGoat\WorkermanBundle\Scheduler\TaskHandler;
+use CrazyGoat\WorkermanBundle\Test\EventDispatcher\RecordingEventDispatcher;
 use CrazyGoat\WorkermanBundle\Util\ServiceMethod;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -64,7 +65,6 @@ final class TaskHandlerTest extends TestCase
 
         $handler = new TaskHandler($locator, $eventDispatcher);
         $handler->__invoke(new ServiceMethod('my_task_service', 'nonexistent'), 'test_task');
-        // Should not throw - error is caught by try-catch and dispatched as event
     }
 
     public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
@@ -98,5 +98,72 @@ final class TaskHandlerTest extends TestCase
 
         $handler = new TaskHandler($locator, $eventDispatcher);
         $handler->__invoke(new ServiceMethod('my_task_service', 'execute'), 'test_task');
+    }
+
+    public function testInvokeCallsMagicInvokeMethod(): void
+    {
+        $service = new class {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_invokable_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_invokable_service', '__invoke'), 'test_task');
+
+        $this->assertTrue($service->called);
+        $this->assertCount(1, $eventDispatcher->events);
+        $this->assertInstanceOf(TaskStartEvent::class, $eventDispatcher->events[0]);
+    }
+
+    public function testEventOrderingWhenServiceMethodThrowsException(): void
+    {
+        $service = new class {
+            public function execute(): never
+            {
+                throw new \RuntimeException('Task failed');
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_task_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_task_service', 'execute'), 'test_task');
+
+        $this->assertCount(2, $eventDispatcher->events);
+        $this->assertInstanceOf(TaskStartEvent::class, $eventDispatcher->events[0]);
+        $this->assertInstanceOf(TaskErrorEvent::class, $eventDispatcher->events[1]);
+        $this->assertInstanceOf(\RuntimeException::class, $eventDispatcher->events[1]->getError());
+        $this->assertSame('Task failed', $eventDispatcher->events[1]->getError()->getMessage());
+    }
+
+    public function testEventOrderingWhenMethodDoesNotExist(): void
+    {
+        $service = new class {
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_task_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new TaskHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_task_service', 'nonexistent'), 'test_task');
+
+        $this->assertCount(2, $eventDispatcher->events);
+        $this->assertInstanceOf(TaskStartEvent::class, $eventDispatcher->events[0]);
+        $this->assertInstanceOf(TaskErrorEvent::class, $eventDispatcher->events[1]);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $eventDispatcher->events[1]->getError());
     }
 }

--- a/tests/Supervisor/ProcessHandlerTest.php
+++ b/tests/Supervisor/ProcessHandlerTest.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\WorkermanBundle\Test\Supervisor;
 use CrazyGoat\WorkermanBundle\Event\ProcessErrorEvent;
 use CrazyGoat\WorkermanBundle\Event\ProcessStartEvent;
 use CrazyGoat\WorkermanBundle\Supervisor\ProcessHandler;
+use CrazyGoat\WorkermanBundle\Test\EventDispatcher\RecordingEventDispatcher;
 use CrazyGoat\WorkermanBundle\Util\ServiceMethod;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -64,7 +65,6 @@ final class ProcessHandlerTest extends TestCase
 
         $handler = new ProcessHandler($locator, $eventDispatcher);
         $handler->__invoke(new ServiceMethod('my_service', 'nonexistent'), 'test_process');
-        // Should not throw - error is caught by try-catch and dispatched as event
     }
 
     public function testInvokeDispatchesErrorEventWhenServiceMethodThrowsException(): void
@@ -98,5 +98,72 @@ final class ProcessHandlerTest extends TestCase
 
         $handler = new ProcessHandler($locator, $eventDispatcher);
         $handler->__invoke(new ServiceMethod('my_service', 'run'), 'test_process');
+    }
+
+    public function testInvokeCallsMagicInvokeMethod(): void
+    {
+        $service = new class {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_invokable_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_invokable_service', '__invoke'), 'test_process');
+
+        $this->assertTrue($service->called);
+        $this->assertCount(1, $eventDispatcher->events);
+        $this->assertInstanceOf(ProcessStartEvent::class, $eventDispatcher->events[0]);
+    }
+
+    public function testEventOrderingWhenServiceMethodThrowsException(): void
+    {
+        $service = new class {
+            public function run(): never
+            {
+                throw new \RuntimeException('Something went wrong');
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_service', 'run'), 'test_process');
+
+        $this->assertCount(2, $eventDispatcher->events);
+        $this->assertInstanceOf(ProcessStartEvent::class, $eventDispatcher->events[0]);
+        $this->assertInstanceOf(ProcessErrorEvent::class, $eventDispatcher->events[1]);
+        $this->assertInstanceOf(\RuntimeException::class, $eventDispatcher->events[1]->getError());
+        $this->assertSame('Something went wrong', $eventDispatcher->events[1]->getError()->getMessage());
+    }
+
+    public function testEventOrderingWhenMethodDoesNotExist(): void
+    {
+        $service = new class {
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('get')->with('my_service')->willReturn($service);
+
+        $eventDispatcher = new RecordingEventDispatcher();
+
+        $handler = new ProcessHandler($locator, $eventDispatcher);
+        $handler->__invoke(new ServiceMethod('my_service', 'nonexistent'), 'test_process');
+
+        $this->assertCount(2, $eventDispatcher->events);
+        $this->assertInstanceOf(ProcessStartEvent::class, $eventDispatcher->events[0]);
+        $this->assertInstanceOf(ProcessErrorEvent::class, $eventDispatcher->events[1]);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $eventDispatcher->events[1]->getError());
     }
 }


### PR DESCRIPTION
Closes #276

## Summary

Adds missing test coverage to `TaskHandlerTest` and `ProcessHandlerTest`:

1. **Event ordering** — new `RecordingEventDispatcher` collector records dispatched events in order; tests verify `TaskStartEvent`/`ProcessStartEvent` is always dispatched before `TaskErrorEvent`/`ProcessErrorEvent` (both for missing-method and method-throws scenarios).

2. **`__invoke` fallback path** — verifies that when the configured method is `__invoke`, the handler calls the service's `__invoke` method.

3. **Custom method path** — existing tests already cover this (e.g. `execute`, `run`).

4. **Missing-method error** — existing tests already cover this; new tests add explicit event ordering via the recording dispatcher.

## Acceptance criteria

- [x] `tests/Scheduler/TaskHandlerTest.php` and `tests/Supervisor/ProcessHandlerTest.php` assert event order via a recording dispatcher
- [x] Tests cover `__invoke` fallback, custom method, and missing-method error
- [x] Tests fail if the start event is dispatched after the error event (regression-protective)
- [x] Existing tests continue to pass