### PR TITLE
test(polling): replace source-grep assertion with behavioral stat-count test (closes #330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- Replace `testSourceFileNoLongerContainsGetFileInfo` (which read `PollingMonitorWatcher.php` as a string and asserted on a substring) with `testPollUsesSingleStatPerFile` — a behavioral test that instruments the iterator with `CountingSplFileInfo` and asserts exactly one `stat()` call per file. The new test catches any redundant stat-touching call (`getFileInfo()`, `getSize()`, `isFile()`, duplicate `getMTime()`, etc.) under any name, not just `getFileInfo()` ([#330](https://github.com/crazy-goat/workerman-bundle/issues/330))
 - Expand `StreamedBinaryFileResponseTest` with comprehensive test coverage: content type detection, Content-Length verification, Content-Disposition, offset/maxlen behavior, `deleteFileAfterSend` cleanup, output correctness for small and large files, chunk size validation, auto ETag/Last-Modified headers, and edge cases (empty file, non-readable file, private responses) ([#353](https://github.com/crazy-goat/workerman-bundle/issues/353))
 
 ### Security
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Code Quality
 
+- `PollingMonitorWatcher`: relax `final` on the class and on `FileMonitorWatcher::createRecursiveIterator()` so a test-only subclass can inject a counting `RecursiveDirectoryIterator`. The behavioral test in `PollingMonitorWatcherTest` requires this extension point to verify the watcher makes exactly one `stat()` call per file; without it, the test would be limited to flaky wall-time heuristics ([#330](https://github.com/crazy-goat/workerman-bundle/issues/330))
 - `CronExpressionTrigger`: remove redundant `class_exists(Cron\CronExpression::class)` gate from the constructor — the check is already performed by `TriggerFactory::create()` before instantiation, making the duplicate guard unreachable and misleading ([#355](https://github.com/crazy-goat/workerman-bundle/issues/355))
 - `TriggerFactory`: replace falsy object check (`if ($dateTime)`) with explicit `instanceof \DateTimeImmutable` check to clarify that the branch is taken only when ISO-8601 datetime parsing succeeds, and to avoid relying on object truthiness ([#361](https://github.com/crazy-goat/workerman-bundle/issues/361))
 - `WorkermanCommand`: rename `$allowedActions` local variable to `$invalidActionMessage` so the name accurately reflects that it holds an error message, not a list of allowed actions ([#373](https://github.com/crazy-goat/workerman-bundle/issues/373))

--- a/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
@@ -58,7 +58,7 @@ abstract class FileMonitorWatcher
      *
      * @return \RecursiveIteratorIterator<\RecursiveDirectoryIterator>
      */
-    final protected function createRecursiveIterator(string $dir, int $flags, int $mode): \RecursiveIteratorIterator
+    protected function createRecursiveIterator(string $dir, int $flags, int $mode): \RecursiveIteratorIterator
     {
         return new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($dir, $flags),

--- a/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher;
 
-final class PollingMonitorWatcher extends FileMonitorWatcher
+class PollingMonitorWatcher extends FileMonitorWatcher
 {
     private const POLLING_INTERVAL = 3;
     private const MAX_FILES_PER_TICK = 500;

--- a/tests/Fixtures/PollingMonitorWatcher/CountingPollingMonitorWatcher.php
+++ b/tests/Fixtures/PollingMonitorWatcher/CountingPollingMonitorWatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher;
+
+use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\PollingMonitorWatcher;
+
+/**
+ * PollingMonitorWatcher subclass that uses CountingRecursiveDirectoryIterator,
+ * so stat() calls performed by the watcher can be observed and counted.
+ */
+final class CountingPollingMonitorWatcher extends PollingMonitorWatcher
+{
+    /**
+     * @param int<0, max> $flags
+     * @param 0|1|2       $mode
+     */
+    protected function createRecursiveIterator(string $dir, int $flags, int $mode): \RecursiveIteratorIterator
+    {
+        // @phpstan-ignore-next-line return.type — CountingRecursiveDirectoryIterator extends \RecursiveDirectoryIterator
+        return new \RecursiveIteratorIterator(
+            new CountingRecursiveDirectoryIterator($dir, $flags),
+            $mode,
+        );
+    }
+}

--- a/tests/Fixtures/PollingMonitorWatcher/CountingRecursiveDirectoryIterator.php
+++ b/tests/Fixtures/PollingMonitorWatcher/CountingRecursiveDirectoryIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher;
+
+/**
+ * RecursiveDirectoryIterator subclass that yields CountingSplFileInfo
+ * instances so stat-related calls on each file are observable.
+ *
+ * `setInfoClass` configures the class returned by `current()`/`getFileInfo()`.
+ * The `current()` override is a belt-and-braces guard: if `setInfoClass` is
+ * ever bypassed (e.g. by a flag change in the iterator), the assertion
+ * surfaces the bug instead of silently returning plain SplFileInfo.
+ */
+final class CountingRecursiveDirectoryIterator extends \RecursiveDirectoryIterator
+{
+    public function __construct(string $directory, int $flags)
+    {
+        parent::__construct($directory, $flags);
+        $this->setInfoClass(CountingSplFileInfo::class);
+    }
+
+    public function current(): \SplFileInfo
+    {
+        $info = parent::current();
+        \assert($info instanceof CountingSplFileInfo, 'Iterator must yield CountingSplFileInfo instances; check setInfoClass()');
+
+        return $info;
+    }
+}

--- a/tests/Fixtures/PollingMonitorWatcher/CountingSplFileInfo.php
+++ b/tests/Fixtures/PollingMonitorWatcher/CountingSplFileInfo.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher;
+
+/**
+ * SplFileInfo subclass that counts stat-related calls.
+ *
+ * Used by tests to verify PollingMonitorWatcher doesn't make redundant
+ * stat() syscalls per file. Each stat-touching method bumps a shared
+ * static counter so a single test can assert the cumulative call count.
+ *
+ * Every method that triggers a stat/lstat syscall is overridden so a
+ * regression under any name (getFileInfo, getSize, isFile, etc.) is caught.
+ */
+final class CountingSplFileInfo extends \SplFileInfo
+{
+    public static int $statCallCount = 0;
+
+    public static function reset(): void
+    {
+        self::$statCallCount = 0;
+    }
+
+    public function getMTime(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getMTime();
+    }
+
+    public function getATime(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getATime();
+    }
+
+    public function getCTime(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getCTime();
+    }
+
+    public function getSize(): int|false
+    {
+        ++self::$statCallCount;
+
+        return parent::getSize();
+    }
+
+    public function getPerms(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getPerms();
+    }
+
+    public function getInode(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getInode();
+    }
+
+    public function getOwner(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getOwner();
+    }
+
+    public function getGroup(): int
+    {
+        ++self::$statCallCount;
+
+        return parent::getGroup();
+    }
+
+    public function getType(): string
+    {
+        ++self::$statCallCount;
+
+        return parent::getType();
+    }
+
+    public function isWritable(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isWritable();
+    }
+
+    public function isReadable(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isReadable();
+    }
+
+    public function isExecutable(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isExecutable();
+    }
+
+    public function isFile(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isFile();
+    }
+
+    public function isDir(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isDir();
+    }
+
+    public function isLink(): bool
+    {
+        ++self::$statCallCount;
+
+        return parent::isLink();
+    }
+
+    public function getLinkTarget(): string|false
+    {
+        ++self::$statCallCount;
+
+        return parent::getLinkTarget();
+    }
+
+    public function getRealPath(): string|false
+    {
+        ++self::$statCallCount;
+
+        return parent::getRealPath();
+    }
+
+    public function getFileInfo(?string $class_name = null): \SplFileInfo
+    {
+        ++self::$statCallCount;
+
+        $class_name ??= CountingSplFileInfo::class;
+
+        return new $class_name($this->getPathname());
+    }
+
+    public function getPathInfo(?string $class_name = null): \SplFileInfo
+    {
+        ++self::$statCallCount;
+
+        $class_name ??= CountingSplFileInfo::class;
+
+        return new $class_name(\dirname($this->getPathname()));
+    }
+}

--- a/tests/PollingMonitorWatcherTest.php
+++ b/tests/PollingMonitorWatcherTest.php
@@ -67,20 +67,26 @@ final class PollingMonitorWatcherTest extends TestCase
     }
 
     /**
-     * Walks up to the declaring class because ReflectionClass::getProperty()
-     * only looks at the given class, not its hierarchy. This is needed when
-     * the property is declared on a parent (e.g. worker, sourceDir,
-     * filePattern on FileMonitorWatcher).
-     */
-    /**
+     * Walks the hierarchy and returns a ReflectionProperty bound to the
+     * declaring class's scope. Required on PHP 8.2/8.3 because
+     * ReflectionProperty::setValue() on a readonly property checks the
+     * scope of the reflection (where getProperty() was called from), not
+     * the property's actual declaring class. Binding to a subclass scope
+     * makes the readonly initializer throw even when the underlying
+     * property is uninitialized.
+     *
      * @phpstan-ignore-next-line missingType.generics
      */
     private function findProperty(\ReflectionClass $class, string $name): \ReflectionProperty
     {
         $className = $class->getName();
         for ($current = $class; $current !== false; $current = $current->getParentClass()) {
-            if ($current->hasProperty($name)) {
-                return $current->getProperty($name);
+            if (!$current->hasProperty($name)) {
+                continue;
+            }
+            $prop = $current->getProperty($name);
+            if ($prop->getDeclaringClass()->getName() === $current->getName()) {
+                return $prop;
             }
         }
 

--- a/tests/PollingMonitorWatcherTest.php
+++ b/tests/PollingMonitorWatcherTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\PollingMonitorWatcher;
+use CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher\CountingPollingMonitorWatcher;
+use CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher\CountingSplFileInfo;
 use PHPUnit\Framework\TestCase;
 use Workerman\Worker;
 
@@ -16,6 +18,7 @@ final class PollingMonitorWatcherTest extends TestCase
     {
         $this->tempDir = \sys_get_temp_dir() . '/workerman_polling_' . \bin2hex(\random_bytes(4));
         \mkdir($this->tempDir, 0700, true);
+        CountingSplFileInfo::reset();
     }
 
     protected function tearDown(): void
@@ -43,33 +46,45 @@ final class PollingMonitorWatcherTest extends TestCase
     /**
      * @param string[] $sourceDir
      * @param string[] $filePattern
+     * @param class-string<PollingMonitorWatcher>|null $class
      */
     private function createWatcher(
         Worker $worker,
         array $sourceDir,
         array $filePattern = ['*.php'],
+        ?string $class = null,
     ): PollingMonitorWatcher {
-        $reflection = new \ReflectionClass(PollingMonitorWatcher::class);
+        $class ??= PollingMonitorWatcher::class;
+        $reflection = new \ReflectionClass($class);
         $instance = $reflection->newInstanceWithoutConstructor();
 
-        $parentClass = $reflection->getParentClass();
-        if (!$parentClass instanceof \ReflectionClass) {
-            throw new \RuntimeException('Failed to get parent class reflection');
-        }
-
-        $workerProp = $parentClass->getProperty('worker');
-        $workerProp->setValue($instance, $worker);
-
-        $sourceDirProp = $parentClass->getProperty('sourceDir');
-        $sourceDirProp->setValue($instance, $sourceDir);
-
-        $filePatternProp = $parentClass->getProperty('filePattern');
-        $filePatternProp->setValue($instance, $filePattern);
-
-        $lastMTimeProp = $reflection->getProperty('lastMTime');
-        $lastMTimeProp->setValue($instance, \time());
+        $this->findProperty($reflection, 'worker')->setValue($instance, $worker);
+        $this->findProperty($reflection, 'sourceDir')->setValue($instance, $sourceDir);
+        $this->findProperty($reflection, 'filePattern')->setValue($instance, $filePattern);
+        $this->findProperty($reflection, 'lastMTime')->setValue($instance, \time());
 
         return $instance;
+    }
+
+    /**
+     * Walks up to the declaring class because ReflectionClass::getProperty()
+     * only looks at the given class, not its hierarchy. This is needed when
+     * the property is declared on a parent (e.g. worker, sourceDir,
+     * filePattern on FileMonitorWatcher).
+     */
+    /**
+     * @phpstan-ignore-next-line missingType.generics
+     */
+    private function findProperty(\ReflectionClass $class, string $name): \ReflectionProperty
+    {
+        $className = $class->getName();
+        for ($current = $class; $current !== false; $current = $current->getParentClass()) {
+            if ($current->hasProperty($name)) {
+                return $current->getProperty($name);
+            }
+        }
+
+        throw new \RuntimeException("Property {$className}::\${$name} does not exist");
     }
 
     private function invokeCheckFileSystemChanges(PollingMonitorWatcher $watcher): void
@@ -80,15 +95,14 @@ final class PollingMonitorWatcherTest extends TestCase
 
     private function setLastMTime(PollingMonitorWatcher $watcher, int $mtime): void
     {
-        $reflection = new \ReflectionProperty(PollingMonitorWatcher::class, 'lastMTime');
-        $reflection->setValue($watcher, $mtime);
+        $this->findProperty(new \ReflectionClass($watcher::class), 'lastMTime')->setValue($watcher, $mtime);
     }
 
     private function getLastMTime(PollingMonitorWatcher $watcher): int
     {
-        $reflection = new \ReflectionProperty(PollingMonitorWatcher::class, 'lastMTime');
+        $prop = $this->findProperty(new \ReflectionClass($watcher::class), 'lastMTime');
 
-        return $reflection->getValue($watcher);
+        return (int) $prop->getValue($watcher);
     }
 
     public function testFileChangeDetectionConditionIsCorrect(): void
@@ -220,15 +234,38 @@ final class PollingMonitorWatcherTest extends TestCase
         );
     }
 
-    public function testSourceFileNoLongerContainsGetFileInfo(): void
+    public function testPollUsesSingleStatPerFile(): void
     {
-        $source = \file_get_contents(__DIR__ . '/../src/Reboot/FileMonitorWatcher/PollingMonitorWatcher.php');
-        \assert(\is_string($source));
+        $fileCount = 10;
+        for ($i = 0; $i < $fileCount; $i++) {
+            \file_put_contents($this->tempDir . '/file' . $i . '.php', '<?php');
+        }
+        \clearstatcache();
 
-        $this->assertStringNotContainsString(
-            'getFileInfo',
-            $source,
-            'PollingMonitorWatcher should call getMTime() directly, not via getFileInfo()',
+        $worker = $this->createMock(Worker::class);
+        $worker->name = 'test';
+
+        $watcher = $this->createWatcher(
+            $worker,
+            [$this->tempDir],
+            ['*.php'],
+            CountingPollingMonitorWatcher::class,
+        );
+        // Set lastMTime to the future so no file is treated as modified and
+        // the watcher iterates the full set instead of triggering reload on
+        // the first match.
+        $this->setLastMTime($watcher, \time() + 3600);
+
+        $this->invokeCheckFileSystemChanges($watcher);
+
+        $this->assertSame(
+            $fileCount,
+            CountingSplFileInfo::$statCallCount,
+            \sprintf(
+                'Expected exactly %d stat() calls (one per file), got %d. Reintroducing redundant stat-touching calls (e.g. getFileInfo(), getSize(), or duplicate getMTime()) would inflate this count.',
+                $fileCount,
+                CountingSplFileInfo::$statCallCount,
+            ),
         );
     }
 


### PR DESCRIPTION
## Description

Closes #330

## Changes

- **Behavioral test replaces source-grep**: `testSourceFileNoLongerContainsGetFileInfo` (which read `PollingMonitorWatcher.php` as a string and asserted on a substring) is replaced with `testPollUsesSingleStatPerFile`, a behavioral test that instruments the iterator with a counting `SplFileInfo` subclass and asserts exactly one `stat()` call per file.
- **Catches regression under any name**: Every stat-touching `SplFileInfo` method is overridden in `CountingSplFileInfo` (`getMTime`, `getATime`, `getCTime`, `getSize`, `getPerms`, `getInode`, `getOwner`, `getGroup`, `getType`, `isWritable`, `isReadable`, `isExecutable`, `isFile`, `isDir`, `isLink`, `getLinkTarget`, `getRealPath`, `getFileInfo`, `getPathInfo`), so a regression introduced as any of these (e.g. `getFileInfo()->getMTime()`, `getSize()`, `isFile()`, duplicate `getMTime()`) inflates the counter and fails the test.
- **Test fixture classes** in `tests/Fixtures/PollingMonitorWatcher/`:
  - `CountingSplFileInfo` — `SplFileInfo` subclass counting every stat-touching call
  - `CountingRecursiveDirectoryIterator` — yields counting `SplFileInfo` instances
  - `CountingPollingMonitorWatcher` — `PollingMonitorWatcher` subclass injecting the counting iterator
- **`final` relaxation**: removed `final` from `PollingMonitorWatcher` class and from `FileMonitorWatcher::createRecursiveIterator()` so the counting subclass can be instantiated. This is the minimum production-code change required to enable deterministic, non-flaky stat counting in the test (a wall-time test would be inherently unreliable for catching `+1 stat per file` regressions).

## Changelog

- **Tests**: `PollingMonitorWatcherTest`: replace `testSourceFileNoLongerContainsGetFileInfo` (source-string assertion) with `testPollUsesSingleStatPerFile` (behavioral test asserting exactly one `stat()` per file via counting `SplFileInfo` fixture)
- **Code Quality**: `PollingMonitorWatcher`: relax `final` on the class and on `FileMonitorWatcher::createRecursiveIterator()` to allow a test-only subclass to inject a counting iterator

## Code Review

- [x] Passed subagent code review (all 4 blockers + 11 warnings addressed: fixed `findProperty` reflection bugs, expanded `CountingSplFileInfo` to override 19 stat-touching methods, moved counter reset to `setUp()`, added `clearstatcache()` to new test, replaced dead-code fallback with assertion in iterator)
- [x] All review comments addressed