### PR TITLE
[Code Quality] StaticFilesMiddleware: extract joinPaths() helper with explicit separator handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ExceptionRebootStrategy`'s full `Throwable` storage with a boolean flag to eliminate a memory leak in long-running workers — the previous implementation retained the exception's entire stack trace (including referenced `Request`, controller, and service object graphs) until `shouldReboot()` was consumed ([#307](https://github.com/crazy-goat/workerman-bundle/issues/307))
 - Cache `method_exists()` results per (class, method) pair in `ServiceHandlerTrait` to avoid redundant reflection lookups on every tick/invocation in `TaskHandler` and `ProcessHandler` ([#315](https://github.com/crazy-goat/workerman-bundle/issues/315))
 
+### Code Quality
+
+- `StaticFilesMiddleware`: replace repeated `DIRECTORY_SEPARATOR . ltrim($path, '/')` with a named `joinPaths()` helper that normalises both root and request path separators explicitly, eliminating implicit coupling that would silently produce wrong paths if a future change stripped the leading slash ([#365](https://github.com/crazy-goat/workerman-bundle/issues/365))
+
 ### Docs
 
 - Update README main configuration example to demonstrate `StaticFilesMiddleware` instead of relying on the deprecated `serve_files` option; the replacement was previously only shown in a dedicated subsection ([#342](https://github.com/crazy-goat/workerman-bundle/issues/342))

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -37,7 +37,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
     public function __construct(string $rootDirectory, array $allowedExtensions = [], private bool $followSymlinks = false)
     {
         if ($this->isPharPath($rootDirectory)) {
-            $this->rootRealPath = $rootDirectory;
+            $this->rootRealPath = rtrim($rootDirectory, '\\/');
         } else {
             $resolved = realpath($rootDirectory);
             if ($resolved === false) {
@@ -191,18 +191,14 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
             unset($cache[$cacheIndex]);
         }
 
-        if ($this->isPharPath($this->rootRealPath)) {
-            $resolved = $this->rootRealPath . DIRECTORY_SEPARATOR . ltrim($cacheKey, '/');
-            if (!file_exists($resolved)) {
-                $resolved = false;
-            }
-        } else {
-            $path = $this->rootRealPath . DIRECTORY_SEPARATOR . ltrim($cacheKey, '/');
+        $path = $this->joinPaths($this->rootRealPath, $cacheKey);
 
+        if ($this->isPharPath($this->rootRealPath)) {
+            $resolved = file_exists($path) ? $path : false;
+        } else {
             if (!$this->followSymlinks) {
-                $components = explode('/', ltrim($cacheKey, '/'));
                 $checkPath = $this->rootRealPath;
-                foreach ($components as $component) {
+                foreach (explode('/', ltrim($cacheKey, '/')) as $component) {
                     if ($component === '' || $component === '.') {
                         continue;
                     }
@@ -231,6 +227,11 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         }
 
         return $resolved;
+    }
+
+    private function joinPaths(string $root, string $path): string
+    {
+        return rtrim($root, '\\/') . DIRECTORY_SEPARATOR . ltrim($path, '\\/');
     }
 
     private function isPharPath(string $path): bool

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -827,6 +827,72 @@ final class StaticFilesMiddlewareTest extends TestCase
         $this->assertInstanceOf(StaticFilesMiddleware::class, $middleware);
     }
 
+    public function testJoinPathsWithRootTrailingSlash(): void
+    {
+        $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public');
+
+        $reflection = new \ReflectionMethod($middleware, 'joinPaths');
+        $result = $reflection->invoke($middleware, 'phar:///test/app.phar/public/', '/sub/file.txt');
+
+        $this->assertSame('phar:///test/app.phar/public' . DIRECTORY_SEPARATOR . 'sub/file.txt', $result);
+    }
+
+    public function testJoinPathsWithRequestPathMissingLeadingSlash(): void
+    {
+        $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public');
+
+        $reflection = new \ReflectionMethod($middleware, 'joinPaths');
+
+        $result = $reflection->invoke($middleware, 'phar:///test/app.phar/public', 'sub/file.txt');
+
+        $this->assertSame('phar:///test/app.phar/public' . DIRECTORY_SEPARATOR . 'sub/file.txt', $result);
+    }
+
+    public function testJoinPathsWithBothRootTrailingSlashAndNoLeadingSlash(): void
+    {
+        $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public');
+
+        $reflection = new \ReflectionMethod($middleware, 'joinPaths');
+
+        $result = $reflection->invoke($middleware, 'phar:///test/app.phar/public/', 'sub/file.txt');
+
+        $this->assertSame('phar:///test/app.phar/public' . DIRECTORY_SEPARATOR . 'sub/file.txt', $result);
+    }
+
+    public function testJoinPathsWithRootNoTrailingSlashAndLeadingSlash(): void
+    {
+        $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public');
+
+        $reflection = new \ReflectionMethod($middleware, 'joinPaths');
+
+        $result = $reflection->invoke($middleware, 'phar:///test/app.phar/public', '/sub/file.txt');
+
+        $this->assertSame('phar:///test/app.phar/public' . DIRECTORY_SEPARATOR . 'sub/file.txt', $result);
+    }
+
+    public function testJoinPathsWithPharPathHavingTrailingSlashConstructed(): void
+    {
+        $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public/');
+
+        $reflection = new \ReflectionProperty($middleware, 'rootRealPath');
+        $rootRealPath = $reflection->getValue($middleware);
+
+        $this->assertStringEndsNotWith('/', $rootRealPath);
+        $this->assertStringEndsNotWith('\\', $rootRealPath);
+    }
+
+    public function testJoinPathsWithFilesystemRoot(): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+        $reflection = new \ReflectionMethod($middleware, 'joinPaths');
+
+        $root = realpath($this->rootDirectory);
+        $result = $reflection->invoke($middleware, $root . '/', '/test.txt');
+
+        $this->assertSame($root . DIRECTORY_SEPARATOR . 'test.txt', $result);
+    }
+
     public function testPharPathNonExistentFilePassesToNext(): void
     {
         $middleware = new StaticFilesMiddleware('phar:///test/app.phar/public');


### PR DESCRIPTION
## What

Replace the repeated `DIRECTORY_SEPARATOR . ltrim($path, '/')` pattern in `StaticFilesMiddleware` with a named `joinPaths()` helper that explicitly normalises both root and request path separators.

## Why

The previous inline concatenation at `src/Middleware/StaticFilesMiddleware.php:200` worked only because the request path always starts with '/'. The coupling was implicit — a future change that strips the leading slash would silently produce wrong paths.

## Acceptance criteria

- [x] Path concatenation is performed by a small, named helper
- [x] Root path trailing slash is normalised (via `rtrim` in constructor for phar paths, `realpath` for filesystem paths)
- [x] Request path leading/trailing slashes are normalised via `ltrim`
- [x] Unit tests cover root with/without trailing slash
- [x] Unit tests cover request path with/without leading slash
- [x] Unit tests cover phar path with trailing slash in constructor
- [x] Existing tests pass (`vendor/bin/phpunit`)
- [x] No behavioural change observable to users for currently-served paths
- [x] CHANGELOG.md updated

Closes #365