### PR TITLE
fix(core): standardise tag set ordering in WorkermanCompilerPass (closes #371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Code Quality
 
 - `StaticFilesMiddleware`: replace repeated `DIRECTORY_SEPARATOR . ltrim($path, '/')` with a named `joinPaths()` helper that normalises both root and request path separators explicitly, eliminating implicit coupling that would silently produce wrong paths if a future change stripped the leading slash ([#365](https://github.com/crazy-goat/workerman-bundle/issues/365))
+- `WorkermanCompilerPass`: standardise tag set ordering — `$responseConverterStrategies` remain sorted by priority (descending) for correct dispatch order in `ResponseConverter::convert()`, while `$tasks`, `$processes`, and `$rebootStrategies` are now sorted by service ID via `ksort` for deterministic ServiceLocator registration and reproducible container builds ([#371](https://github.com/crazy-goat/workerman-bundle/issues/371))
 
 ### Docs
 

--- a/src/DependencyInjection/WorkermanCompilerPass.php
+++ b/src/DependencyInjection/WorkermanCompilerPass.php
@@ -25,7 +25,17 @@ final class WorkermanCompilerPass implements CompilerPassInterface
         $processesTagged = $container->findTaggedServiceIds('workerman.process');
         $rebootStrategies = $container->findTaggedServiceIds('workerman.reboot_strategy');
         $responseConverterStrategies = $container->findTaggedServiceIds('workerman.response_converter.strategy');
+
+        // Sort response converter strategies by priority (descending) so that
+        // higher-priority strategies are checked first in ResponseConverter::convert().
         uasort($responseConverterStrategies, fn(array $a, array $b): int => ($b[0]['priority'] ?? 0) <=> ($a[0]['priority'] ?? 0));
+
+        // Sort remaining tag sets by service ID for deterministic ordering in
+        // the ServiceLocator registrations. Tasks and processes do not carry a
+        // priority attribute; sorting by ID ensures reproducible container builds.
+        ksort($tasksTagged);
+        ksort($processesTagged);
+        ksort($rebootStrategies);
 
         $tasks = array_map(fn(array $a): array => $a[0], $tasksTagged);
         $processes = array_map(fn(array $a): array => $a[0], $processesTagged);

--- a/tests/DependencyInjection/WorkermanCompilerPassTest.php
+++ b/tests/DependencyInjection/WorkermanCompilerPassTest.php
@@ -224,4 +224,65 @@ final class WorkermanCompilerPassTest extends TestCase
         $this->assertArrayHasKey('strategy.a', $references);
         $this->assertArrayHasKey('strategy.b', $references);
     }
+
+    public function testTasksAndProcessesAreSortedDeterministically(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->container->register('z.last', \stdClass::class)->addTag('workerman.task');
+        $this->container->register('a.first', \stdClass::class)->addTag('workerman.task');
+        $this->container->register('m.middle', \stdClass::class)->addTag('workerman.task');
+
+        $this->container->register('p.process.z', \stdClass::class)->addTag('workerman.process');
+        $this->container->register('p.process.a', \stdClass::class)->addTag('workerman.process');
+
+        $this->compilerPass->process($this->container);
+
+        $taskLocator = $this->container->getDefinition('workerman.task_locator');
+        $taskReferences = array_keys($taskLocator->getArguments()[0]);
+        $this->assertSame(['a.first', 'm.middle', 'z.last'], $taskReferences, 'Tasks must be sorted by service ID');
+
+        $processLocator = $this->container->getDefinition('workerman.process_locator');
+        $processReferences = array_keys($processLocator->getArguments()[0]);
+        $this->assertSame(['p.process.a', 'p.process.z'], $processReferences, 'Processes must be sorted by service ID');
+    }
+
+    public function testRebootStrategiesAreSortedDeterministically(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->container->register('strategy.z', \stdClass::class)->addTag('workerman.reboot_strategy');
+        $this->container->register('strategy.a', \stdClass::class)->addTag('workerman.reboot_strategy');
+
+        $this->compilerPass->process($this->container);
+
+        $rebootStrategy = $this->container->getDefinition('workerman.reboot_strategy');
+        $references = array_keys($rebootStrategy->getArguments()[0]);
+        $this->assertSame(['strategy.a', 'strategy.z'], $references, 'Reboot strategies must be sorted by service ID');
+    }
+
+    public function testResponseConverterStrategiesRetainPriorityOrder(): void
+    {
+        $this->container->register('workerman.config_loader', \stdClass::class);
+
+        $this->container->register('strategy.low', \stdClass::class)
+            ->addTag('workerman.response_converter.strategy', ['priority' => 0]);
+        $this->container->register('strategy.high', \stdClass::class)
+            ->addTag('workerman.response_converter.strategy', ['priority' => 100]);
+        $this->container->register('strategy.medium', \stdClass::class)
+            ->addTag('workerman.response_converter.strategy', ['priority' => 50]);
+        // Register another low-priority strategy to verify stable sort behavior
+        $this->container->register('strategy.low.another', \stdClass::class)
+            ->addTag('workerman.response_converter.strategy', ['priority' => 0]);
+
+        $this->compilerPass->process($this->container);
+
+        $responseConverter = $this->container->getDefinition('workerman.response_converter');
+        $references = array_keys($responseConverter->getArguments()[0]);
+
+        // Expected: descending priority (100, 50, 0, 0). For equal priorities,
+        // uasort preserves insertion order (low before low.another).
+        $expected = ['strategy.high', 'strategy.medium', 'strategy.low', 'strategy.low.another'];
+        $this->assertSame($expected, $references, 'Response converter strategies must be sorted by priority descending');
+    }
 }


### PR DESCRIPTION
## Description

Closes #371

## Changes

- Add `ksort()` for `$tasksTagged`, `$processesTagged`, and `$rebootStrategies` to ensure deterministic ordering by service ID in ServiceLocator registrations
- Keep `uasort()` by priority (descending) for `$responseConverterStrategies` — this ordering is semantically important for `ResponseConverter::convert()` dispatch order
- Add inline comments explaining the sorting rationale for each tag set
- Add unit tests verifying:
  - Tasks and processes are sorted by service ID
  - Reboot strategies are sorted by service ID
  - Response converter strategies retain priority order with stable sort behavior

## Changelog

WorkermanCompilerPass: standardise tag set ordering — $responseConverterStrategies remain sorted by priority (descending) for correct dispatch order in ResponseConverter::convert(), while $tasks, $processes, and $rebootStrategies are now sorted by service ID via ksort for deterministic ServiceLocator registration and reproducible container builds

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed