### PR TITLE
[Security] Remove @unlink error suppression in BinaryFileResponseStrategy; log failures via PSR-3 (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Remove `@unlink` error suppression in `BinaryFileResponseStrategy` cleanup callback; unlink failures are now checked and logged through the injected PSR-3 logger ([#314](https://github.com/crazy-goat/workerman-bundle/issues/314))
+
 ### Performance
 
 - Gate `memory_reset_peak_usage()` behind a boot-time flag so the per-request syscall is skipped when no reboot strategy needs `memory_get_peak_usage()` — currently no bundled strategy uses peak memory, so the call is eliminated entirely on the hot path ([#317](https://github.com/crazy-goat/workerman-bundle/issues/317))

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -11,6 +11,7 @@ use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
 use CrazyGoat\WorkermanBundle\Command\BuildPharCommand;
 use CrazyGoat\WorkermanBundle\Command\WorkermanCommand;
 use CrazyGoat\WorkermanBundle\ConfigLoader;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\BinaryFileResponseReflector;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\BinaryFileResponseStrategy;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
@@ -254,8 +255,16 @@ final readonly class ServicesConfigurator
     private function configureResponseStrategies(ContainerBuilder $container): void
     {
         $container
+            ->register('workerman.binary_file_response_reflector', BinaryFileResponseReflector::class)
+        ;
+
+        $container
             ->register('workerman.binary_file_response_strategy', BinaryFileResponseStrategy::class)
             ->addTag('workerman.response_converter.strategy', ['priority' => 100])
+            ->setArguments([
+                new Reference('workerman.binary_file_response_reflector'),
+                new Reference('logger'),
+            ])
         ;
 
         $container

--- a/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Http\Response\Strategy;
 
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverterStrategyInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Workerman\Connection\TcpConnection;
@@ -23,6 +25,7 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
 {
     public function __construct(
         private BinaryFileResponseReflector $reflector = new BinaryFileResponseReflector(),
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -60,7 +63,7 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
             $filePath = $file->getPathname();
 
             $workermanResponse->withFile($filePath, $offset ?? 0, $maxlen ?? 0);
-            $connection->onClose = $this->createCleanupCallback($filePath, $connection->onClose);
+            $connection->onClose = $this->createCleanupCallback($filePath, $connection->onClose, $this->logger);
 
             return $workermanResponse;
         }
@@ -74,16 +77,19 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
         return $workermanResponse;
     }
 
-    private function createCleanupCallback(string $filePath, mixed $previousOnClose): \Closure
+    private function createCleanupCallback(string $filePath, mixed $previousOnClose, LoggerInterface $logger): \Closure
     {
-        return static function () use ($filePath, $previousOnClose): void {
+        return static function () use ($filePath, $previousOnClose, $logger): void {
             try {
                 if (is_callable($previousOnClose)) {
                     $previousOnClose();
                 }
             } finally {
-                if (is_file($filePath)) {
-                    @unlink($filePath);
+                if (is_file($filePath) && !unlink($filePath)) {
+                    $logger->warning('Failed to delete temporary file after send', [
+                        'path' => $filePath,
+                        'error' => error_get_last()['message'] ?? 'Unknown error',
+                    ]);
                 }
             }
         };

--- a/tests/Strategy/BinaryFileResponseStrategyTest.php
+++ b/tests/Strategy/BinaryFileResponseStrategyTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Test\Strategy;
 
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\BinaryFileResponseStrategy;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Workerman\Connection\TcpConnection;
@@ -311,5 +312,72 @@ final class BinaryFileResponseStrategyTest extends TestCase
         ], $this->connection);
 
         $this->assertSame(404, $workermanResponse->getStatusCode());
+    }
+
+    public function testConvertLogsWarningWhenUnlinkFails(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                'Failed to delete temporary file after send',
+                $this->callback(fn(array $context): bool => isset($context['path']) && is_string($context['path'])),
+            );
+
+        $strategy = new BinaryFileResponseStrategy(logger: $logger);
+
+        // Create a directory, put a file in it, then make directory read-only
+        $dir = sys_get_temp_dir() . '/unlink_test_' . uniqid();
+        mkdir($dir, 0777);
+        $tempFile = $dir . '/file.txt';
+        file_put_contents($tempFile, 'should fail to unlink');
+        chmod($dir, 0555);
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onCloseCallback = $this->connection->onClose;
+        assert(is_callable($onCloseCallback));
+
+        // Suppress PHP warning from unlink() on read-only directory
+        set_error_handler(static fn(): true => true);
+        try {
+            $onCloseCallback();
+        } finally {
+            restore_error_handler();
+        }
+
+        // Restore permissions for cleanup
+        chmod($dir, 0777);
+        @unlink($tempFile);
+        rmdir($dir);
+    }
+
+    public function testConvertDoesNotLogWhenUnlinkSucceeds(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $strategy = new BinaryFileResponseStrategy(logger: $logger);
+
+        $tempFile = sys_get_temp_dir() . '/unlink_success_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'should unlink fine');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onCloseCallback = $this->connection->onClose;
+        assert(is_callable($onCloseCallback));
+        $onCloseCallback();
+
+        $this->assertFileDoesNotExist($tempFile);
     }
 }


### PR DESCRIPTION
## Summary

- Remove  error suppression operator from  in  cleanup callback
- Check  return value and log failures through injected PSR-3 logger
- Add optional  parameter to constructor (defaults to )
- Register  as a named service for proper DI wiring

## Related Issue

Closes #314

## Changes

- : Remove , add return value check + logger warning
- : Register reflector service, inject logger into strategy
- : Add positive test (no log on success) and negative test (unlink failure logged)
- : Add entry under [Unreleased] Security section