### PR TITLE
[Docs] Add class-level PHPDoc to start/error events (#335)

### DIFF
--- a/src/Event/ProcessErrorEvent.php
+++ b/src/Event/ProcessErrorEvent.php
@@ -6,6 +6,19 @@ namespace CrazyGoat\WorkermanBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * Dispatched when a supervised process throws an exception.
+ *
+ * Listeners receive the thrown exception, the service class name, and
+ * the process name. The error is not re-thrown — the child process will
+ * exit with code 1 after the event has been dispatched.
+ *
+ * This is an extension point — use it to implement post-failure logic
+ * such as logging, alerting, or metrics.
+ *
+ * @see ProcessStartEvent Fired before the process runs
+ * @see \CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait The dispatch site in the shared invoke flow
+ */
 final class ProcessErrorEvent extends Event
 {
     public function __construct(private \Throwable $error, private readonly string $serviceClass, private readonly string $processName)

--- a/src/Event/ProcessStartEvent.php
+++ b/src/Event/ProcessStartEvent.php
@@ -6,6 +6,20 @@ namespace CrazyGoat\WorkermanBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * Dispatched right before a supervised process is started.
+ *
+ * Listeners receive the fully-qualified service class name and the
+ * configured process name. The event is fired after the service has been
+ * resolved from the container but before the configured method is
+ * invoked.
+ *
+ * This is an extension point — use it to implement pre-process logic
+ * such as logging, metrics, or dynamic configuration changes.
+ *
+ * @see ProcessErrorEvent Fired when the process throws
+ * @see \CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait The dispatch site in the shared invoke flow
+ */
 final class ProcessStartEvent extends Event
 {
     public function __construct(private readonly string $serviceClass, private readonly string $processName)

--- a/src/Event/TaskErrorEvent.php
+++ b/src/Event/TaskErrorEvent.php
@@ -6,6 +6,19 @@ namespace CrazyGoat\WorkermanBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * Dispatched when a scheduled task throws an exception.
+ *
+ * Listeners receive the thrown exception, the service class name, and
+ * the task name. The error is not re-thrown — the child process will
+ * exit with code 1 after the event has been dispatched.
+ *
+ * This is an extension point — use it to implement post-failure logic
+ * such as logging, alerting, or metrics.
+ *
+ * @see TaskStartEvent Fired before the task runs
+ * @see \CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait The dispatch site in the shared invoke flow
+ */
 final class TaskErrorEvent extends Event
 {
     public function __construct(

--- a/src/Event/TaskStartEvent.php
+++ b/src/Event/TaskStartEvent.php
@@ -6,6 +6,20 @@ namespace CrazyGoat\WorkermanBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * Dispatched right before a scheduled task is executed.
+ *
+ * Listeners receive the fully-qualified service class name and the
+ * configured task name. The event is fired after the service has been
+ * resolved from the container but before the configured method is
+ * invoked.
+ *
+ * This is an extension point — use it to implement pre-task logic
+ * such as logging, metrics, or dynamic configuration changes.
+ *
+ * @see TaskErrorEvent Fired when the task throws
+ * @see \CrazyGoat\WorkermanBundle\Handler\ServiceHandlerTrait The dispatch site in the shared invoke flow
+ */
 final class TaskStartEvent extends Event
 {
     public function __construct(private readonly string $serviceClass, private readonly string $taskName)


### PR DESCRIPTION
## Description

Closes #335

Adds class-level PHPDoc to all four lifecycle events in the bundle:

- **TaskStartEvent** — dispatched before a scheduled task runs
- **TaskErrorEvent** — dispatched when a scheduled task throws
- **ProcessStartEvent** — dispatched before a supervised process starts
- **ProcessErrorEvent** — dispatched when a supervised process throws

Each PHPDoc explains:
- When the event fires (before invocation / on failure)
- What data listeners receive
- That this is a public extension point for pre/post logic
- A cross-reference to the companion event and the dispatch site in ServiceHandlerTrait

## Verification
- 12 relevant tests pass (`TaskHandlerTest`, `ProcessHandlerTest`)
- No behavioural change — only documentation added
- Only 54 lines of PHPDoc added across 4 files