### PR TITLE
[Security] StaticFilesMiddleware: add follow_symlinks option (default: false)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -118,10 +118,30 @@ workerman:
 
 When `allowed_extensions` is set, only files with one of the listed extensions are served — all others return 404. The denylist (dotfiles, `.php`, etc.) takes precedence and is always enforced regardless of the allowlist setting.
 
+### Symlink Protection
+
+By default, `StaticFilesMiddleware` refuses to serve files that are accessed through a symlink under the static root directory (`follow_symlinks: false`). This prevents an attacker or a compromised tool from creating a symlink inside the public directory to expose files outside the intended root.
+
+To restore the previous behaviour and allow symlinks to be followed, set `follow_symlinks: true`:
+
+```yaml
+workerman:
+    servers:
+        - name: 'Web'
+          listen: 'http://0.0.0.0:80'
+          serve_files: true
+          root_dir: '%kernel.project_dir%/public'
+          static_files:
+              follow_symlinks: true
+```
+
+When `follow_symlinks` is `false` (default), any path component inside the root directory that is a symlink will cause the request to be treated as a non-existent file, passing control to the next middleware.
+
 ### Security Considerations
 
 - **Keep `root_dir` isolated**: Point `root_dir` to a dedicated public directory (e.g., `%kernel.project_dir%/public`). Never set it to the project root or a directory containing `.env`, source code, or VCS metadata.
 - **Use the allowlist**: Configure `allowed_extensions` to only permit the file types your application actually serves as static assets.
