### PR TITLE
[Docs] Add class-level and constructor PHPDoc to AsTask and AsProcess attributes

### DIFF
--- a/src/Attribute/AsProcess.php
+++ b/src/Attribute/AsProcess.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Attribute;
 
+/**
+ * Marks a service class as a managed process for the Workerman supervisor.
+ *
+ * Apply this attribute to any service class registered in the container to have
+ * the supervisor spawn and manage one or more persistent child processes. The
+ * supervisor monitors these processes and restarts them on failure.
+ *
+ * This attribute is consumed by ServicesConfigurator::configureAutoConfiguration()
+ * which registers the `workerman.process` tag for each annotated class. The tag
+ * is then picked up by the supervisor at runtime.
+ *
+ * @see ServicesConfigurator::configureAutoConfiguration()
+ */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsProcess
 {
+    /**
+     * @param string|null $name       A human-readable name for the process.
+     *                                If null, the service ID is used.
+     * @param int|null    $processes  Number of child processes to spawn.
+     *                                Defaults to 1 when null.
+     * @param string|null $method     The method to call on each process start.
+     *                                Defaults to `__invoke` when null.
+     */
     public function __construct(
         public ?string $name = null,
         public ?int $processes = null,

--- a/src/Attribute/AsTask.php
+++ b/src/Attribute/AsTask.php
@@ -4,9 +4,35 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Attribute;
 
+/**
+ * Marks a service class as a scheduled task for the Workerman scheduler.
+ *
+ * Apply this attribute to any service class registered in the container to
+ * have it executed on a recurring schedule. The scheduler (see
+ * SchedulerWorker) resolves tagged services and invokes them according to
+ * the schedule expression.
+ *
+ * This attribute is consumed by ServicesConfigurator::configureAutoConfiguration()
+ * which registers the `workerman.task` tag for each annotated class. The tag
+ * is then picked up by the scheduler at runtime.
+ *
+ * @see ServicesConfigurator::configureAutoConfiguration()
+ */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsTask
 {
+    /**
+     * @param string|null $name     A human-readable name for the task. If null,
+     *                              the service ID is used as the display name.
+     * @param string|null $schedule A cron-expression or human-readable interval
+     *                              (e.g. `'0 * * * *'`, `'@daily'`, `'1 second'`).
+     *                              If null the task is skipped with a warning.
+     * @param string|null $method   The method to call on the service.
+     *                              Defaults to `__invoke` when null.
+     * @param int|null    $jitter   Random delay in seconds added to the scheduled
+     *                              time to spread out task execution. 0 means no
+     *                              jitter. Null defaults to 0.
+     */
     public function __construct(
         public ?string $name = null,
         public ?string $schedule = null,


### PR DESCRIPTION
Closes #309

## What has been added/changed

- **AsTask.php**: Class-level PHPDoc explaining purpose, schedule wiring, and cross-reference to `ServicesConfigurator::configureAutoConfiguration()`. Constructor parameter PHPDoc for `name`, `schedule`, `method`, `jitter`.
- **AsProcess.php**: Class-level PHPDoc explaining purpose, supervisor wiring, and cross-reference to `ServicesConfigurator::configureAutoConfiguration()`. Constructor parameter PHPDoc for `name`, `processes`, `method`.

## Acceptance criteria

- [x] `AsTask` has class-level and constructor-parameter PHPDoc.
- [x] `AsProcess` has class-level and constructor-parameter PHPDoc.
- [x] IDE tooltips show parameter help when applying the attribute.
- [x] No remaining gap between the attribute's importance and its lack of inline documentation.

## Verification

- `vendor/bin/phpunit --filter="AsTask|AsProcess|ServicesConfigurator"` — 49 tests, OK