### PR TITLE
fix: use === true consistently for boolean config flags in ServicesConfigurator (closes #370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StaticFilesMiddleware`: replace repeated `DIRECTORY_SEPARATOR . ltrim($path, '/')` with a named `joinPaths()` helper that normalises both root and request path separators explicitly, eliminating implicit coupling that would silently produce wrong paths if a future change stripped the leading slash ([#365](https://github.com/crazy-goat/workerman-bundle/issues/365))
 - `WorkermanCompilerPass`: standardise tag set ordering — `$responseConverterStrategies` remain sorted by priority (descending) for correct dispatch order in `ResponseConverter::convert()`, while `$tasks`, `$processes`, and `$rebootStrategies` are now sorted by service ID via `ksort` for deterministic ServiceLocator registration and reproducible container builds ([#371](https://github.com/crazy-goat/workerman-bundle/issues/371))
 - `PeriodicalTrigger`: remove fragile `(array)` cast on `\DateInterval` to read the private `from_string` property; replace with a flat `'DateInterval'` description for directly-passed `DateInterval` objects ([#360](https://github.com/crazy-goat/workerman-bundle/issues/360))
+- `ServicesConfigurator`: use `=== true` consistently for all boolean `active` config flags in `configureRebootStrategies()` — previously only `memory.active` used strict comparison, while `always`, `max_requests`, and `exception` used a truthy check ([#370](https://github.com/crazy-goat/workerman-bundle/issues/370))
 
 ### Docs
 

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -127,14 +127,14 @@ final readonly class ServicesConfigurator
      */
     private function configureRebootStrategies(array $config, ContainerBuilder $container): void
     {
-        if ($config['reload_strategy']['always']['active']) {
+        if ($config['reload_strategy']['always']['active'] === true) {
             $container
                 ->register('workerman.always_reboot_strategy', AlwaysRebootStrategy::class)
                 ->addTag('workerman.reboot_strategy')
             ;
         }
 
-        if ($config['reload_strategy']['max_requests']['active']) {
+        if ($config['reload_strategy']['max_requests']['active'] === true) {
             $container
                 ->register('workerman.max_requests_reboot_strategy', MaxJobsRebootStrategy::class)
                 ->addTag('workerman.reboot_strategy')
@@ -145,7 +145,7 @@ final readonly class ServicesConfigurator
             ;
         }
 
-        if ($config['reload_strategy']['exception']['active']) {
+        if ($config['reload_strategy']['exception']['active'] === true) {
             $container
                 ->register('workerman.exception_reboot_strategy', ExceptionRebootStrategy::class)
                 ->addTag('workerman.reboot_strategy')

--- a/tests/DependencyInjection/ServicesConfiguratorTest.php
+++ b/tests/DependencyInjection/ServicesConfiguratorTest.php
@@ -142,6 +142,30 @@ final class ServicesConfiguratorTest extends TestCase
         self::assertSame([134_217_728, 100_663_296, 60], $definition->getArguments());
     }
 
+    public function testConfigureDisablesMemoryRebootStrategyByDefault(): void
+    {
+        $this->configurator->configure($this->getDefaultConfig(), $this->container);
+
+        self::assertFalse($this->container->hasDefinition('workerman.memory_reboot_strategy'));
+    }
+
+    public function testConfigureDisablesMaxRequestsRebootStrategyByDefault(): void
+    {
+        $this->configurator->configure($this->getDefaultConfig(), $this->container);
+
+        self::assertFalse($this->container->hasDefinition('workerman.max_requests_reboot_strategy'));
+    }
+
+    public function testConfigureDisablesExceptionRebootStrategy(): void
+    {
+        $config = $this->getDefaultConfig();
+        $config['reload_strategy']['exception']['active'] = false;
+
+        $this->configurator->configure($config, $this->container);
+
+        self::assertFalse($this->container->hasDefinition('workerman.exception_reboot_strategy'));
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
## Description

Closes #370

## Changes

- Changed all four `active` boolean config checks in `ServicesConfigurator::configureRebootStrategies()` to use `=== true` consistently
- Previously only `memory.active` used strict comparison; `always`, `max_requests`, and `exception` used a truthy check
- Added unit tests verifying disabled-by-default strategies and disabling exception strategy

## Changelog

- `ServicesConfigurator`: use `=== true` consistently for all boolean `active` config flags in `configureRebootStrategies()` — previously only `memory.active` used strict comparison, while `always`, `max_requests`, and `exception` used a truthy check

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed