### PR TITLE
[Code Quality] Remove redundant function_exists checks in InotifyMonitorWatcher

### DIFF
--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -48,46 +48,42 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
      */
     private function onNotify(mixed $inotifyFd): void
     {
-        if (function_exists('inotify_read')) {
-            $events = \inotify_read($inotifyFd) ?: [];
+        $events = \inotify_read($inotifyFd) ?: [];
 
-            if ($this->reloadCallback instanceof \Closure) {
-                return;
+        if ($this->reloadCallback instanceof \Closure) {
+            return;
+        }
+
+        foreach ($events as $event) {
+            if ($this->isFlagSet($event['mask'], IN_IGNORED)) {
+                unset($this->pathByWd[$event['wd']]);
+                continue;
             }
 
-            foreach ($events as $event) {
-                if ($this->isFlagSet($event['mask'], IN_IGNORED)) {
-                    unset($this->pathByWd[$event['wd']]);
-                    continue;
-                }
-
-                if ($this->isFlagSet($event['mask'], IN_CREATE | IN_ISDIR)) {
-                    $this->watchDir($this->pathByWd[$event['wd']] . '/' . $event['name']);
-                    continue;
-                }
-
-                if (!$this->checkPattern($event['name'])) {
-                    continue;
-                }
-
-                $this->reloadCallback = function (): void {
-                    $this->reloadCallback = null;
-                    $this->reload();
-                };
-
-                $this->worker::$globalEvent?->delay(self::RELOAD_DELAY, $this->reloadCallback);
-
-                return;
+            if ($this->isFlagSet($event['mask'], IN_CREATE | IN_ISDIR)) {
+                $this->watchDir($this->pathByWd[$event['wd']] . '/' . $event['name']);
+                continue;
             }
+
+            if (!$this->checkPattern($event['name'])) {
+                continue;
+            }
+
+            $this->reloadCallback = function (): void {
+                $this->reloadCallback = null;
+                $this->reload();
+            };
+
+            $this->worker::$globalEvent?->delay(self::RELOAD_DELAY, $this->reloadCallback);
+
+            return;
         }
     }
 
     private function watchDir(string $path): void
     {
-        if (function_exists('inotify_add_watch')) {
-            $wd = \inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
-            $this->pathByWd[$wd] = $path;
-        }
+        $wd = \inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
+        $this->pathByWd[$wd] = $path;
     }
 
     private function isFlagSet(int $check, int $flag): bool

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -113,20 +113,6 @@ final class InotifyMonitorWatcherTest extends TestCase
         $this->assertCount(0, $pathByWd, 'pathByWd should be empty when inotify is not available');
     }
 
-    public function testOnNotifyIsNoOpWhenInotifyReadNotAvailable(): void
-    {
-        if (function_exists('inotify_read')) {
-            $this->markTestSkipped('Inotify is available on this system; this test checks the no-extension path');
-        }
-
-        $watcher = $this->createWatcherInstance();
-
-        $this->invokeOnNotify($watcher, null);
-
-        $reloadCallback = $this->getPrivateProperty($watcher, 'reloadCallback');
-        $this->assertNull($reloadCallback, 'reloadCallback should remain null when inotify_read is not available');
-    }
-
     // ---- Tests that require inotify extension (skipped on macOS) ----
 
     /**


### PR DESCRIPTION
## Description

`start()` already gates the entire watcher on `function_exists('inotify_init')`. Since `inotify_read()` and `inotify_add_watch()` belong to the same PHP extension, they are guaranteed to exist when `onNotify()` or `watchDir()` are called.

## Changes

1. **`InotifyMonitorWatcher::onNotify()`**: Removed the redundant `if (function_exists('inotify_read'))` wrapper — the body now runs unconditionally.
2. **`InotifyMonitorWatcher::watchDir()`**: Removed the redundant `if (function_exists('inotify_add_watch'))` check — the function call now runs unconditionally.
3. **`InotifyMonitorWatcherTest`**: Removed `testOnNotifyIsNoOpWhenInotifyReadNotAvailable` — tests an impossible scenario (given `start()` guards registration on extension availability).

## Acceptance criteria

- [x] `function_exists('inotify_read')` is called zero times (was called in `onNotify()`).
- [x] Both `function_exists('inotify_add_watch')` guards are removed.
- [x] Existing tests pass (`vendor/bin/phpunit`).
- [x] No behavioural change observable in inotify-based file monitoring.

Closes #341