### PR TITLE
fix(http): use onBufferDrain for file cleanup instead of overwriting onClose (closes #308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Remove `@unlink` error suppression in `BinaryFileResponseStrategy` cleanup callback; unlink failures are now checked and logged through the injected PSR-3 logger ([#314](https://github.com/crazy-goat/workerman-bundle/issues/314))
+- Use `onBufferDrain` as the primary cleanup hook in `BinaryFileResponseStrategy` instead of `onClose`, so file deletion runs at the correct lifecycle point (after the send buffer is flushed) and does not persist across keep-alive requests; `onClose` is retained as a fallback for early disconnects; both callbacks self-remove after firing and chain to any previously-set handlers ([#308](https://github.com/crazy-goat/workerman-bundle/issues/308))
 - Use atomic rename-before-read (TOCTOU fix) in `ServerManager::consumeFile()` for status and connections files to prevent symlink-swap redirection of the unlink. A failure to unlink the renamed temp file is now logged through the PSR-3 logger instead of being silently suppressed ([#304](https://github.com/crazy-goat/workerman-bundle/issues/304))
 
 ### Performance

--- a/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
@@ -63,7 +63,7 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
             $filePath = $file->getPathname();
 
             $workermanResponse->withFile($filePath, $offset ?? 0, $maxlen ?? 0);
-            $connection->onClose = $this->createCleanupCallback($filePath, $connection->onClose, $this->logger);
+            $this->scheduleFileCleanup($filePath, $connection);
 
             return $workermanResponse;
         }
@@ -77,21 +77,76 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
         return $workermanResponse;
     }
 
-    private function createCleanupCallback(string $filePath, mixed $previousOnClose, LoggerInterface $logger): \Closure
+    /**
+     * Schedule file deletion using onBufferDrain (fires when the send buffer
+     * is empty — i.e. the file has been fully sent) with an onClose fallback
+     * for early disconnects. Both callbacks self-remove after firing so they
+     * do not persist across keep-alive requests.
+     */
+    private function scheduleFileCleanup(string $filePath, TcpConnection $connection): void
     {
-        return static function () use ($filePath, $previousOnClose, $logger): void {
-            try {
-                if (is_callable($previousOnClose)) {
-                    $previousOnClose();
-                }
-            } finally {
-                if (is_file($filePath) && !unlink($filePath)) {
-                    $logger->warning('Failed to delete temporary file after send', [
-                        'path' => $filePath,
-                        'error' => error_get_last()['message'] ?? 'Unknown error',
-                    ]);
-                }
+        $previousOnClose = $connection->onClose;
+        $previousOnBufferDrain = $connection->onBufferDrain;
+        $logger = $this->logger;
+
+        $cleanup = static function () use ($filePath, $logger): void {
+            if (is_file($filePath) && !unlink($filePath)) {
+                $logger->warning('Failed to delete temporary file after send', [
+                    'path' => $filePath,
+                    'error' => error_get_last()['message'] ?? 'Unknown error',
+                ]);
             }
         };
+
+        $onBufferDrain = static function (TcpConnection $conn) use (
+            $cleanup,
+            &$onBufferDrain,
+            &$onClose,
+            $previousOnBufferDrain,
+            $previousOnClose,
+        ): void {
+            // Self-remove: this callback must not fire on subsequent requests
+            // over the same keep-alive connection.
+            if ($conn->onBufferDrain === $onBufferDrain) {
+                $conn->onBufferDrain = is_callable($previousOnBufferDrain) ? $previousOnBufferDrain : null;
+            }
+            // Restore original onClose now that the file is deleted.
+            if ($conn->onClose === $onClose) {
+                $conn->onClose = $previousOnClose;
+            }
+
+            $cleanup();
+
+            // Chain to any previous onBufferDrain callback.
+            if (is_callable($previousOnBufferDrain)) {
+                $previousOnBufferDrain($conn);
+            }
+        };
+
+        $onClose = static function (TcpConnection $conn) use (
+            $cleanup,
+            &$onBufferDrain,
+            &$onClose,
+            $previousOnBufferDrain,
+            $previousOnClose,
+        ): void {
+            // Self-remove: prevent double-firing if both drain and close trigger.
+            if ($conn->onClose === $onClose) {
+                $conn->onClose = $previousOnClose;
+            }
+            if ($conn->onBufferDrain === $onBufferDrain) {
+                $conn->onBufferDrain = is_callable($previousOnBufferDrain) ? $previousOnBufferDrain : null;
+            }
+
+            $cleanup();
+
+            // Chain to any previous onClose callback.
+            if (is_callable($previousOnClose)) {
+                $previousOnClose($conn);
+            }
+        };
+
+        $connection->onBufferDrain = $onBufferDrain;
+        $connection->onClose = $onClose;
     }
 }

--- a/tests/Strategy/BinaryFileResponseStrategyTest.php
+++ b/tests/Strategy/BinaryFileResponseStrategyTest.php
@@ -14,13 +14,18 @@ use Workerman\Connection\TcpConnection;
 final class BinaryFileResponseStrategyTest extends TestCase
 {
     private string $testFile;
-    private TcpConnection&\PHPUnit\Framework\MockObject\MockObject $connection;
+    private TcpConnection $connection;
 
     protected function setUp(): void
     {
         $this->testFile = sys_get_temp_dir() . '/test_binary_file_' . uniqid() . '.txt';
         file_put_contents($this->testFile, 'Hello World from binary file!');
-        $this->connection = $this->createMock(TcpConnection::class);
+        $this->connection = new class extends TcpConnection {
+            public function __construct()
+            {
+                // Bypass parent constructor — we only need the public properties.
+            }
+        };
     }
 
     protected function tearDown(): void
@@ -58,7 +63,6 @@ final class BinaryFileResponseStrategyTest extends TestCase
         ], $this->connection);
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
-        // Workerman Response with file has file property set
         $this->assertNotNull($workermanResponse->file);
     }
 
@@ -93,14 +97,11 @@ final class BinaryFileResponseStrategyTest extends TestCase
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Create a temp file object
         $tempFile = new \SplTempFileObject();
         $tempFile->fwrite('Temp file content');
 
-        // Create BinaryFileResponse with temp file
         $binaryResponse = new BinaryFileResponse($this->testFile);
 
-        // Use reflection to set the temp file object
         $reflection = new \ReflectionClass($binaryResponse);
         $property = $reflection->getProperty('tempFileObject');
         $property->setValue($binaryResponse, $tempFile);
@@ -108,7 +109,6 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
-        // For temp files, content is read directly into body (no temp file created)
         $this->assertSame('Temp file content', $workermanResponse->rawBody());
     }
 
@@ -116,17 +116,13 @@ final class BinaryFileResponseStrategyTest extends TestCase
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Create response with offset and maxlen (simulating range request)
         $binaryResponse = new BinaryFileResponse($this->testFile, Response::HTTP_OK, [
             'Content-Range' => 'bytes 0-4/29',
         ]);
 
-        // Use reflection to set offset and maxlen
         $reflection = new \ReflectionClass($binaryResponse);
-
         $offsetProperty = $reflection->getProperty('offset');
         $offsetProperty->setValue($binaryResponse, 0);
-
         $maxlenProperty = $reflection->getProperty('maxlen');
         $maxlenProperty->setValue($binaryResponse, 5);
 
@@ -138,11 +134,10 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $this->assertNotNull($workermanResponse->file);
     }
 
-    public function testConvertHandlesDeleteFileAfterSend(): void
+    public function testConvertHandlesDeleteFileAfterSendViaBufferDrain(): void
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Create a temp file that should be deleted after connection closes
         $tempFile = sys_get_temp_dir() . '/delete_me_' . uniqid() . '.txt';
         file_put_contents($tempFile, 'Delete me after send!');
 
@@ -150,7 +145,6 @@ final class BinaryFileResponseStrategyTest extends TestCase
             'Content-Type' => 'text/plain',
         ]);
 
-        // Use reflection to set deleteFileAfterSend
         $reflection = new \ReflectionClass($binaryResponse);
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
@@ -162,17 +156,41 @@ final class BinaryFileResponseStrategyTest extends TestCase
         ], $this->connection);
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
-        // File should NOT be deleted yet (only after connection closes)
         $this->assertFileExists($tempFile);
-        // File should be streamed via withFile()
         $this->assertNotNull($workermanResponse->file);
 
-        // Simulate connection close
-        $onCloseCallback = $this->connection->onClose;
-        $this->assertNotNull($onCloseCallback, 'onClose callback should be registered');
-        $onCloseCallback();
+        // Simulate buffer drain (primary cleanup path)
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $this->assertNotNull($onBufferDrain, 'onBufferDrain callback should be registered');
+        $onBufferDrain($this->connection);
 
-        // Now file should be deleted
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testConvertHandlesDeleteFileAfterSendViaOnCloseFallback(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/delete_fallback_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Fallback delete!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [
+            'Content-Type' => ['text/plain'],
+        ], $this->connection);
+
+        // Simulate connection close without buffer drain (early disconnect)
+        $onCloseCallback = $this->connection->onClose;
+        $this->assertNotNull($onCloseCallback, 'onClose fallback callback should be registered');
+        $onCloseCallback($this->connection);
+
         $this->assertFileDoesNotExist($tempFile);
     }
 
@@ -189,7 +207,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property->setValue($binaryResponse, true);
 
         $existingCalled = false;
-        $this->connection->onClose = function () use (&$existingCalled): void {
+        $this->connection->onClose = function (TcpConnection $conn) use (&$existingCalled): void {
             $existingCalled = true;
         };
 
@@ -197,28 +215,106 @@ final class BinaryFileResponseStrategyTest extends TestCase
             'Content-Type' => ['text/plain'],
         ], $this->connection);
 
+        // Trigger via onClose fallback
         $onCloseCallback = $this->connection->onClose;
-        $onCloseCallback();
+        $onCloseCallback($this->connection);
 
         $this->assertTrue($existingCalled, 'Previous onClose callback must be invoked');
         $this->assertFileDoesNotExist($tempFile);
     }
 
-    public function testConvertHandlesMultipleChainedCleanups(): void
+    public function testBufferDrainPreservesExistingOnCloseCallback(): void
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        $tempFile1 = sys_get_temp_dir() . '/chain_1_' . uniqid() . '.txt';
-        $tempFile2 = sys_get_temp_dir() . '/chain_2_' . uniqid() . '.txt';
-        file_put_contents($tempFile1, 'First');
-        file_put_contents($tempFile2, 'Second');
+        $tempFile = sys_get_temp_dir() . '/drain_preserve_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Drain preserve!');
 
-        $callOrder = [];
-        $this->connection->onClose = function () use (&$callOrder): void {
-            $callOrder[] = 'existing';
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $existingOnClose = function (TcpConnection $conn): void {
         };
+        $this->connection->onClose = $existingOnClose;
 
-        $binaryResponse = new BinaryFileResponse($tempFile1, Response::HTTP_OK);
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        // Simulate buffer drain (primary path)
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $onBufferDrain($this->connection);
+
+        // After buffer drain, onClose should be restored to the original
+        $this->assertSame(
+            $existingOnClose,
+            $this->connection->onClose,
+            'onClose must be restored to original after buffer drain fires',
+        );
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testBufferDrainPreservesExistingOnBufferDrainCallback(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/drain_chain_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Drain chain!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $existingDrainCalled = false;
+        $existingOnBufferDrain = function (TcpConnection $conn) use (&$existingDrainCalled): void {
+            $existingDrainCalled = true;
+        };
+        $this->connection->onBufferDrain = $existingOnBufferDrain;
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        // Simulate buffer drain
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $onBufferDrain($this->connection);
+
+        $this->assertTrue($existingDrainCalled, 'Previous onBufferDrain callback must be invoked');
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testBufferDrainSelfRemovesAfterFiring(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/drain_selfremove_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Self-remove!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $this->assertNotNull($onBufferDrain);
+
+        $onBufferDrain($this->connection);
+
+        $this->assertNull(
+            $this->connection->onBufferDrain,
+            'onBufferDrain must self-remove after firing to avoid persisting on keep-alive connections',
+        );
+    }
+
+    public function testOnCloseSelfRemovesAfterFiring(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/close_selfremove_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Self-remove close!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
         $reflection = new \ReflectionClass($binaryResponse);
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
@@ -226,36 +322,97 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $strategy->convert($binaryResponse, [], $this->connection);
 
         $onCloseCallback = $this->connection->onClose;
-        $onCloseCallback();
+        $this->assertNotNull($onCloseCallback);
 
-        $this->assertSame(['existing'], $callOrder);
-        $this->assertFileDoesNotExist($tempFile1);
+        $onCloseCallback($this->connection);
 
-        file_put_contents($tempFile2, 'Second');
+        $this->assertNull(
+            $this->connection->onClose,
+            'onClose must self-remove after firing',
+        );
+    }
 
-        $binaryResponse2 = new BinaryFileResponse($tempFile2, Response::HTTP_OK);
-        $reflection2 = new \ReflectionClass($binaryResponse2);
-        $property2 = $reflection2->getProperty('deleteFileAfterSend');
-        $property2->setValue($binaryResponse2, true);
+    public function testBufferDrainRemovesOnCloseToo(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
 
-        $this->connection->onClose = $onCloseCallback;
+        $tempFile = sys_get_temp_dir() . '/drain_removes_close_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Drain removes close!');
 
-        $strategy->convert($binaryResponse2, [], $this->connection);
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
 
-        $secondOnClose = $this->connection->onClose;
+        $strategy->convert($binaryResponse, [], $this->connection);
 
-        $callOrder = [];
-        $secondOnClose();
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $onBufferDrain($this->connection);
 
-        $this->assertSame(['existing'], $callOrder);
-        $this->assertFileDoesNotExist($tempFile2);
+        $this->assertNull($this->connection->onBufferDrain);
+        $this->assertNull(
+            $this->connection->onClose,
+            'onClose fallback must be removed when buffer drain fires first',
+        );
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testOnCloseRemovesBufferDrainToo(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/close_removes_drain_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Close removes drain!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onCloseCallback = $this->connection->onClose;
+        $onCloseCallback($this->connection);
+
+        $this->assertNull($this->connection->onClose);
+        $this->assertNull(
+            $this->connection->onBufferDrain,
+            'onBufferDrain must be removed when onClose fires first',
+        );
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testNoDoubleDeleteWhenBothDrainAndCloseFire(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $strategy = new BinaryFileResponseStrategy(logger: $logger);
+
+        $tempFile = sys_get_temp_dir() . '/no_double_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'No double delete!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        // Fire buffer drain (deletes file)
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $onBufferDrain($this->connection);
+
+        $this->assertFileDoesNotExist($tempFile);
+
+        // onClose was already restored to null, so no second cleanup runs
+        $this->assertNull($this->connection->onClose);
     }
 
     public function testConvertWorksForNormalBinaryFileResponse(): void
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Test that normal BinaryFileResponse works correctly
         $binaryResponse = new BinaryFileResponse($this->testFile, Response::HTTP_OK);
 
         $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
@@ -268,20 +425,15 @@ final class BinaryFileResponseStrategyTest extends TestCase
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Create a temp file
         $tempFile = sys_get_temp_dir() . '/vanishing_file_' . uniqid() . '.txt';
         file_put_contents($tempFile, 'I will disappear!');
 
-        // Create response while file exists
         $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
 
-        // Delete file after construction but before conversion (race condition)
         unlink($tempFile);
 
-        // Conversion should handle gracefully - Workerman returns 404 for missing files
         $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
 
-        // Workerman detects missing file and returns 404
         $this->assertSame(404, $workermanResponse->getStatusCode());
     }
 
@@ -289,24 +441,19 @@ final class BinaryFileResponseStrategyTest extends TestCase
     {
         $strategy = new BinaryFileResponseStrategy();
 
-        // Create a temp file
         $tempFile = sys_get_temp_dir() . '/delete_missing_' . uniqid() . '.txt';
         file_put_contents($tempFile, 'Delete me!');
 
-        // Create response while file exists
         $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK, [
             'Content-Type' => 'text/plain',
         ]);
 
-        // Use reflection to set deleteFileAfterSend
         $reflection = new \ReflectionClass($binaryResponse);
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        // Delete file after construction but before conversion
         unlink($tempFile);
 
-        // Conversion should handle gracefully - Workerman returns 404 for missing files
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
         ], $this->connection);
@@ -326,7 +473,6 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy = new BinaryFileResponseStrategy(logger: $logger);
 
-        // Create a directory, put a file in it, then make directory read-only
         $dir = sys_get_temp_dir() . '/unlink_test_' . uniqid();
         mkdir($dir, 0777);
         $tempFile = $dir . '/file.txt';
@@ -346,7 +492,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         // Suppress PHP warning from unlink() on read-only directory
         set_error_handler(static fn(): true => true);
         try {
-            $onCloseCallback();
+            $onCloseCallback($this->connection);
         } finally {
             restore_error_handler();
         }
@@ -374,9 +520,10 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy->convert($binaryResponse, [], $this->connection);
 
-        $onCloseCallback = $this->connection->onClose;
-        assert(is_callable($onCloseCallback));
-        $onCloseCallback();
+        // Trigger via buffer drain (primary path)
+        $onBufferDrain = $this->connection->onBufferDrain;
+        assert(is_callable($onBufferDrain));
+        $onBufferDrain($this->connection);
 
         $this->assertFileDoesNotExist($tempFile);
     }

--- a/tests/Strategy/BinaryFileResponseStrategyTest.php
+++ b/tests/Strategy/BinaryFileResponseStrategyTest.php
@@ -162,6 +162,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         // Simulate buffer drain (primary cleanup path)
         $onBufferDrain = $this->connection->onBufferDrain;
         $this->assertNotNull($onBufferDrain, 'onBufferDrain callback should be registered');
+        assert(is_callable($onBufferDrain));
         $onBufferDrain($this->connection);
 
         $this->assertFileDoesNotExist($tempFile);
@@ -189,6 +190,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         // Simulate connection close without buffer drain (early disconnect)
         $onCloseCallback = $this->connection->onClose;
         $this->assertNotNull($onCloseCallback, 'onClose fallback callback should be registered');
+        assert(is_callable($onCloseCallback));
         $onCloseCallback($this->connection);
 
         $this->assertFileDoesNotExist($tempFile);
@@ -243,6 +245,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         // Simulate buffer drain (primary path)
         $onBufferDrain = $this->connection->onBufferDrain;
+        assert(is_callable($onBufferDrain));
         $onBufferDrain($this->connection);
 
         // After buffer drain, onClose should be restored to the original
@@ -298,6 +301,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $onBufferDrain = $this->connection->onBufferDrain;
         $this->assertNotNull($onBufferDrain);
+        assert(is_callable($onBufferDrain));
 
         $onBufferDrain($this->connection);
 
@@ -323,6 +327,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $onCloseCallback = $this->connection->onClose;
         $this->assertNotNull($onCloseCallback);
+        assert(is_callable($onCloseCallback));
 
         $onCloseCallback($this->connection);
 
@@ -346,7 +351,9 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy->convert($binaryResponse, [], $this->connection);
 
+        // Fire buffer drain
         $onBufferDrain = $this->connection->onBufferDrain;
+        assert(is_callable($onBufferDrain));
         $onBufferDrain($this->connection);
 
         $this->assertNull($this->connection->onBufferDrain);
@@ -371,7 +378,9 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy->convert($binaryResponse, [], $this->connection);
 
+        // Fire onClose (early disconnect)
         $onCloseCallback = $this->connection->onClose;
+        assert(is_callable($onCloseCallback));
         $onCloseCallback($this->connection);
 
         $this->assertNull($this->connection->onClose);
@@ -401,6 +410,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         // Fire buffer drain (deletes file)
         $onBufferDrain = $this->connection->onBufferDrain;
+        assert(is_callable($onBufferDrain));
         $onBufferDrain($this->connection);
 
         $this->assertFileDoesNotExist($tempFile);


### PR DESCRIPTION
## Description

Closes #308

## Changes

- **Primary cleanup via `onBufferDrain`**: File deletion now runs when the send buffer is flushed (i.e., the file has been fully sent), not when the connection closes. This is the correct lifecycle point and matches the intent of `deleteFileAfterSend`.
- **`onClose` as fallback**: If the connection closes before the buffer drains (early disconnect), the file is still cleaned up via the `onClose` fallback.
- **Self-removing callbacks**: Both `onBufferDrain` and `onClose` callbacks self-remove after firing and remove each other, so they never persist across keep-alive requests.
- **Callback chaining preserved**: Existing `onClose` and `onBufferDrain` handlers from other middleware are preserved and invoked.
- **No double-delete**: When `onBufferDrain` fires first, it removes the `onClose` callback; the file is deleted once.

### Before (bug)
```php
$connection->onClose = $this->createCleanupCallback($filePath, $connection->onClose, $this->logger);
```
- Cleanup runs on connection close (too late for `deleteFileAfterSend` semantics)
- On keep-alive connections, the callback persists across requests
- Previous `onClose` is chained but only via the old closure pattern

### After (fixed)
```php
$connection->onBufferDrain = $onBufferDrain;  // primary: fires when file is sent
$connection->onClose = $onClose;              // fallback: fires on early disconnect
```
- Both self-remove after firing
- Both chain to previous handlers
- `onBufferDrain` also restores the original `onClose` after cleanup

## Changelog

### Security
- Use `onBufferDrain` as the primary cleanup hook in `BinaryFileResponseStrategy` instead of `onClose`, so file deletion runs at the correct lifecycle point and does not persist across keep-alive requests

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed