### PR TITLE
[Docs] Normalise ** list/emphasis markers to */blockquote in README (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix orphaned footnote notation for php-event extension note in README ([#311](https://github.com/crazy-goat/workerman-bundle/issues/311))
 - Add License section and MIT badge to README so users can see the project's license at a glance ([#300](https://github.com/crazy-goat/workerman-bundle/issues/300))
+- Normalise `**` list/emphasis markers to `*` / blockquote format across the README for consistent rendering ([#310](https://github.com/crazy-goat/workerman-bundle/issues/310))
 
 ## [0.21.0] - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ There are a few restart strategies that are implemented and can be enabled or di
  - **max_requests**  
    Reload worker on every N request to prevent memory leaks.
  - **file_monitor**  
-   Reload all workers each time you change the files**.
+   Reload all workers each time you change the files.
  - **always**  
    Reload worker after each request.
  - **memory**  
@@ -196,7 +196,7 @@ There are a few restart strategies that are implemented and can be enabled or di
          gc_limit: 201326592    # 192 MB
    ```
  
-** It is highly recommended to install the _php-inotify_ extension for file monitoring. Without it, monitoring will work in polling mode, which can be very cpu and disk intensive for large projects.
+> **Note:** It is highly recommended to install the _php-inotify_ extension for file monitoring. Without it, monitoring will work in polling mode, which can be very cpu and disk intensive for large projects.
 
 See all available options for each strategy in the command output.
 ```bash
@@ -316,9 +316,9 @@ Schedule string can be formatted in several ways:
  - An ISO8601 datetime format. Example: _2023-08-01T01:00:00+08:00_
  - An ISO8601 duration format. Example: _PT1M_
  - A relative date format as supported by DateInterval. Example: _1 minutes_
- - A cron expression**. Example: _*/1 * * * *_
+ - A cron expression. Example: _*/1 * * * *_
 
-** Note that you need to install the [dragonmantank/cron-expression](https://github.com/dragonmantank/cron-expression) package if you want to use cron expressions as schedule strings
+> **Note:** You need to install the [dragonmantank/cron-expression](https://github.com/dragonmantank/cron-expression) package if you want to use cron expressions as schedule strings
 
 ```php
 <?php


### PR DESCRIPTION
Resolves #310

## Changes

- Fixed spurious trailing `**` on `file_monitor` list item (line 184) — leftover bold formatting that rendered literally
- Converted standalone `** …` note about php-inotify to `> **Note:**` blockquote (line 199), matching the convention used elsewhere in the README
- Fixed spurious trailing `**` on cron expression list item (line 319) — same leftover bold formatting
- Converted standalone `** …` note about cron-expression package to `> **Note:**` blockquote (line 321), matching the same convention

## Acceptance criteria

- [x] README.md uses a single, consistent marker style in the affected section
- [x] No remaining marker mismatch between consecutive list items
- [x] CHANGELOG.md receives an entry under [Unreleased] documenting the formatting fix

## Verification

- `tests/BinDirectoryTest.php` (7 tests, 15 assertions) passes