### PR TITLE
[Docs] Update README main example to demonstrate StaticFilesMiddleware instead of deprecated serve_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ExceptionRebootStrategy`'s full `Throwable` storage with a boolean flag to eliminate a memory leak in long-running workers — the previous implementation retained the exception's entire stack trace (including referenced `Request`, controller, and service object graphs) until `shouldReboot()` was consumed ([#307](https://github.com/crazy-goat/workerman-bundle/issues/307))
 - Cache `method_exists()` results per (class, method) pair in `ServiceHandlerTrait` to avoid redundant reflection lookups on every tick/invocation in `TaskHandler` and `ProcessHandler` ([#315](https://github.com/crazy-goat/workerman-bundle/issues/315))
 
+### Docs
+
+- Update README main configuration example to demonstrate `StaticFilesMiddleware` instead of relying on the deprecated `serve_files` option; the replacement was previously only shown in a dedicated subsection ([#342](https://github.com/crazy-goat/workerman-bundle/issues/342))
+
 ## [0.22.0] - 2026-05-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ $ bin/console config:dump-reference workerman
 ```
 
 ```yaml
-# config/packages/workerman.yaml
+# config/services.yaml
+services:
+  workerman.middleware.static_files:
+    class: CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware
+    arguments:
+      $rootDirectory: '%kernel.project_dir%/public'
 
+# config/packages/workerman.yaml
 workerman:
   servers:
     - name: 'Symfony webserver'
       listen: http://127.0.0.1:8080
       processes: 4
+      middlewares:
+        - workerman.middleware.static_files
 
   reload_strategy:
     exception:


### PR DESCRIPTION
- Fixes #342
- Update main configuration example in README with StaticFilesMiddleware service definition and middleware reference
- Add CHANGELOG entry under [Unreleased] Docs
- Existing tests pass (vendor/bin/phpunit)