### PR TITLE
fix(core): move assignment out of if condition in DateTimeTrigger (closes #359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WorkermanCompilerPass`: standardise tag set ordering — `$responseConverterStrategies` remain sorted by priority (descending) for correct dispatch order in `ResponseConverter::convert()`, while `$tasks`, `$processes`, and `$rebootStrategies` are now sorted by service ID via `ksort` for deterministic ServiceLocator registration and reproducible container builds ([#371](https://github.com/crazy-goat/workerman-bundle/issues/371))
 - `PeriodicalTrigger`: remove fragile `(array)` cast on `\DateInterval` to read the private `from_string` property; replace with a flat `'DateInterval'` description for directly-passed `DateInterval` objects ([#360](https://github.com/crazy-goat/workerman-bundle/issues/360))
 - `ServicesConfigurator`: use `=== true` consistently for all boolean `active` config flags in `configureRebootStrategies()` — previously only `memory.active` used strict comparison, while `always`, `max_requests`, and `exception` used a truthy check ([#370](https://github.com/crazy-goat/workerman-bundle/issues/370))
+- `DateTimeTrigger`: move assignment out of `if` condition to eliminate assignment-in-condition smell and avoid potential `=`/`==` confusion ([#359](https://github.com/crazy-goat/workerman-bundle/issues/359))
 
 ### Docs
 

--- a/src/Scheduler/Trigger/DateTimeTrigger.php
+++ b/src/Scheduler/Trigger/DateTimeTrigger.php
@@ -12,7 +12,8 @@ final class DateTimeTrigger implements TriggerInterface
 
     public function __construct(string|\DateTimeImmutable $date)
     {
-        if (is_string($date) && $iso8601Date = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $date)) {
+        $iso8601Date = is_string($date) ? \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $date) : false;
+        if ($iso8601Date !== false) {
             $date = $iso8601Date;
         }
 


### PR DESCRIPTION
## Description

Closes #359

## Changes

- Move the `$iso8601Date = ...createFromFormat(...)` assignment out of the `if` condition in `DateTimeTrigger::__construct()` to eliminate the assignment-in-condition smell
- Keep the same logic: only when `createFromFormat` returns a non-false `DateTimeImmutable` is `$date` replaced
- All existing tests pass without modification

## Changelog

Code Quality: `DateTimeTrigger`: move assignment out of `if` condition to eliminate assignment-in-condition smell and avoid potential `=`/`==` confusion.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed