### PR TITLE
[Security] ServerWorker: validate SSL cert/key paths are regular files and not symlinks

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -144,6 +144,34 @@ When `follow_symlinks` is `false` (default), any path component inside the root 
 - **Disable symlinks**: Keep `follow_symlinks: false` (default) to prevent symlink-based file disclosure unless your application explicitly requires symlinks inside the public directory.
 - **404 for blocked files**: Denied files always return a 404 response (identical to non-existent files). This prevents attackers from probing whether a blocked file exists.
 
+## SSL Certificate and Key Validation
+
+When configuring HTTPS or WSS servers, the `local_cert` and `local_pk` options specify the paths to the SSL certificate and private key files. These paths are validated before being passed to the TLS stream context:
+
+### Regular File Check
+
+Both paths must point to **regular files**. Configuration pointing to:
+- **Directories** are rejected with a clear error message.
+- **FIFO/named pipes** are rejected.
+- **Device files** (e.g., `/dev/zero`, `/dev/random`) are rejected.
+
+This prevents an attacker or misconfiguration from causing the TLS stack to read unbounded bytes from a device file or hang on a FIFO.
+
+### Symlink Protection
+
+Symlinked certificate and key paths are **rejected by default**. This prevents:
+- **Symlink-based file disclosure**: An attacker who controls a compromised tool or deployment process cannot create a symlink pointing the cert/key to a different file.
+- **Unintended key material exposure**: A symlink swapped at runtime would load different credentials than expected.
+
+### Error Messages
+
+- `SSL certificate path must not be a symlink: <path>`
+- `SSL private key path must not be a symlink: <path>`
+- `SSL certificate path must be a regular file: <path>`
+- `SSL private key path must be a regular file: <path>`
+
+These checks are applied in addition to the existing `is_readable()` validation, which catches non-existent files and permission issues.
+
 ## SFX Download Protection (Zip-Slip)
 
 The `SfxDownloader` downloads and extracts `phpmicro.sfx` from upstream HTTPS mirrors. Before extracting a downloaded ZIP archive, each entry name is validated against path traversal attacks (zip-slip):

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -115,6 +115,30 @@ final readonly class ServerWorker
             );
         }
 
+        if (is_link($cert)) {
+            throw new \InvalidArgumentException(
+                sprintf('SSL certificate path must not be a symlink: %s', $cert),
+            );
+        }
+
+        if (is_link($key)) {
+            throw new \InvalidArgumentException(
+                sprintf('SSL private key path must not be a symlink: %s', $key),
+            );
+        }
+
+        if (!is_file($cert)) {
+            throw new \InvalidArgumentException(
+                sprintf('SSL certificate path must be a regular file: %s', $cert),
+            );
+        }
+
+        if (!is_file($key)) {
+            throw new \InvalidArgumentException(
+                sprintf('SSL private key path must be a regular file: %s', $key),
+            );
+        }
+
         if (!is_readable($cert)) {
             throw new \InvalidArgumentException(
                 sprintf('SSL certificate file is not readable: %s', $cert),

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -92,6 +92,12 @@ final class ServerWorkerTest extends TestCase
 
     public function testUnreadableCertThrowsException(): void
     {
+        $certFile = $this->tempDir . '/unreadable_cert.pem';
+        touch($certFile);
+        chmod($certFile, 0000);
+        $keyFile = $this->tempDir . '/key.pem';
+        touch($keyFile);
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('not readable');
 
@@ -102,14 +108,20 @@ final class ServerWorkerTest extends TestCase
             [
                 'name' => 'test-server',
                 'listen' => 'https://0.0.0.0:8443',
-                'local_cert' => '/nonexistent/cert.pem',
-                'local_pk' => $this->tempDir . '/key.pem',
+                'local_cert' => $certFile,
+                'local_pk' => $keyFile,
             ],
         );
     }
 
     public function testUnreadableKeyThrowsException(): void
     {
+        $certFile = $this->tempDir . '/cert.pem';
+        touch($certFile);
+        $keyFile = $this->tempDir . '/unreadable_key.pem';
+        touch($keyFile);
+        chmod($keyFile, 0000);
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('not readable');
 
@@ -120,8 +132,8 @@ final class ServerWorkerTest extends TestCase
             [
                 'name' => 'test-server',
                 'listen' => 'https://0.0.0.0:8443',
-                'local_cert' => $this->tempDir . '/cert.pem',
-                'local_pk' => '/nonexistent/key.pem',
+                'local_cert' => $certFile,
+                'local_pk' => $keyFile,
             ],
         );
     }
@@ -171,6 +183,93 @@ final class ServerWorkerTest extends TestCase
         );
 
         $this->assertInstanceOf(ServerWorker::class, $serverWorker, 'ServerWorker should work without reuse_port key');
+    }
+
+    public function testNonRegularCertPathThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be a regular file');
+
+        new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            [
+                'name' => 'test-server',
+                'listen' => 'https://0.0.0.0:8443',
+                'local_cert' => $this->tempDir,
+                'local_pk' => $this->tempDir . '/key.pem',
+            ],
+        );
+    }
+
+    public function testNonRegularKeyPathThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be a regular file');
+
+        $certFile = $this->tempDir . '/cert.pem';
+        touch($certFile);
+
+        new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            [
+                'name' => 'test-server',
+                'listen' => 'https://0.0.0.0:8443',
+                'local_cert' => $certFile,
+                'local_pk' => $this->tempDir,
+            ],
+        );
+    }
+
+    public function testSymlinkedCertPathThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not be a symlink');
+
+        $certFile = $this->tempDir . '/cert.pem';
+        touch($certFile);
+        $symlink = $this->tempDir . '/cert-symlink.pem';
+        symlink($certFile, $symlink);
+
+        new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            [
+                'name' => 'test-server',
+                'listen' => 'https://0.0.0.0:8443',
+                'local_cert' => $symlink,
+                'local_pk' => $this->tempDir . '/key.pem',
+            ],
+        );
+    }
+
+    public function testSymlinkedKeyPathThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not be a symlink');
+
+        $certFile = $this->tempDir . '/cert.pem';
+        touch($certFile);
+        $keyFile = $this->tempDir . '/key.pem';
+        touch($keyFile);
+        $symlink = $this->tempDir . '/key-symlink.pem';
+        symlink($keyFile, $symlink);
+
+        new ServerWorker(
+            $this->createKernelFactory(),
+            null,
+            null,
+            [
+                'name' => 'test-server',
+                'listen' => 'https://0.0.0.0:8443',
+                'local_cert' => $certFile,
+                'local_pk' => $symlink,
+            ],
+        );
     }
 
     public function testCorrectSslConfigurationDoesNotThrow(): void


### PR DESCRIPTION
## Description

SSL certificate and key paths in ServerWorker were validated only with is_readable(). They were not checked for is_file() nor for !is_link(). An attacker (or a misconfiguration) who controls the configuration could point the cert/key to a FIFO, a device file (/dev/random, /dev/zero), or a symlink pointing somewhere unintended.

## Changes

- **src/Worker/ServerWorker.php**: Added is_link() and is_file() checks before is_readable() in createSslContext()
- **tests/ServerWorkerTest.php**: Added 4 new tests (non-regular cert/key, symlinked cert/key), updated 2 existing unreadable tests
- **docs/security.md**: Added SSL Certificate and Key Validation section

Closes #286