### PR TITLE
[Code Quality] Correct InotifyMonitorWatcher::$pathByWd PHPDoc type from string[] to array<int, string>

### DIFF
--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -12,7 +12,7 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
     private const RELOAD_DELAY = 0.33;
     /** @var resource */
     private $fd;
-    /** @var string[] */
+    /** @var array<int, string> */
     private array $pathByWd = [];
     private \Closure|null $reloadCallback = null;
 


### PR DESCRIPTION
## Description

Fixes #347

`InotifyMonitorWatcher::$pathByWd` is keyed by inotify watch descriptors (integers), but was typed as `string[]`. This corrects it to `array<int, string>`.

The `$fd` property already has the correct `@var resource` annotation and accessor types are consistent.

## Acceptance criteria

- [x] PHPDoc on `$pathByWd` is `array<int, string>`
- [x] No PHPStan regression (`level 8` passes with 0 errors)
- [x] Existing tests pass (43/43, 1 skipped — inotify not available)
- [x] No behavioural change observable to users