+- **Disable symlinks**: Keep `follow_symlinks: false` (default) to prevent symlink-based file disclosure unless your application explicitly requires symlinks inside the public directory.
 - **404 for blocked files**: Denied files always return a 404 response (identical to non-existent files). This prevents attackers from probing whether a blocked file exists.
 
 ## SFX Download Protection (Zip-Slip)

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -31,6 +31,8 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
 
     /**
      * @param string[] $allowedExtensions
+     * @param bool     $followSymlinks When false (default), symlinks under the root directory are not followed.
+     *                                 Set to true to allow serving files through symlinks.
      */
     public function __construct(string $rootDirectory, array $allowedExtensions = [], private bool $followSymlinks = false)
     {

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -32,7 +32,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
     /**
      * @param string[] $allowedExtensions
      */
-    public function __construct(string $rootDirectory, array $allowedExtensions = [])
+    public function __construct(string $rootDirectory, array $allowedExtensions = [], private bool $followSymlinks = false)
     {
         if ($this->isPharPath($rootDirectory)) {
             $this->rootRealPath = $rootDirectory;
@@ -175,16 +175,18 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
 
         $cache = &$this->getRealPathCache();
 
-        if (isset($cache[$cacheKey])) {
-            $cached = $cache[$cacheKey];
+        $cacheIndex = $cacheKey . "\0" . ($this->followSymlinks ? '1' : '0') . "\0" . $this->rootRealPath;
+
+        if (isset($cache[$cacheIndex])) {
+            $cached = $cache[$cacheIndex];
             $ttl = $cached['path'] === false ? self::CACHE_NEGATIVE_TTL : self::CACHE_TTL;
             if ($now - $cached['time'] < $ttl) {
-                unset($cache[$cacheKey]);
-                $cache[$cacheKey] = $cached;
+                unset($cache[$cacheIndex]);
+                $cache[$cacheIndex] = $cached;
 
                 return $cached['path'];
             }
-            unset($cache[$cacheKey]);
+            unset($cache[$cacheIndex]);
         }
 
         if ($this->isPharPath($this->rootRealPath)) {
@@ -193,10 +195,31 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
                 $resolved = false;
             }
         } else {
-            $resolved = realpath($this->rootRealPath . DIRECTORY_SEPARATOR . ltrim($cacheKey, '/'));
+            $path = $this->rootRealPath . DIRECTORY_SEPARATOR . ltrim($cacheKey, '/');
+
+            if (!$this->followSymlinks) {
+                $components = explode('/', ltrim($cacheKey, '/'));
+                $checkPath = $this->rootRealPath;
+                foreach ($components as $component) {
+                    if ($component === '' || $component === '.') {
+                        continue;
+                    }
+                    $checkPath .= DIRECTORY_SEPARATOR . $component;
+                    if (is_link($checkPath)) {
+                        $cache[$cacheIndex] = [
+                            'path' => false,
+                            'time' => $now,
+                        ];
+
+                        return false;
+                    }
+                }
+            }
+
+            $resolved = realpath($path);
         }
 
-        $cache[$cacheKey] = [
+        $cache[$cacheIndex] = [
             'path' => $resolved,
             'time' => $now,
         ];

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -133,7 +133,47 @@ final class StaticFilesMiddlewareTest extends TestCase
         }
     }
 
-    public function testSymlinkInsideRootAllowed(): void
+    public function testSymlinkInsideRootAllowedWhenFollowSymlinksEnabled(): void
+    {
+        $linkPath = $this->rootDirectory . '/linked';
+        $subDir = $this->rootDirectory . '/subdir';
+
+        try {
+            if (!is_dir($subDir)) {
+                mkdir($subDir, 0777, true);
+            }
+            file_put_contents($subDir . '/linked_file.txt', 'linked content');
+
+            if (!file_exists($linkPath)) {
+                symlink($subDir, $linkPath);
+            }
+
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, [], true);
+
+            $request = $this->createRequest('/linked/linked_file.txt');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should not be called for symlink inside root when follow_symlinks enabled');
+        } finally {
+            if (file_exists($linkPath)) {
+                unlink($linkPath);
+            }
+            if (file_exists($subDir . '/linked_file.txt')) {
+                unlink($subDir . '/linked_file.txt');
+            }
+            if (is_dir($subDir)) {
+                rmdir($subDir);
+            }
+        }
+    }
+
+    public function testSymlinkInsideRootBlockedByDefault(): void
     {
         $linkPath = $this->rootDirectory . '/linked';
         $subDir = $this->rootDirectory . '/subdir';
@@ -157,9 +197,10 @@ final class StaticFilesMiddlewareTest extends TestCase
                 return new Response(404);
             };
 
-            $middleware($request, $next);
+            $response = $middleware($request, $next);
 
-            $this->assertFalse($called, 'Next should not be called for symlink inside root');
+            $this->assertTrue($called, 'Next should be called for symlink when follow_symlinks is disabled');
+            $this->assertEquals(404, $response->getStatusCode());
         } finally {
             if (file_exists($linkPath)) {
                 unlink($linkPath);
@@ -169,6 +210,63 @@ final class StaticFilesMiddlewareTest extends TestCase
             }
             if (is_dir($subDir)) {
                 rmdir($subDir);
+            }
+        }
+    }
+
+    public function testRegularFileStillServedWithFollowSymlinksDisabled(): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+        $request = $this->createRequest('/test.txt');
+        $called = false;
+        $next = function (Request $req) use (&$called): Response {
+            $called = true;
+            return new Response(404);
+        };
+
+        $middleware($request, $next);
+
+        $this->assertFalse($called, 'Next should not be called for regular file with follow_symlinks disabled');
+    }
+
+    public function testSymlinkEscapingBlockedWithFollowSymlinksEnabled(): void
+    {
+        $targetDir = __DIR__ . '/data/outside';
+        $linkPath = $this->rootDirectory . '/escape_link';
+
+        try {
+            if (!is_dir($targetDir)) {
+                mkdir($targetDir, 0777, true);
+            }
+            file_put_contents($targetDir . '/secret.txt', 'secret content');
+
+            if (!file_exists($linkPath)) {
+                symlink($targetDir, $linkPath);
+            }
+
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, [], true);
+
+            $request = $this->createRequest('/escape_link/secret.txt');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(200);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertTrue($called, 'Next should be called for symlink escaping path even with follow_symlinks enabled');
+            $this->assertEquals(200, $response->getStatusCode());
+        } finally {
+            if (file_exists($linkPath)) {
+                unlink($linkPath);
+            }
+            if (file_exists($targetDir . '/secret.txt')) {
+                unlink($targetDir . '/secret.txt');
+            }
+            if (is_dir($targetDir)) {
+                rmdir($targetDir);
             }
         }
     }


### PR DESCRIPTION
Closes #292

## Summary

Adds a `follow_symlinks` configuration option to `StaticFilesMiddleware` that controls whether symlinks under the static root directory are followed when serving files. Defaults to `false` (safer) to prevent symlink-based file disclosure.

## Changes

- **src/Middleware/StaticFilesMiddleware.php**: Added `$followSymlinks` constructor parameter (default `false`). When disabled, walks path components with `is_link()` before resolving the real path and refuses to serve if any component is a symlink. Cache key now includes `followSymlinks` and `rootRealPath` to prevent stale values across instances.
- **tests/StaticFilesMiddlewareTest.php**: Updated existing symlink test to use `follow_symlinks: true`. Added 3 new tests: symlink blocked by default, regular file still served, escape blocked even when enabled.
- **docs/security.md**: Added Symlink Protection section documenting the option with config example.

## Acceptance criteria

- [x] Configuration option in place at `src/Middleware/StaticFilesMiddleware.php`
- [x] Negative test: symlink under static root pointing inside root is not served when option disabled
- [x] Positive test: legitimate static files are still served
- [x] Negative test: symlink escaping root is blocked even when option enabled (defense-in-depth)
- [x] Documented in `docs/security.md`
- [x] Existing tests pass