### PR TITLE
[#307] ExceptionRebootStrategy no longer retains full Throwable to prevent memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Replace `ExceptionRebootStrategy`'s full `Throwable` storage with a boolean flag to eliminate a memory leak in long-running workers — the previous implementation retained the exception's entire stack trace (including referenced `Request`, controller, and service object graphs) until `shouldReboot()` was consumed ([#307](https://github.com/crazy-goat/workerman-bundle/issues/307))
+
 ## [0.22.0] - 2026-05-30
 
 ### Security

--- a/src/Reboot/Strategy/ExceptionRebootStrategy.php
+++ b/src/Reboot/Strategy/ExceptionRebootStrategy.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class ExceptionRebootStrategy implements RebootStrategyInterface
 {
-    private \Throwable|null $exception = null;
+    private bool $shouldReboot = false;
 
     /**
      * @param array<class-string> $allowedExceptions
@@ -30,14 +30,14 @@ final class ExceptionRebootStrategy implements RebootStrategyInterface
             }
         }
 
-        $this->exception = $event->getThrowable();
+        $this->shouldReboot = true;
     }
 
     public function shouldReboot(): bool
     {
-        $shouldReboot = $this->exception instanceof \Throwable;
-        $this->exception = null;
+        $result = $this->shouldReboot;
+        $this->shouldReboot = false;
 
-        return $shouldReboot;
+        return $result;
     }
 }

--- a/tests/RebootStrategyTest.php
+++ b/tests/RebootStrategyTest.php
@@ -139,6 +139,24 @@ final class RebootStrategyTest extends TestCase
         $this->assertFalse($strategy->shouldReboot(), 'State should be reset after second check');
     }
 
+    public function testExceptionRebootStrategyDoesNotRetainThrowableAfterOnException(): void
+    {
+        $strategy = new ExceptionRebootStrategy();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+
+        $exception = new \RuntimeException('Memory leak test');
+        $weakRef = \WeakReference::create($exception);
+
+        $event = new ExceptionEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $exception);
+        $strategy->onException($event);
+
+        unset($exception, $event);
+
+        $this->assertNull($weakRef->get(), 'ExceptionRebootStrategy must not retain the Throwable after onException()');
+        $this->assertTrue($strategy->shouldReboot());
+    }
+
     public function testExceptionRebootStrategyIgnoresSubRequests(): void
     {
         $strategy = new ExceptionRebootStrategy();


### PR DESCRIPTION
## Description

Replaces the  field in  with a  flag to eliminate a memory leak in long-running workers.

**Problem:** The previous implementation stored the full  (including its entire stack trace with all referenced objects — , controller, EntityManager, etc.) in  from  until  was consumed. In a long-running worker that never restarts between exceptions, this caused unbounded memory growth.

**Fix:** Store only a boolean flag indicating that a reboot is needed. The underlying  is never retained, so its transitive object graph is immediately eligible for GC.

## Changes

- : Replace  with 
- : Add  — uses  to verify the Throwable is not kept alive
- : Add entry under [Unreleased] > Performance

## Acceptance criteria

- [x] After every request $this->exception is null (or holds at most the lightweight summary), verifiable with an instrumented test
- [x] Behavior preserved (the strategy still triggers a reboot on the request that produced an exception)
- [x] Unit tests verify the memory-clearing behaviour
- [x] No new memory growth across requests including injected exceptions
- [x] Existing tests pass
- [x] CHANGELOG.md receives an entry under [Unreleased] describing the memory leak fix

Closes #307