### PR TITLE
fix(core): rename inner closure param to avoid shadowing outer $args (closes #366)

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -19,6 +19,6 @@ final readonly class Resolver implements ResolverInterface
     {
         [$app, $args] = $this->resolver->resolve();
 
-        return [static fn(...$args): KernelFactory => new KernelFactory(...$args), [$app, $args, $this->options]];
+        return [static fn(...$kernelArgs): KernelFactory => new KernelFactory(...$kernelArgs), [$app, $args, $this->options]];
     }
 }


### PR DESCRIPTION
## Description

Closes #366

## Changes

- Renamed inner closure parameter `...$args` to `...$kernelArgs` in `Resolver::resolve()` to eliminate variable shadowing

## Changelog

Added `Fixed` entry in CHANGELOG.md under `[Unreleased]`

## Code Review

- [x] Passed subagent code review
- [x] All linters pass (php-cs-fixer, phpstan, rector)
- [x] All existing tests pass