### PR TITLE
fix(http): add runtime deprecation notice to Request::withHeader() (closes #364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PeriodicalTrigger`: remove fragile `(array)` cast on `\DateInterval` to read the private `from_string` property; replace with a flat `'DateInterval'` description for directly-passed `DateInterval` objects ([#360](https://github.com/crazy-goat/workerman-bundle/issues/360))
 - `ServicesConfigurator`: use `=== true` consistently for all boolean `active` config flags in `configureRebootStrategies()` — previously only `memory.active` used strict comparison, while `always`, `max_requests`, and `exception` used a truthy check ([#370](https://github.com/crazy-goat/workerman-bundle/issues/370))
 - `DateTimeTrigger`: move assignment out of `if` condition to eliminate assignment-in-condition smell and avoid potential `=`/`==` confusion ([#359](https://github.com/crazy-goat/workerman-bundle/issues/359))
+- `Http\Request`: add runtime deprecation notice to `withHeader()` warning that the PSR-7-named alias is misleading — it mutates the request in place rather than returning a new instance; users should migrate to `setHeader()` ([#364](https://github.com/crazy-goat/workerman-bundle/issues/364))
 
 ### Docs
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -11,21 +11,23 @@ namespace CrazyGoat\WorkermanBundle\Http;
  * it decodes the raw HTTP buffer but exposes no public mutators for headers.
  * This subclass adds header-write capability needed by the middleware pipeline:
  *
- *  - {@see setHeader()} writes or overwrites a single header by name.
+ *  - {@see setHeader()} writes or overwrites a single header by name (the primary API).
  *  - {@see withHeader()} is a deprecated alias kept for backward compatibility.
+ *    It emits an `E_USER_DEPRECATED` warning advising use of {@see setHeader()}.
  *
- * Unlike PSR-7's immutable {@see withHeader()}, both methods mutate the request
- * in place and return \$this. This is intentional: the middleware pipeline passes
- * the same Request instance through each layer, and middleware that mutates
- * headers (e.g. trusted-proxy, authentication, routing) needs to affect the
- * instance seen by downstream layers.
+ * **⚠️ PSR-7 semantic mismatch:** Unlike PSR-7's immutable {@see withHeader()},
+ * both methods mutate the request in place and return \$this. The PSR-7 convention
+ * reserves the `with*` prefix for methods that return a **new** instance. This
+ * bundle intentionally deviates because the middleware pipeline passes the same
+ * Request instance through each layer, and middleware that mutates headers
+ * (e.g. trusted-proxy, authentication, routing) needs to affect the instance seen
+ * by downstream layers.
  *
- * **Security caveat:** Because {@see setHeader()}/\{{@see withHeader()} are exposed
- * to every middleware, any middleware can re-inject `X-Forwarded-*` or other
- * hop-by-hop headers after trusted-proxy validation has run. If your application
- * relies on trusted-proxy header filtering, ensure that filtering runs *after*
- * any middleware that calls these methods, or scope-limit which middleware is
- * allowed to set forwarding headers.
+ * **Security caveat:** Because {@see setHeader()} is exposed to every middleware,
+ * any middleware can re-inject `X-Forwarded-*` or other hop-by-hop headers after
+ * trusted-proxy validation has run. If your application relies on trusted-proxy
+ * header filtering, ensure that filtering runs *after* any middleware that calls
+ * these methods, or scope-limit which middleware is allowed to set forwarding headers.
  *
  * @see \Workerman\Protocols\Http\Request The parent read-only request parser.
  * @see \CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface Middleware that receives this request.
@@ -58,16 +60,27 @@ class Request extends \Workerman\Protocols\Http\Request
     }
 
     /**
-     * @deprecated Use setHeader() instead. This method is kept for backward compatibility.
+     * Sets a header value, mutating the current instance.
      *
-     * This method **mutates** the request and returns \$this, mirroring
-     * {@see setHeader()}. This differs from PSR-7's immutable
+     * Alias of {@see setHeader()}. Unlike PSR-7's immutable
      * {@see \Psr\Http\Message\MessageInterface::withHeader()} which returns
-     * a **new** instance. The mutation semantics are intentional for the
-     * middleware pipeline — see the class-level docblock for details.
+     * a **new** instance, this method **mutates** the request in place.
+     *
+     * @deprecated since 0.23.0 Use {@see setHeader()} instead.
+     *             This method will be removed in the next major version.
+     *             The PSR-7 naming is misleading because the mutation semantics
+     *             differ from PSR-7's immutable pattern.
      */
     public function withHeader(string $name, string $value): self
     {
+        trigger_error(
+            \sprintf(
+                'Since crazy-goat/workerman-bundle 0.23.0: %s::withHeader() is deprecated, use setHeader() instead.',
+                self::class,
+            ),
+            \E_USER_DEPRECATED,
+        );
+
         return $this->setHeader($name, $value);
     }
 }

--- a/tests/App/TestMiddleware.php
+++ b/tests/App/TestMiddleware.php
@@ -16,8 +16,8 @@ class TestMiddleware implements MiddlewareInterface
 
     public function __invoke(Request $request, callable $next): Response
     {
-        $request->withHeader($this->headerName, $this->headerValue);
-        $request->withHeader('X-Test-Middleware-request-order', $request->header('X-Test-Middleware-request-order') . $this->headerName . '|');
+        $request->setHeader($this->headerName, $this->headerValue);
+        $request->setHeader('X-Test-Middleware-request-order', $request->header('X-Test-Middleware-request-order') . $this->headerName . '|');
         $response = $next($request);
         $response->header($this->headerName, $this->headerValue);
         return $response;

--- a/tests/MiddlewarePipelineTest.php
+++ b/tests/MiddlewarePipelineTest.php
@@ -215,7 +215,7 @@ final readonly class AddHeaderMiddleware implements MiddlewareInterface
 
     public function __invoke(Request $request, callable $next): WorkermanResponse
     {
-        $request->withHeader($this->header, $this->value);
+        $request->setHeader($this->header, $this->value);
         if ($this->trackKey !== null) {
             $this->tracker->set($this->trackKey, $request->header(strtolower($this->header)));
         }
@@ -255,7 +255,7 @@ final readonly class ReadAndAddHeaderMiddleware implements MiddlewareInterface
     public function __invoke(Request $request, callable $next): WorkermanResponse
     {
         $this->tracker->set($this->trackKey, $request->header($this->readHeaderName));
-        $request->withHeader($this->addHeader, $this->addValue);
+        $request->setHeader($this->addHeader, $this->addValue);
         return $next($request);
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -62,29 +62,69 @@ final class RequestTest extends TestCase
     {
         $request = $this->createRequest('GET', '/');
 
-        $result = $request->withHeader('X-New-Header', 'new-value');
+        $result = @$request->withHeader('X-New-Header', 'new-value');
 
         $this->assertSame('new-value', $request->header('x-new-header'));
         $this->assertSame($request, $result);
     }
 
-    public function testWithHeaderOverwritesExistingHeader(): void
+    public function testWithHeaderTriggersDeprecation(): void
+    {
+        $request = $this->createRequest('GET', '/');
+
+        $deprecationMessage = null;
+        set_error_handler(function (int $errno, string $errstr) use (&$deprecationMessage): bool {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecationMessage = $errstr;
+                return true;
+            }
+            return false;
+        });
+
+        $request->withHeader('X-Test', 'value');
+
+        restore_error_handler();
+
+        $this->assertNotNull($deprecationMessage, 'Expected E_USER_DEPRECATED to be triggered');
+        $this->assertStringContainsString('withHeader() is deprecated', $deprecationMessage);
+    }
+
+    public function testSetHeaderAddsHeader(): void
+    {
+        $request = $this->createRequest('GET', '/');
+
+        $result = $request->setHeader('X-New-Header', 'new-value');
+
+        $this->assertSame('new-value', $request->header('x-new-header'));
+        $this->assertSame($request, $result);
+    }
+
+    public function testSetHeaderOverwritesExistingHeader(): void
     {
         $request = $this->createRequest('GET', '/', ['X-Test' => 'old-value']);
 
-        $request->withHeader('X-Test', 'new-value');
+        $request->setHeader('X-Test', 'new-value');
 
         $this->assertSame('new-value', $request->header('x-test'));
     }
 
-    public function testWithHeaderIsCaseInsensitive(): void
+    public function testSetHeaderIsCaseInsensitive(): void
     {
         $request = $this->createRequest('GET', '/');
 
-        $request->withHeader('X-Mixed-Case', 'value1');
-        $request->withHeader('x-mixed-case', 'value2');
+        $request->setHeader('X-Mixed-Case', 'value1');
+        $request->setHeader('x-mixed-case', 'value2');
 
         $this->assertSame('value2', $request->header('x-mixed-case'));
+    }
+
+    public function testSetHeaderReturnsSameInstance(): void
+    {
+        $request = $this->createRequest('GET', '/');
+
+        $result = $request->setHeader('X-Test', 'value');
+
+        $this->assertSame($request, $result);
     }
 
     public function testHeaderLookupIsCaseInsensitive(): void
@@ -107,7 +147,7 @@ final class RequestTest extends TestCase
     {
         $request = $this->createRequest('GET', '/');
 
-        $result = $request->withHeader('X-Test', 'value');
+        $result = @$request->withHeader('X-Test', 'value');
 
         $this->assertSame($request, $result);
     }
@@ -116,7 +156,7 @@ final class RequestTest extends TestCase
     {
         $request = $this->createRequest('GET', '/');
 
-        $request->withHeader('X-Test', 'value');
+        @$request->withHeader('X-Test', 'value');
 
         $this->assertSame('value', $request->header('x-test'));
     }


### PR DESCRIPTION
## Description

Closes #364

## Changes

- Added `E_USER_DEPRECATED` trigger_error() notice to `Http\Request::withHeader()` warning about PSR-7 semantic mismatch
- Updated class-level PHPDoc to explicitly document that both methods mutate the request (deviating from PSR-7)
- Added unit tests for `setHeader()` as the primary API and for the deprecation notice
- Updated all internal callers (`TestMiddleware`, `MiddlewarePipelineTest`) to use `setHeader()` instead of deprecated alias

## Changelog

- `Http\Request`: add runtime deprecation notice to `withHeader()` warning that the PSR-7-named alias is misleading — it mutates the request in place rather than returning a new instance; users should migrate to `setHeader()`

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed