### PR TITLE
[Docs] Add License section and MIT badge to README (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Utils::reboot()` is deprecated since 0.17.0 and remains deprecated; `Utils::reload()` is the replacement. `reboot()` is scheduled for removal in the next major release. No internal call sites remain in the bundle ([#318](https://github.com/crazy-goat/workerman-bundle/issues/318))
 
+### Docs
+
+- Add License section and MIT badge to README so users can see the project's license at a glance ([#300](https://github.com/crazy-goat/workerman-bundle/issues/300))
+
 ## [0.21.0] - 2026-05-29
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![PHP ^8.2](https://img.shields.io/badge/PHP-^8.2-777bb3.svg?style=flat)
 ![Symfony ^6.4|^7.0|^8.0](https://img.shields.io/badge/Symfony-^6.4|^7.0|^8.0-374151.svg?style=flat)
 [![Tests Status](https://img.shields.io/github/actions/workflow/status/crazy-goat/workerman-bundle/tests.yaml?branch=master)](../../actions/workflows/tests.yaml)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 [Workerman](https://github.com/walkor/workerman) is a high-performance, asynchronous event-driven PHP framework written in pure PHP.  
 This bundle provides a Workerman integration in Symfony, allowing you to easily create a http server, scheduler and supervisor all in one place.
@@ -391,3 +392,7 @@ For an overview of all documentation files, see [docs/](docs/).
 For security-related documentation including Host-header protection and trusted hosts configuration, see [docs/security.md](docs/security.md).
 
 For long-running worker gotchas, state pollution, stale DB connections, blocking IO, and other common issues, see [docs/troubleshooting.md](docs/troubleshooting.md).
+
+## License
+
+This bundle is open-sourced software licensed under the [MIT license](LICENSE).

--- a/tests/BinDirectoryTest.php
+++ b/tests/BinDirectoryTest.php
@@ -51,4 +51,19 @@ final class BinDirectoryTest extends TestCase
         $this->assertNotFalse($content);
         $this->assertStringContainsString('bin/README.md', $content);
     }
+
+    public function testReadmeHasLicenseSection(): void
+    {
+        $content = file_get_contents($this->projectDir . '/README.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('## License', $content);
+        $this->assertStringContainsString('[MIT license](LICENSE)', $content);
+    }
+
+    public function testReadmeHasLicenseBadge(): void
+    {
+        $content = file_get_contents($this->projectDir . '/README.md');
+        $this->assertNotFalse($content);
+        $this->assertStringContainsString('License-MIT', $content);
+    }
 }


### PR DESCRIPTION
Closes #300

## Summary

Adds a License section at the end of README.md linking to the LICENSE file, along with an MIT badge in the header. This ensures users can see the project's license at a glance without opening the LICENSE file directly.

## Changes

- **README.md**: Added `[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)` badge to the header block; added a License section at the end of the file.
- **BinDirectoryTest.php**: Added two tests verifying the README contains the License section and the MIT badge.
- **CHANGELOG.md**: Added Docs entry under [Unreleased].

## Acceptance criteria

- [x] README.md contains a License section naming the license.
- [x] The section links to the LICENSE file.
- [x] No remaining ambiguity about the project's license from the README alone.
- [x] Existing tests pass (pre-existing daemon-dependent failures are unrelated).