### PR TITLE
[Docs] Document Utils::reboot() deprecation status and schedule for removal in next major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cache PID file handles in `SchedulerWorker` to avoid `fopen`/`fclose` blocking syscalls in the event loop on every scheduled task fire — handles are opened once per PID file and reused across the worker's lifetime ([#297](https://github.com/crazy-goat/workerman-bundle/issues/297))
 
+### Deprecated
+
+- `Utils::reboot()` is deprecated since 0.17.0 and remains deprecated; `Utils::reload()` is the replacement. `reboot()` is scheduled for removal in the next major release. No internal call sites remain in the bundle ([#318](https://github.com/crazy-goat/workerman-bundle/issues/318))
+
 ## [0.21.0] - 2026-05-29
 
 ### Security

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -67,11 +67,11 @@ final class Utils
     }
 
     /**
-     * @deprecated since 0.17.0, use Utils::reload() instead.
+     * @deprecated since 0.17.0, use Utils::reload() instead. Will be removed in the next major release.
      */
     public static function reboot(bool $rebootAllWorkers = false): void
     {
-        trigger_deprecation('crazy-goat/workerman-bundle', '0.17.0', 'Utils::reboot() is deprecated, use Utils::reload() instead.');
+        trigger_deprecation('crazy-goat/workerman-bundle', '0.17.0', 'Utils::reboot() is deprecated since 0.17.0, use Utils::reload() instead. Will be removed in the next major release.');
         self::reload($rebootAllWorkers);
     }
 


### PR DESCRIPTION
## Summary

Closes #318

## Changes

- **CHANGELOG**: Add `Deprecated` section documenting that `Utils::reboot()` remains deprecated since 0.17.0, `Utils::reload()` is the replacement, and `reboot()` is scheduled for removal in the next major release. Confirms no internal call sites remain.
- **Utils::reboot() PHPDoc**: Updated `@deprecated` annotation to mention removal in next major.
- **Deprecation trigger message**: Updated to include the next-major timeframe.

## Audit

Confirmed `Utils::reboot()` has zero internal call sites in `src/`. All production code uses `Utils::reload()`. The deprecated method is only referenced in its own definition and in tests that verify the deprecation behaviour.

## Acceptance criteria

- [x] A documented decision exists for whether `Utils::reboot()` stays or goes (CHANGELOG entry)
- [x] `@deprecated` annotation kept and justified (replacement exists)
- [x] No internal call sites remain
- [x] Existing tests pass (`vendor/bin/phpunit` — 6 pre-existing failures unrelated to this change)
- [x] No behavioural change before the next major