### PR TITLE
docs: document composer test port binding and troubleshooting in CONTRIBUTING.md (closes #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - Update "What's new in this fork" section in `README.md` with a comprehensive comparison against upstream `luzrain/workerman-bundle`, covering 20+ feature additions, dependency differences, and architectural changes ([#491](https://github.com/crazy-goat/workerman-bundle/issues/491))
+- Document `composer test` port binding, troubleshooting steps, and workarounds in `CONTRIBUTING.md` to help contributors avoid "Address already in use" errors ([#358](https://github.com/crazy-goat/workerman-bundle/issues/358))
 
 - Update README main configuration example to demonstrate `StaticFilesMiddleware` instead of relying on the deprecated `serve_files` option; the replacement was previously only shown in a dedicated subsection ([#342](https://github.com/crazy-goat/workerman-bundle/issues/342))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,25 @@ rm .git/hooks/pre-push
    composer test
    ```
 
-   Note: `composer test` boots a real Workerman daemon binding ports 8888 and
-   9999 for E2E tests. If you see "Address already in use" errors, ensure
-   those ports are free.
+   Note: `composer test` boots a real Workerman daemon binding ports **8888** and
+   **9999** for end-to-end HTTP tests. The ports are hardcoded in
+   `tests/App/Kernel.php` and cannot be overridden via environment variables.
+
+   > **Troubleshooting "Address already in use"**
+   > - Find the process occupying the port: `lsof -i :8888` or `ss -tlnp | grep 8888`
+   > - Stop the conflicting service or kill the process (e.g. `kill <PID>`)
+   > - If a previous test run was interrupted, a Workerman daemon may still be
+   >   running in the background. Stop it manually:
+   >   ```bash
+   >   php tests/App/index.php stop
+   >   ```
+   > - To run tests without starting the daemon (you are responsible for starting
+   >   it yourself beforehand), run only phpunit:
+   >   ```bash
+   >   vendor/bin/phpunit
+   >   ```
+   > - On macOS, ports below 1024 require root. Ports 8888 and 9999 are above
+   >   that threshold and should work without special privileges.
 
 3. Ensure all checks pass before pushing
 


### PR DESCRIPTION
## Description

Closes #358

## Changes

- Enhanced the `composer test` note in `CONTRIBUTING.md` with:
  - Clear port numbers (8888, 9999) and mention they are hardcoded
  - Troubleshooting steps for "Address already in use" errors
  - Commands to find and free occupied ports
  - How to stop a stray Workerman daemon after an interrupted test run
  - How to run tests without starting the daemon manually
- Added CHANGELOG entry under [Unreleased] Docs section

## Changelog

- Document `composer test` port binding and troubleshooting in `CONTRIBUTING.md`

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed