### PR TITLE
test(core): expand StreamedBinaryFileResponseTest with comprehensive coverage (closes #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- Expand `StreamedBinaryFileResponseTest` with comprehensive test coverage: content type detection, Content-Length verification, Content-Disposition, offset/maxlen behavior, `deleteFileAfterSend` cleanup, output correctness for small and large files, chunk size validation, auto ETag/Last-Modified headers, and edge cases (empty file, non-readable file, private responses) ([#353](https://github.com/crazy-goat/workerman-bundle/issues/353))
+
 ### Security
 
 - Remove `@unlink` error suppression in `BinaryFileResponseStrategy` cleanup callback; unlink failures are now checked and logged through the injected PSR-3 logger ([#314](https://github.com/crazy-goat/workerman-bundle/issues/314))

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
         "php-cs-fixer/shim": "^3.75",
         "phpunit/phpunit": "^10.4",
         "rector/rector": "^2.0",
-        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-        "symfony/mime": "^6.4|^7.0|^8.1"
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0"
     },
     "suggest": {
         "ext-event": "For better performance",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "php-cs-fixer/shim": "^3.75",
         "phpunit/phpunit": "^10.4",
         "rector/rector": "^2.0",
-        "symfony/framework-bundle": "^6.4|^7.0|^8.0"
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+        "symfony/mime": "^6.4|^7.0|^8.1"
     },
     "suggest": {
         "ext-event": "For better performance",

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -24,7 +24,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         if (is_dir($this->fixtureDir)) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($this->fixtureDir, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::CHILD_FIRST
+                \RecursiveIteratorIterator::CHILD_FIRST,
             );
             foreach ($files as $fileinfo) {
                 if ($fileinfo->isDir()) {
@@ -136,7 +136,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
             200,
             [],
             true,
-            ResponseHeaderBag::DISPOSITION_ATTACHMENT
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
         );
 
         $disposition = $response->headers->get('Content-Disposition');

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\WorkermanBundle\Test;
 use CrazyGoat\WorkermanBundle\Protocol\Http\Response\StreamedBinaryFileResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 final class StreamedBinaryFileResponseTest extends TestCase
@@ -15,7 +16,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->fixtureDir = sys_get_temp_dir() . '/sfr_test_' . uniqid();
+        $this->fixtureDir = sys_get_temp_dir() . '/sbfr_test_' . uniqid();
         mkdir($this->fixtureDir, 0777, true);
     }
 
@@ -55,6 +56,10 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
     public function testContentTypeIsAutomaticallyDetectedForTextFile(): void
     {
+        if (!class_exists(\Symfony\Component\Mime\MimeTypes::class)) {
+            $this->markTestSkipped('symfony/mime is required for MIME type auto-detection.');
+        }
+
         $testFile = $this->createFixtureFile('test.txt', 'Hello, World!');
         $response = new StreamedBinaryFileResponse($testFile);
 
@@ -66,6 +71,10 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
     public function testContentTypeIsAutomaticallyDetectedForHtmlFile(): void
     {
+        if (!class_exists(\Symfony\Component\Mime\MimeTypes::class)) {
+            $this->markTestSkipped('symfony/mime is required for MIME type auto-detection.');
+        }
+
         $testFile = $this->createFixtureFile('test.html', '<html><body>Hello</body></html>');
         $response = new StreamedBinaryFileResponse($testFile);
 
@@ -77,6 +86,10 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
     public function testContentTypeIsOctetStreamForUnknownExtension(): void
     {
+        if (!class_exists(\Symfony\Component\Mime\MimeTypes::class)) {
+            $this->markTestSkipped('symfony/mime is required for MIME type auto-detection.');
+        }
+
         $testFile = $this->createFixtureFile('test.bin', "\x00\x01\x02\x03");
         $response = new StreamedBinaryFileResponse($testFile);
 
@@ -92,6 +105,8 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('test.txt', $content);
         $response = new StreamedBinaryFileResponse($testFile);
 
+        // Set Content-Type before prepare() to avoid MIME type detection dependency
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertSame((string) $expectedLength, $response->headers->get('Content-Length'));
@@ -102,6 +117,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('empty.txt', '');
         $response = new StreamedBinaryFileResponse($testFile);
 
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertSame('0', $response->headers->get('Content-Length'));
@@ -135,7 +151,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('download.zip', 'ZIP content');
         $response = new StreamedBinaryFileResponse(
             $testFile,
-            \Symfony\Component\HttpFoundation\Response::HTTP_OK,
+            Response::HTTP_OK,
             [],
             true,
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
@@ -258,6 +274,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('big.txt', $content);
         $response = new StreamedBinaryFileResponse($testFile);
 
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertSame((string) \strlen($content), $response->headers->get('Content-Length'));
@@ -266,15 +283,15 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testStatusCanBeSet(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_CREATED);
+        $response = new StreamedBinaryFileResponse($testFile, Response::HTTP_CREATED);
 
-        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
     }
 
     public function testCustomHeadersCanBeSet(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, ['X-Custom' => 'value']);
+        $response = new StreamedBinaryFileResponse($testFile, Response::HTTP_OK, ['X-Custom' => 'value']);
 
         $this->assertSame('value', $response->headers->get('X-Custom'));
     }
@@ -299,8 +316,9 @@ final class StreamedBinaryFileResponseTest extends TestCase
     {
         $content = 'ETag test content';
         $testFile = $this->createFixtureFile('etag_test.txt', $content);
-        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], true, null, true);
+        $response = new StreamedBinaryFileResponse($testFile, Response::HTTP_OK, [], true, null, true);
 
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertNotNull($response->getEtag());
@@ -311,6 +329,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('test.txt', 'content');
         $response = new StreamedBinaryFileResponse($testFile);
 
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertNotNull($response->getLastModified());
@@ -319,8 +338,9 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testAutoLastModifiedCanBeDisabled(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], true, null, false, false);
+        $response = new StreamedBinaryFileResponse($testFile, Response::HTTP_OK, [], true, null, false, false);
 
+        $response->headers->set('Content-Type', 'text/plain');
         $response->prepare($this->createRequest());
 
         $this->assertNull($response->getLastModified());
@@ -354,7 +374,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testResponseCanBePrivate(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'private content');
-        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], false);
+        $response = new StreamedBinaryFileResponse($testFile, Response::HTTP_OK, [], false);
 
         $this->assertNull($response->headers->getCacheControlDirective('public'));
     }

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -135,7 +135,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('download.zip', 'ZIP content');
         $response = new StreamedBinaryFileResponse(
             $testFile,
-            200,
+            \Symfony\Component\HttpFoundation\Response::HTTP_OK,
             [],
             true,
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
@@ -266,15 +266,15 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testStatusCanBeSet(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, 201);
+        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_CREATED);
 
-        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
     }
 
     public function testCustomHeadersCanBeSet(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, 200, ['X-Custom' => 'value']);
+        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, ['X-Custom' => 'value']);
 
         $this->assertSame('value', $response->headers->get('X-Custom'));
     }
@@ -299,7 +299,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
     {
         $content = 'ETag test content';
         $testFile = $this->createFixtureFile('etag_test.txt', $content);
-        $response = new StreamedBinaryFileResponse($testFile, 200, [], true, null, true);
+        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], true, null, true);
 
         $response->prepare($this->createRequest());
 
@@ -319,7 +319,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testAutoLastModifiedCanBeDisabled(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'content');
-        $response = new StreamedBinaryFileResponse($testFile, 200, [], true, null, false, false);
+        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], true, null, false, false);
 
         $response->prepare($this->createRequest());
 
@@ -354,7 +354,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
     public function testResponseCanBePrivate(): void
     {
         $testFile = $this->createFixtureFile('test.txt', 'private content');
-        $response = new StreamedBinaryFileResponse($testFile, 200, [], false);
+        $response = new StreamedBinaryFileResponse($testFile, \Symfony\Component\HttpFoundation\Response::HTTP_OK, [], false);
 
         $this->assertNull($response->headers->getCacheControlDirective('public'));
     }
@@ -375,7 +375,6 @@ final class StreamedBinaryFileResponseTest extends TestCase
     private function getDeleteFileAfterSend(BinaryFileResponse $response): bool
     {
         $property = new \ReflectionProperty(BinaryFileResponse::class, 'deleteFileAfterSend');
-        $property->setAccessible(true);
 
         /** @var bool $value */
         $value = $property->getValue($response);

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -6,30 +6,365 @@ namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\Protocol\Http\Response\StreamedBinaryFileResponse;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 final class StreamedBinaryFileResponseTest extends TestCase
 {
+    private string $fixtureDir;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = sys_get_temp_dir() . '/sfr_test_' . uniqid();
+        mkdir($this->fixtureDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->fixtureDir)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->fixtureDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $fileinfo) {
+                if ($fileinfo->isDir()) {
+                    rmdir($fileinfo->getRealPath());
+                } else {
+                    unlink($fileinfo->getRealPath());
+                }
+            }
+            rmdir($this->fixtureDir);
+        }
+    }
+
     public function testCanBeInstantiated(): void
     {
-        $testFile = sys_get_temp_dir() . '/test_streamed_' . uniqid() . '.txt';
-        file_put_contents($testFile, 'test content');
-
+        $testFile = $this->createFixtureFile('test.txt', 'test content');
         $response = new StreamedBinaryFileResponse($testFile);
 
         $this->assertInstanceOf(StreamedBinaryFileResponse::class, $response);
-
-        unlink($testFile);
     }
 
     public function testExtendsBinaryFileResponse(): void
     {
-        $testFile = sys_get_temp_dir() . '/test_streamed_' . uniqid() . '.txt';
-        file_put_contents($testFile, 'test content');
-
+        $testFile = $this->createFixtureFile('test.txt', 'test content');
         $response = new StreamedBinaryFileResponse($testFile);
 
-        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\BinaryFileResponse::class, $response);
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+    }
+
+    public function testContentTypeIsAutomaticallyDetectedForTextFile(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'Hello, World!');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertStringContainsString('text/plain', $response->headers->get('Content-Type', ''));
+    }
+
+    public function testContentTypeIsAutomaticallyDetectedForHtmlFile(): void
+    {
+        $testFile = $this->createFixtureFile('test.html', '<html><body>Hello</body></html>');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertStringContainsString('text/html', $response->headers->get('Content-Type', ''));
+    }
+
+    public function testContentTypeIsOctetStreamForUnknownExtension(): void
+    {
+        $testFile = $this->createFixtureFile('test.bin', "\x00\x01\x02\x03");
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertSame('application/octet-stream', $response->headers->get('Content-Type'));
+    }
+
+    public function testContentLengthMatchesFileSize(): void
+    {
+        $content = 'This is a test file for StreamedBinaryFileResponse!' . \str_repeat('x', 1000);
+        $expectedLength = \strlen($content);
+        $testFile = $this->createFixtureFile('test.txt', $content);
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertSame((string) $expectedLength, $response->headers->get('Content-Length'));
+    }
+
+    public function testContentLengthForEmptyFile(): void
+    {
+        $testFile = $this->createFixtureFile('empty.txt', '');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertSame('0', $response->headers->get('Content-Length'));
+    }
+
+    public function testContentDispositionCanBeSetToAttachment(): void
+    {
+        $testFile = $this->createFixtureFile('document.pdf', '%PDF-1.4 fake content');
+        $response = new StreamedBinaryFileResponse($testFile);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+
+        $disposition = $response->headers->get('Content-Disposition');
+        $this->assertNotNull($disposition);
+        $this->assertStringContainsString('attachment', $disposition);
+        $this->assertStringContainsString('document.pdf', $disposition);
+    }
+
+    public function testContentDispositionCanBeSetToInline(): void
+    {
+        $testFile = $this->createFixtureFile('readme.txt', 'Read me!');
+        $response = new StreamedBinaryFileResponse($testFile);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE);
+
+        $disposition = $response->headers->get('Content-Disposition');
+        $this->assertNotNull($disposition);
+        $this->assertStringContainsString('inline', $disposition);
+    }
+
+    public function testContentDispositionInConstructor(): void
+    {
+        $testFile = $this->createFixtureFile('download.zip', 'ZIP content');
+        $response = new StreamedBinaryFileResponse(
+            $testFile,
+            200,
+            [],
+            true,
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT
+        );
+
+        $disposition = $response->headers->get('Content-Disposition');
+        $this->assertNotNull($disposition);
+        $this->assertStringContainsString('attachment', $disposition);
+    }
+
+    public function testGetFileReturnsExpectedFile(): void
+    {
+        $testFile = $this->createFixtureFile('data.json', '{"key": "value"}');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $file = $response->getFile();
+
+        $this->assertSame($testFile, $file->getPathname());
+    }
+
+    public function testSetChunkSizeAcceptsValidValues(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $result = $response->setChunkSize(8192);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testSetChunkSizeThrowsExceptionForInvalidValues(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $response->setChunkSize(0);
+    }
+
+    public function testDeleteFileAfterSendFlagIsFalseByDefault(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $this->assertFalse($response->deleteFileAfterSend);
+    }
+
+    public function testDeleteFileAfterSendCanBeEnabled(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->deleteFileAfterSend(true);
+
+        $this->assertTrue($response->deleteFileAfterSend);
+    }
+
+    public function testDeleteFileAfterSendDeletesFileAfterSendContent(): void
+    {
+        $testFile = $this->createFixtureFile('delete_me.txt', 'delete me');
+        $response = new StreamedBinaryFileResponse($testFile);
+        $response->deleteFileAfterSend(true);
+
+        $this->assertFileExists($testFile);
+
+        // Capture output from sendContent()
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $this->assertFileDoesNotExist($testFile);
+    }
+
+    public function testFileIsNotDeletedWhenDeleteFileAfterSendIsFalse(): void
+    {
+        $testFile = $this->createFixtureFile('keep_me.txt', 'keep me');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $this->assertFileExists($testFile);
 
         unlink($testFile);
+    }
+
+    public function testSendContentOutputsFullFileContent(): void
+    {
+        $content = 'Hello from StreamedBinaryFileResponse!';
+        $testFile = $this->createFixtureFile('test.txt', $content);
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        ob_start();
+        $response->sendContent();
+        $output = ob_get_clean();
+
+        $this->assertSame($content, $output);
+    }
+
+    public function testSendContentOutputsCorrectLengthForLargeFile(): void
+    {
+        $content = \str_repeat("ABCDEFGHIJ\n", 2000); // ~22KB
+        $testFile = $this->createFixtureFile('large.txt', $content);
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        ob_start();
+        $response->sendContent();
+        $output = ob_get_clean();
+
+        $this->assertSame(\strlen($content), \strlen($output));
+        $this->assertSame($content, $output);
+    }
+
+    public function testPrepareSetsContentLengthForLargeFile(): void
+    {
+        $content = \str_repeat("0123456789\n", 5000); // ~55KB
+        $testFile = $this->createFixtureFile('big.txt', $content);
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertSame((string) \strlen($content), $response->headers->get('Content-Length'));
+    }
+
+    public function testStatusCanBeSet(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile, 201);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public function testCustomHeadersCanBeSet(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile, 200, ['X-Custom' => 'value']);
+
+        $this->assertSame('value', $response->headers->get('X-Custom'));
+    }
+
+    public function testFileNotReadableThrowsException(): void
+    {
+        $testFile = $this->fixtureDir . '/unreadable.txt';
+        file_put_contents($testFile, 'secret');
+        chmod($testFile, 0000);
+
+        $this->expectException(\Symfony\Component\HttpFoundation\File\Exception\FileException::class);
+
+        try {
+            new StreamedBinaryFileResponse($testFile);
+        } finally {
+            chmod($testFile, 0644);
+            unlink($testFile);
+        }
+    }
+
+    public function testAutoEtagHeaderIsSetWhenRequested(): void
+    {
+        $content = 'ETag test content';
+        $testFile = $this->createFixtureFile('etag_test.txt', $content);
+        $response = new StreamedBinaryFileResponse($testFile, 200, [], true, null, true);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertNotNull($response->getEtag());
+    }
+
+    public function testAutoLastModifiedHeaderIsSetByDefault(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertNotNull($response->getLastModified());
+    }
+
+    public function testAutoLastModifiedCanBeDisabled(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile, 200, [], true, null, false, false);
+
+        $response->prepare($this->createRequest());
+
+        $this->assertNull($response->getLastModified());
+    }
+
+    public function testSetContentThrowsException(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $this->expectException(\LogicException::class);
+        $response->setContent('not allowed');
+    }
+
+    public function testGetContentReturnsFalse(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $this->assertFalse($response->getContent());
+    }
+
+    public function testResponseIsPublicByDefault(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'public content');
+        $response = new StreamedBinaryFileResponse($testFile);
+
+        $this->assertTrue($response->headers->getCacheControlDirective('public'));
+    }
+
+    public function testResponseCanBePrivate(): void
+    {
+        $testFile = $this->createFixtureFile('test.txt', 'private content');
+        $response = new StreamedBinaryFileResponse($testFile, 200, [], false);
+
+        $this->assertNull($response->headers->getCacheControlDirective('public'));
+    }
+
+    private function createFixtureFile(string $filename, string $content): string
+    {
+        $path = $this->fixtureDir . '/' . $filename;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    private function createRequest(): \Symfony\Component\HttpFoundation\Request
+    {
+        return \Symfony\Component\HttpFoundation\Request::create('http://localhost/test');
     }
 }

--- a/tests/StreamedBinaryFileResponseTest.php
+++ b/tests/StreamedBinaryFileResponseTest.php
@@ -60,7 +60,8 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
         $response->prepare($this->createRequest());
 
-        $this->assertStringContainsString('text/plain', $response->headers->get('Content-Type', ''));
+        $contentType = (string) $response->headers->get('Content-Type', '');
+        $this->assertStringContainsString('text/plain', $contentType);
     }
 
     public function testContentTypeIsAutomaticallyDetectedForHtmlFile(): void
@@ -70,7 +71,8 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
         $response->prepare($this->createRequest());
 
-        $this->assertStringContainsString('text/html', $response->headers->get('Content-Type', ''));
+        $contentType = (string) $response->headers->get('Content-Type', '');
+        $this->assertStringContainsString('text/html', $contentType);
     }
 
     public function testContentTypeIsOctetStreamForUnknownExtension(): void
@@ -178,7 +180,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $testFile = $this->createFixtureFile('test.txt', 'content');
         $response = new StreamedBinaryFileResponse($testFile);
 
-        $this->assertFalse($response->deleteFileAfterSend);
+        $this->assertFalse($this->getDeleteFileAfterSend($response));
     }
 
     public function testDeleteFileAfterSendCanBeEnabled(): void
@@ -188,7 +190,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
 
         $response->deleteFileAfterSend(true);
 
-        $this->assertTrue($response->deleteFileAfterSend);
+        $this->assertTrue($this->getDeleteFileAfterSend($response));
     }
 
     public function testDeleteFileAfterSendDeletesFileAfterSendContent(): void
@@ -231,6 +233,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $response->sendContent();
         $output = ob_get_clean();
 
+        $this->assertNotFalse($output);
         $this->assertSame($content, $output);
     }
 
@@ -244,6 +247,7 @@ final class StreamedBinaryFileResponseTest extends TestCase
         $response->sendContent();
         $output = ob_get_clean();
 
+        $this->assertNotFalse($output);
         $this->assertSame(\strlen($content), \strlen($output));
         $this->assertSame($content, $output);
     }
@@ -366,5 +370,16 @@ final class StreamedBinaryFileResponseTest extends TestCase
     private function createRequest(): \Symfony\Component\HttpFoundation\Request
     {
         return \Symfony\Component\HttpFoundation\Request::create('http://localhost/test');
+    }
+
+    private function getDeleteFileAfterSend(BinaryFileResponse $response): bool
+    {
+        $property = new \ReflectionProperty(BinaryFileResponse::class, 'deleteFileAfterSend');
+        $property->setAccessible(true);
+
+        /** @var bool $value */
+        $value = $property->getValue($response);
+
+        return $value;
     }
 }


### PR DESCRIPTION
## Description

Closes #353

Expands `StreamedBinaryFileResponseTest` from 2 basic instantiation tests to **30 tests** covering:

- Content-Type auto-detection (text, HTML, binary fallback)
- Content-Length verification (small, empty, large files)
- Content-Disposition (attachment, inline, constructor injection)
- Streamed output correctness (small and large files)
- `deleteFileAfterSend` flag behavior and file cleanup
- Chunk size validation (valid and invalid values)
- Auto ETag and Last-Modified headers
- Public/private cache directives
- Edge cases: non-readable file exception, invalid chunk size, `setContent()`/`getContent()` contract

Also:
- Added `symfony/mime` dev dependency (required by `BinaryFileResponse::prepare()` for MIME type detection)
- Updated CHANGELOG under [Unreleased]

## Changes

- `tests/StreamedBinaryFileResponseTest.php` — comprehensive test coverage (30 tests, 38 assertions)
- `composer.json` — added `symfony/mime` dev dependency
- `CHANGELOG.md` — added entry under [Unreleased] Tests section

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed
