### PR TITLE
docs: add PHPDoc to MiddlewareInterface, RebootStrategyInterface, TriggerInterface (closes #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- Add comprehensive interface-level and per-method PHPDoc to `MiddlewareInterface`, `RebootStrategyInterface`, and `TriggerInterface` — every interface now documents its purpose, lifecycle, consumption site, and parameter/return semantics so third-party implementers have a complete contract reference ([#322](https://github.com/crazy-goat/workerman-bundle/issues/322))
 - Update "What's new in this fork" section in `README.md` with a comprehensive comparison against upstream `luzrain/workerman-bundle`, covering 20+ feature additions, dependency differences, and architectural changes ([#491](https://github.com/crazy-goat/workerman-bundle/issues/491))
 - Document `composer test` port binding, troubleshooting steps, and workarounds in `CONTRIBUTING.md` to help contributors avoid "Address already in use" errors ([#358](https://github.com/crazy-goat/workerman-bundle/issues/358))
 

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -7,7 +7,54 @@ namespace CrazyGoat\WorkermanBundle\Middleware;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use Workerman\Protocols\Http\Response;
 
+/**
+ * Middleware for the HTTP request/response pipeline.
+ *
+ * Implementations are composed into a chain via
+ * MiddlewareDispatchInterface::withMiddlewares() and executed in FIFO order
+ * (first added = first executed). Each middleware receives the incoming
+ * Request and a callable $next that dispatches to the next middleware in
+ * the chain (or to the Symfony controller for the innermost layer).
+ *
+ * A middleware can:
+ *  - Pass the request to $next and return its Response (possibly modified).
+ *  - Short-circuit the pipeline by returning a Response without calling $next.
+ *  - Set $connection->context->responseSentDirectly = true to skip the
+ *    automatic response send step (used by StaticFilesMiddleware for
+ *    streaming large files).
+ *
+ * The middleware pipeline is built ONCE and cached across requests, so
+ * middleware instances are reused. Per-request state should be stored on
+ * $connection->context, not on the middleware instance itself.
+ *
+ * Lifecycle: per-request. The __invoke method is called for every incoming
+ * HTTP request after the pipeline has been composed.
+ *
+ * @see MiddlewareDispatchInterface::withMiddlewares() for adding middlewares.
+ * @see StaticFilesMiddleware for an example implementation.
+ * @see SymfonyController for the innermost controller middleware.
+ */
 interface MiddlewareInterface
 {
+    /**
+     * Handle the incoming request.
+     *
+     * Called for each HTTP request during pipeline dispatch. Implementations
+     * should either:
+     *
+     * 1. Forward the request by calling $next($request) and returning its
+     *    Response (possibly after modifying it).
+     * 2. Return a Response directly, short-circuiting the rest of the chain.
+     * 3. Throw an exception (caught by the error handling layer).
+     *
+     * @param Request  $request The incoming Workerman HTTP request. The
+     *                          bundle's extended Request class adds
+     *                          setHeader()/withHeader() for header manipulation.
+     * @param callable $next    The next middleware in the pipeline. Signature:
+     *                          fn(Request $request): Http\Response. The
+     *                          innermost $next delegates to SymfonyController.
+     *
+     * @return Response The HTTP response to send back to the client.
+     */
     public function __invoke(Request $request, callable $next): Response;
 }

--- a/src/Reboot/Strategy/RebootStrategyInterface.php
+++ b/src/Reboot/Strategy/RebootStrategyInterface.php
@@ -4,15 +4,57 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Reboot\Strategy;
 
+/**
+ * Determines whether the current worker process should be gracefully reloaded.
+ *
+ * After each HTTP request is fully handled (including kernel termination and
+ * response send), HttpRequestHandler consults the reboot strategy. If
+ * shouldReboot() returns true, the worker sends SIGUSR1 to itself via
+ * Utils::reload(), triggering a graceful restart. The next request is picked
+ * up by a fresh worker process.
+ *
+ * Implementations can track any state across requests: memory usage, job count,
+ * elapsed time, exception frequency, or any custom metric. The strategy is
+ * instantiated once per worker and reused across all requests it handles.
+ *
+ * Lifecycle: per-worker (singleton within the worker process). Methods are
+ * called synchronously after each request response is sent.
+ *
+ * @see MemoryRebootStrategy Reboots when memory_get_usage() exceeds a limit.
+ * @see MaxJobsRebootStrategy Reboots after a configurable number of requests.
+ * @see ExceptionRebootStrategy Reboots after non-allowed kernel exceptions.
+ * @see AlwaysRebootStrategy Reboots after every request (for debugging).
+ * @see StackRebootStrategy Composes multiple strategies via OR logic.
+ */
 interface RebootStrategyInterface
 {
+    /**
+     * Whether the current worker should be reloaded after this request.
+     *
+     * Called synchronously after the response is sent and kernel termination
+     * has completed. The implementation may use any internal state accumulated
+     * during the request lifecycle.
+     *
+     * Return true to trigger a graceful worker restart via SIGUSR1.
+     * The worker finishes handling its current request before reloading.
+     *
+     * @return bool true if the worker should be gracefully restarted.
+     */
     public function shouldReboot(): bool;
 
     /**
-     * Whether this strategy needs memory_get_peak_usage() to be reset
-     * on every request. When no strategy needs it, the HttpRequestHandler
-     * skips the memory_reset_peak_usage() call entirely, saving a syscall
-     * on the hot path.
+     * Whether this strategy depends on memory_get_peak_usage() being reset.
+     *
+     * Called once at HttpRequestHandler construction time. When every strategy
+     * returns false, HttpRequestHandler skips the memory_reset_peak_usage()
+     * call entirely, saving a syscall on the hot path for every request.
+     *
+     * Strategies that read memory_get_peak_usage() in shouldReboot() (e.g.,
+     * MemoryRebootStrategy) should return true here. All other strategies
+     * should return false.
+     *
+     * @return bool true if memory_reset_peak_usage() must be called before
+     *              every request for this strategy to work correctly.
      */
     public function needsPeakMemory(): bool;
 }

--- a/src/Scheduler/Trigger/TriggerInterface.php
+++ b/src/Scheduler/Trigger/TriggerInterface.php
@@ -4,7 +4,51 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Scheduler\Trigger;
 
+/**
+ * Determines the next scheduled execution time for a recurring task.
+ *
+ * Implementations specify when a scheduled task should next run. The
+ * SchedulerWorker uses TriggerInterface to schedule delayed callbacks:
+ * after a task completes, getNextRunDate() is called to determine when
+ * it should fire again.
+ *
+ * Supported trigger types:
+ *  - CronExpressionTrigger: standard cron expressions (via dragonmantank/cron-expression).
+ *  - PeriodicalTrigger: fixed intervals (seconds, ISO 8601 durations, relative date strings).
+ *  - DateTimeTrigger: single absolute date/time (one-shot).
+ *  - JitterTrigger: decorator that adds random jitter to any trigger.
+ *
+ * Use TriggerFactory::create() to instantiate a trigger from a configuration
+ * value (string, int, DateInterval, or DateTimeImmutable).
+ *
+ * Lifecycle: one trigger instance per scheduled task, evaluated repeatedly
+ * during the worker's lifetime. Implementations must be stateless or handle
+ * repeated getNextRunDate() calls correctly.
+ *
+ * @see TriggerFactory::create() For creating triggers from config values.
+ * @see CronExpressionTrigger For cron-based scheduling.
+ * @see PeriodicalTrigger For periodic interval scheduling.
+ * @see DateTimeTrigger For one-shot date-based scheduling.
+ * @see JitterTrigger For adding random jitter to an existing trigger.
+ */
 interface TriggerInterface extends \Stringable
 {
+    /**
+     * Calculate the next scheduled run date/time after the given moment.
+     *
+     * Given the current time (or any reference moment), returns the next
+     * DateTimeImmutable when the task should run, or null if no future run
+     * is scheduled (e.g., a one-shot DateTimeTrigger whose date has passed).
+     *
+     * The SchedulerWorker uses the returned value to set a delayed timer.
+     * The timer fires at $nextRunDate, after which getNextRunDate() is called
+     * again to schedule the subsequent run.
+     *
+     * @param \DateTimeImmutable $now The reference date/time (typically the
+     *                                current time when scheduling).
+     *
+     * @return \DateTimeImmutable|null The next run date/time, or null if the
+     *                                 trigger has no future occurrences.
+     */
     public function getNextRunDate(\DateTimeImmutable $now): \DateTimeImmutable|null;
 }


### PR DESCRIPTION
## Description

Closes #322

## Changes

- Add comprehensive interface-level and per-method PHPDoc to `MiddlewareInterface` — documents pipeline composition, middleware actions (forward, short-circuit, responseSentDirectly), pipeline caching, and per-request lifecycle
- Add comprehensive interface-level and per-method PHPDoc to `RebootStrategyInterface` — documents reload mechanism, call timing, per-worker singleton lifecycle, and the needsPeakMemory optimization
- Add comprehensive interface-level and per-method PHPDoc to `TriggerInterface` — documents scheduling purpose, all four bundled trigger implementations, entry point via TriggerFactory::create(), and getNextRunDate semantics
- Update CHANGELOG.md under [Unreleased] > Docs

## Changelog

Docs: Add PHPDoc to MiddlewareInterface, RebootStrategyInterface, TriggerInterface

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed