### PR TITLE
docs(build): document --include-tests and --kernel-class options (closes #331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document `composer test` port binding, troubleshooting steps, and workarounds in `CONTRIBUTING.md` to help contributors avoid "Address already in use" errors ([#358](https://github.com/crazy-goat/workerman-bundle/issues/358))
 
 - Update README main configuration example to demonstrate `StaticFilesMiddleware` instead of relying on the deprecated `serve_files` option; the replacement was previously only shown in a dedicated subsection ([#342](https://github.com/crazy-goat/workerman-bundle/issues/342))
+- Document `--include-tests` and `--kernel-class` CLI options in `docs/build-packaging.md` — these options were already supported by `workerman:build:phar` but omitted from the documentation ([#331](https://github.com/crazy-goat/workerman-bundle/issues/331))
 
 ## [0.22.0] - 2026-05-30
 

--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -173,8 +173,10 @@ The runtime directory defaults to the directory containing the PHAR/BIN file, an
 php bin/console workerman:build:phar [options]
 
 Options:
-  -o, --output-dir=DIR   Output directory (default: config build.build_dir)
-      --filename=NAME    Output filename (default: config build.phar_filename)
+  -o, --output-dir=DIR       Output directory (default: config build.build_dir)
+      --filename=NAME        Output filename (default: config build.phar_filename)
+      --kernel-class=CLASS   Kernel class to use in the PHAR stub (default: config build.kernel_class)
+      --include-tests        Include tests/ directory in the PHAR (for testing only)
 ```
 
 ### `workerman:build:bin`


### PR DESCRIPTION
## Description

Closes #331

## Changes

- Add `--kernel-class` and `--include-tests` options to the `workerman:build:phar` command documentation in `docs/build-packaging.md`
- Add CHANGELOG entry under [Unreleased] Docs

## Changelog

Documented `--include-tests` and `--kernel-class` CLI options in build-packaging.md.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed