### PR TITLE
[Code Quality] ConfigLoader::getConfig: split into named methods, replace silent empty-fallback with exception

### DIFF
--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 final class ConfigLoader implements CacheWarmerInterface
 {
-    /** @var mixed[] */
+    /** @var array<string, mixed[]> */
     private array $config;
     private readonly ConfigCache $cache;
     private readonly string $yamlConfigFilePath;
@@ -59,28 +59,38 @@ final class ConfigLoader implements CacheWarmerInterface
     /** @return array<string, mixed[]> */
     private function getConfig(): array
     {
-        // If config was set directly via setters, return it without filesystem access.
-        if (isset($this->config)) {
-            return $this->config;
-        }
+        return $this->loadFromMemory()
+            ?? $this->loadFromCache()
+            ?? $this->loadFresh();
+    }
 
-        // Config not set in memory — load from cache file.
+    /** @return array<string, mixed[]>|null */
+    private function loadFromMemory(): ?array
+    {
+        return $this->config ?? null;
+    }
+
+    /** @return array<string, mixed[]>|null */
+    private function loadFromCache(): ?array
+    {
         $cachePath = $this->cache->getPath();
-        if (is_file($cachePath)) {
-            return $this->config = require $cachePath;
+        if (!is_file($cachePath)) {
+            return null;
         }
 
-        // Cache not available and config not injected. This is reachable when a fresh
-        // ConfigLoader is constructed outside the DI container and no cache has been
-        // warmed up yet. Returning empty sections is intentional so downstream getters
-        // do not error; the caller is responsible for treating "empty config" as
-        // "no Workerman configuration".
-        return $this->config = [
-            ConfigSection::WORKERMAN->value => [],
-            ConfigSection::PROCESS->value => [],
-            ConfigSection::SCHEDULER->value => [],
-            ConfigSection::BUILD->value => [],
-        ];
+        /** @var array<string, mixed[]> $cached */
+        $cached = require $cachePath;
+
+        return $this->config = $cached;
+    }
+
+    /** @return array<string, mixed[]> */
+    private function loadFresh(): array
+    {
+        throw new \LogicException(
+            'Configuration not available: no config has been set via setters and no cached '
+            . 'config file exists. Ensure the cache has been warmed up before accessing config.',
+        );
     }
 
     /** @param mixed[] $config */

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -211,4 +211,42 @@ final class ConfigLoaderTest extends TestCase
 
         $this->assertSame($buildConfig, $loader->getBuildConfig());
     }
+
+    public function testLoadFromCacheReturnsConfigWhenCacheFileExists(): void
+    {
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $config = [
+            'server' => ['listen' => 'http://0.0.0.0:8080'],
+        ];
+        $loaderA->setWorkermanConfig($config);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        // Create loader B (no config set via setters) — should load from cache
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $this->assertSame($config, $loaderB->getWorkermanConfig());
+    }
+
+    public function testLoadFreshThrowsWhenNoConfigAndNoCache(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Configuration not available');
+
+        $loader->getWorkermanConfig();
+    }
+
+    public function testLoadFreshThrowsForAnyGetterWhenNoConfigAndNoCache(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Configuration not available');
+
+        $loader->getProcessConfig();
+    }
 }


### PR DESCRIPTION
## Description

Refactors `ConfigLoader::getConfig()` to split the three configuration resolution paths into individually named, unit-testable private methods:

- `loadFromMemory()` — returns config previously set via setters
- `loadFromCache()` — loads config from the Symfony ConfigCache file
- `loadFresh()` — throws a `LogicException` when no configuration is available

The silent empty-fallback (returning `[]` for all sections) has been replaced with a `LogicException` so callers fail loudly when no configuration has been provided or cached, rather than silently operating with empty config.

Closes #325

## Changes

- `src/ConfigLoader.php`: refactored `getConfig()` into three named methods, fixed property type from `mixed[]` to `array<string, mixed[]>`, added phpstan type assertion in cache-loading path
- `tests/ConfigLoaderTest.php`: added three tests covering the in-memory, cache-loading, and exception paths

## Acceptance criteria

- [x] `getConfig()` is a thin orchestrator; the three paths are individually named and unit-testable
- [x] The empty-fallback raises a typed exception (`LogicException`)
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change for the in-memory and cache-file paths
- [x] phpstan passes at max level on changed file