### PR TITLE
[Performance] Gate memory_reset_peak_usage() behind boot-time flag (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- Gate `memory_reset_peak_usage()` behind a boot-time flag so the per-request syscall is skipped when no reboot strategy needs `memory_get_peak_usage()` — currently no bundled strategy uses peak memory, so the call is eliminated entirely on the hot path ([#317](https://github.com/crazy-goat/workerman-bundle/issues/317))
 - Replace `ExceptionRebootStrategy`'s full `Throwable` storage with a boolean flag to eliminate a memory leak in long-running workers — the previous implementation retained the exception's entire stack trace (including referenced `Request`, controller, and service object graphs) until `shouldReboot()` was consumed ([#307](https://github.com/crazy-goat/workerman-bundle/issues/307))
 - Cache `method_exists()` results per (class, method) pair in `ServiceHandlerTrait` to avoid redundant reflection lookups on every tick/invocation in `TaskHandler` and `ProcessHandler` ([#315](https://github.com/crazy-goat/workerman-bundle/issues/315))
 

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -69,11 +69,18 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
      */
     private ?\Closure $pipeline = null;
 
+    /**
+     * Whether to call memory_reset_peak_usage() on each request.
+     * Determined at construction time by querying the reboot strategy.
+     */
+    private readonly bool $resetPeakUsage;
+
     public function __construct(
         private readonly SymfonyController         $controller,
         private readonly RebootStrategyInterface   $rebootStrategy,
         private readonly ?LoggerInterface          $logger = null,
     ) {
+        $this->resetPeakUsage = $rebootStrategy->needsPeakMemory();
     }
 
     public function withMiddlewares(MiddlewareInterface ...$middlewares): self
@@ -198,7 +205,9 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
      */
     public function __invoke(TcpConnection $connection, Request $request): void
     {
-        \memory_reset_peak_usage();
+        if ($this->resetPeakUsage) {
+            \memory_reset_peak_usage();
+        }
 
         // 1. Dispatch through middleware chain → controller
         $controllerCall = fn(Request $input): Http\Response => ($this->controller)($input, $connection);

--- a/src/Reboot/Strategy/AlwaysRebootStrategy.php
+++ b/src/Reboot/Strategy/AlwaysRebootStrategy.php
@@ -10,4 +10,9 @@ final class AlwaysRebootStrategy implements RebootStrategyInterface
     {
         return true;
     }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
 }

--- a/src/Reboot/Strategy/ExceptionRebootStrategy.php
+++ b/src/Reboot/Strategy/ExceptionRebootStrategy.php
@@ -40,4 +40,9 @@ final class ExceptionRebootStrategy implements RebootStrategyInterface
 
         return $result;
     }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
 }

--- a/src/Reboot/Strategy/MaxJobsRebootStrategy.php
+++ b/src/Reboot/Strategy/MaxJobsRebootStrategy.php
@@ -22,4 +22,9 @@ final class MaxJobsRebootStrategy implements RebootStrategyInterface
     {
         return ++$this->jobsCount > $this->maxJobs;
     }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
 }

--- a/src/Reboot/Strategy/MemoryRebootStrategy.php
+++ b/src/Reboot/Strategy/MemoryRebootStrategy.php
@@ -18,6 +18,11 @@ final class MemoryRebootStrategy implements RebootStrategyInterface
     ) {
     }
 
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
+
     public function shouldReboot(): bool
     {
         $memoryUsage = memory_get_usage();

--- a/src/Reboot/Strategy/RebootStrategyInterface.php
+++ b/src/Reboot/Strategy/RebootStrategyInterface.php
@@ -7,4 +7,12 @@ namespace CrazyGoat\WorkermanBundle\Reboot\Strategy;
 interface RebootStrategyInterface
 {
     public function shouldReboot(): bool;
+
+    /**
+     * Whether this strategy needs memory_get_peak_usage() to be reset
+     * on every request. When no strategy needs it, the HttpRequestHandler
+     * skips the memory_reset_peak_usage() call entirely, saving a syscall
+     * on the hot path.
+     */
+    public function needsPeakMemory(): bool;
 }

--- a/src/Reboot/Strategy/StackRebootStrategy.php
+++ b/src/Reboot/Strategy/StackRebootStrategy.php
@@ -23,4 +23,15 @@ final readonly class StackRebootStrategy implements RebootStrategyInterface
 
         return false;
     }
+
+    public function needsPeakMemory(): bool
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->needsPeakMemory()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -162,10 +162,34 @@ final class HttpHandlerTestKernel implements KernelInterface, TerminableInterfac
 final class TestRebootStrategy implements RebootStrategyInterface
 {
     public bool $shouldReboot = false;
+    public bool $needsPeakMemory = false;
 
     public function shouldReboot(): bool
     {
         return $this->shouldReboot;
+    }
+
+    public function needsPeakMemory(): bool
+    {
+        return $this->needsPeakMemory;
+    }
+}
+
+/**
+ * Test reboot strategy that always needs peak memory.
+ */
+final class TestPeakMemoryRebootStrategy implements RebootStrategyInterface
+{
+    public bool $shouldReboot = false;
+
+    public function shouldReboot(): bool
+    {
+        return $this->shouldReboot;
+    }
+
+    public function needsPeakMemory(): bool
+    {
+        return true;
     }
 }
 
@@ -598,6 +622,50 @@ final class HttpRequestHandlerTest extends TestCase
             $this->kernel->terminateCalled,
             'Kernel terminate should be called on every request (no more timer deferral)',
         );
+    }
+
+    // ──────────────────────────────────────────────
+    // memory_reset_peak_usage gating
+    // ──────────────────────────────────────────────
+
+    public function testMemoryResetPeakUsageIsSkippedWhenNoStrategyNeedsIt(): void
+    {
+        $this->rebootStrategy->needsPeakMemory = false;
+
+        $reflection = new \ReflectionClass($this->handler);
+        $property = $reflection->getProperty('resetPeakUsage');
+
+        $this->assertFalse(
+            $property->getValue($this->handler),
+            'resetPeakUsage should be false when no strategy needs peak memory',
+        );
+    }
+
+    public function testMemoryResetPeakUsageIsCalledWhenStrategyNeedsIt(): void
+    {
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $peakStrategy = new TestPeakMemoryRebootStrategy();
+        $handler = new HttpRequestHandler($controller, $peakStrategy);
+
+        $reflection = new \ReflectionClass($handler);
+        $property = $reflection->getProperty('resetPeakUsage');
+
+        $this->assertTrue(
+            $property->getValue($handler),
+            'resetPeakUsage should be true when a strategy needs peak memory',
+        );
+    }
+
+    public function testMemoryResetPeakUsageGatingDoesNotAffectRequestHandling(): void
+    {
+        // With needsPeakMemory = false, the handler should still process requests normally
+        $connection = new MockTcpConnection();
+        $request = new Request(self::HTTP11);
+
+        ($this->handler)($connection, $request);
+
+        $this->assertCount(1, $connection->sentData, 'Response should be sent regardless of peak memory gating');
+        $this->assertStringContainsString('Test response', $connection->sentData[0]);
     }
 
     // ──────────────────────────────────────────────

--- a/tests/RebootStrategyTest.php
+++ b/tests/RebootStrategyTest.php
@@ -349,6 +349,11 @@ final class RebootStrategyTest extends TestCase
             {
                 return false;
             }
+
+            public function needsPeakMemory(): bool
+            {
+                return false;
+            }
         };
 
         $strategy = new StackRebootStrategy([$neverReboot, $neverReboot]);
@@ -366,6 +371,11 @@ final class RebootStrategyTest extends TestCase
             public function shouldReboot(): bool
             {
                 ++$this->callCount;
+                return false;
+            }
+
+            public function needsPeakMemory(): bool
+            {
                 return false;
             }
 


### PR DESCRIPTION
Closes #317

## Summary

Adds a `needsPeakMemory(): bool` method to `RebootStrategyInterface` so each strategy can declare whether it needs `memory_get_peak_usage()` to be reset. The `HttpRequestHandler` queries this at construction time and skips the `memory_reset_peak_usage()` call entirely on every request when no strategy needs peak memory.

Currently no bundled strategy uses peak memory (`MemoryRebootStrategy` uses `memory_get_usage()`), so the per-request syscall is eliminated on the hot path.

## Changes

- **RebootStrategyInterface:** add `needsPeakMemory(): bool`  
- **All 5 strategy implementations:** return `false` from `needsPeakMemory()`  
- **StackRebootStrategy:** aggregate `needsPeakMemory()` across children  
- **HttpRequestHandler:** gate `memory_reset_peak_usage()` behind a `resetPeakUsage` flag set at boot time  
- **Tests:** verify gating logic with active/inactive strategies, confirm request handling unaffected  

## Acceptance criteria

- [x] 0 `memory_reset_peak_usage` calls per request when no memory-tracking consumer is active  
- [x] Behavior preserved (the memory reload strategy still works when active)  
- [x] Unit tests verify the gating logic with active/inactive strategies  
- [x] Existing tests pass  
- [x] CHANGELOG.md updated