### PR TITLE
fix(core): replace falsy object check with instanceof in TriggerFactory (closes #361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Code Quality
 
+- `TriggerFactory`: replace falsy object check (`if ($dateTime)`) with explicit `instanceof \DateTimeImmutable` check to clarify that the branch is taken only when ISO-8601 datetime parsing succeeds, and to avoid relying on object truthiness ([#361](https://github.com/crazy-goat/workerman-bundle/issues/361))
 - `StaticFilesMiddleware`: replace repeated `DIRECTORY_SEPARATOR . ltrim($path, '/')` with a named `joinPaths()` helper that normalises both root and request path separators explicitly, eliminating implicit coupling that would silently produce wrong paths if a future change stripped the leading slash ([#365](https://github.com/crazy-goat/workerman-bundle/issues/365))
 - `WorkermanCompilerPass`: standardise tag set ordering — `$responseConverterStrategies` remain sorted by priority (descending) for correct dispatch order in `ResponseConverter::convert()`, while `$tasks`, `$processes`, and `$rebootStrategies` are now sorted by service ID via `ksort` for deterministic ServiceLocator registration and reproducible container builds ([#371](https://github.com/crazy-goat/workerman-bundle/issues/371))
 

--- a/src/Scheduler/Trigger/TriggerFactory.php
+++ b/src/Scheduler/Trigger/TriggerFactory.php
@@ -31,7 +31,7 @@ final class TriggerFactory
     {
         if (is_string($expression)) {
             $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $expression);
-            if ($dateTime) {
+            if ($dateTime instanceof \DateTimeImmutable) {
                 $expression = $dateTime;
             }
         }

--- a/tests/TriggerFactoryTest.php
+++ b/tests/TriggerFactoryTest.php
@@ -144,4 +144,13 @@ final class TriggerFactoryTest extends TestCase
 
         TriggerFactory::create('* * * *');
     }
+
+    public function testInvalidIso8601StringFallsThroughToPeriodicalAndThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid interval');
+
+        // A string that is neither valid ISO8601 datetime, nor cron, nor valid interval
+        TriggerFactory::create('not-a-date-or-interval');
+    }
 }


### PR DESCRIPTION
## Description

Closes #361

## Changes

- Replace `if ()` (falsy object check) with `if ( instanceof \DateTimeImmutable)` in `TriggerFactory::create()`
- Add test for invalid ISO-8601 datetime string fallback path

## Changelog

```
### Code Quality

- `TriggerFactory`: replace falsy object check (`if ()`) with explicit `instanceof \DateTimeImmutable` check ([#361](https://github.com/crazy-goat/workerman-bundle/issues/361))
```

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed