### PR TITLE
[Code Quality] ConfigLoader: move setBuildConfig into setters block

### DIFF
--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -111,6 +111,12 @@ final class ConfigLoader implements CacheWarmerInterface
         $this->config[ConfigSection::SCHEDULER->value] = $config;
     }
 
+    /** @param mixed[] $config */
+    public function setBuildConfig(array $config): void
+    {
+        $this->config[ConfigSection::BUILD->value] = $config;
+    }
+
     /** @return mixed[] */
     public function getWorkermanConfig(): array
     {
@@ -121,12 +127,6 @@ final class ConfigLoader implements CacheWarmerInterface
     public function getProcessConfig(): array
     {
         return $this->getConfig()[ConfigSection::PROCESS->value];
-    }
-
-    /** @param mixed[] $config */
-    public function setBuildConfig(array $config): void
-    {
-        $this->config[ConfigSection::BUILD->value] = $config;
     }
 
     /** @return mixed[] */


### PR DESCRIPTION
## Description

`setBuildConfig()` was positioned between getters (`getWorkermanConfig`, `getProcessConfig`), breaking the setter-then-getter ordering convention in `ConfigLoader`.

## What changed

- Moved `setBuildConfig()` right after `setSchedulerConfig()`
- All setters (lines 97-118) now precede all getters (lines 120-142)

## Acceptance criteria

- [x] Method ordering in ConfigLoader is consistent (setters together, getters together)
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change observable to users

Closes #329