### PR TITLE
test: replace source-grep exception logging test with behavioral test (closes #306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace `testSourceFileNoLongerContainsGetFileInfo` (which read `PollingMonitorWatcher.php` as a string and asserted on a substring) with `testPollUsesSingleStatPerFile` — a behavioral test that instruments the iterator with `CountingSplFileInfo` and asserts exactly one `stat()` call per file. The new test catches any redundant stat-touching call (`getFileInfo()`, `getSize()`, `isFile()`, duplicate `getMTime()`, etc.) under any name, not just `getFileInfo()` ([#330](https://github.com/crazy-goat/workerman-bundle/issues/330))
 - Expand `StreamedBinaryFileResponseTest` with comprehensive test coverage: content type detection, Content-Length verification, Content-Disposition, offset/maxlen behavior, `deleteFileAfterSend` cleanup, output correctness for small and large files, chunk size validation, auto ETag/Last-Modified headers, and edge cases (empty file, non-readable file, private responses) ([#353](https://github.com/crazy-goat/workerman-bundle/issues/353))
+- Replace `testSchedulerWorkerLogsExceptionsInChildProcess` (which read `SchedulerWorker.php` as a string and asserted on substrings) with a behavioral test that forks a child, invokes `SchedulerWorker::handleChild` via reflection with a `TaskHandler` that throws, and asserts the child exits with code 1 and the exception is logged via `Worker::log()` ([#306](https://github.com/crazy-goat/workerman-bundle/issues/306))
 
 ### Security
 

--- a/tests/Fixtures/sigchld_test_runner.php
+++ b/tests/Fixtures/sigchld_test_runner.php
@@ -127,6 +127,7 @@ match ($testName) {
     'signal_kill' => testSignalKill(),
     'multiple_children' => testMultipleChildren(),
     'scheduler_worker_handler' => testSchedulerWorkerHandler(),
+    'scheduler_worker_exception_logging' => testSchedulerWorkerExceptionLogging(),
     default => (function () use ($testName): never {
         fwrite(STDERR, "Unknown test: $testName\n");
         exit(2);
@@ -405,6 +406,121 @@ function requireAutoloader(): void
     }
     require $autoloadPath;
     $loaded = true;
+}
+
+function testSchedulerWorkerExceptionLogging(): void
+{
+    requireAutoloader();
+
+    $logFilePath = tempnam(sys_get_temp_dir(), 'test_exc_log_');
+    if ($logFilePath === false) {
+        fail('Failed to create temp log file');
+    }
+    $logStream = fopen($logFilePath, 'w+');
+    if ($logStream === false) {
+        fail('Failed to open temp log stream');
+    }
+    \Workerman\Worker::$outputStream = $logStream;
+    \Workerman\Worker::$logFile = $logFilePath;
+
+    $pidDir = sys_get_temp_dir();
+    \Workerman\Worker::$pidFile = $pidDir . '/workerman_test.pid';
+
+    $schedulerWorker = createSchedulerWorkerInstance();
+
+    $handleChild = (new \ReflectionMethod(
+        \CrazyGoat\WorkermanBundle\Worker\SchedulerWorker::class,
+        'handleChild',
+    ))->getClosure($schedulerWorker);
+
+    if (!$handleChild instanceof \Closure) {
+        fail('handleChild must be accessible via reflection');
+    }
+
+    $service = new \CrazyGoat\WorkermanBundle\Util\ServiceMethod('test.exception.service', '__invoke');
+    $taskName = 'test_exception_task';
+
+    // Create mocks that cause TaskHandler to throw during dispatchAndInvoke
+    $container = new class implements \Psr\Container\ContainerInterface {
+        public function get(string $id): mixed
+        {
+            throw new \RuntimeException('Simulated container error');
+        }
+
+        public function has(string $id): bool
+        {
+            return true;
+        }
+    };
+
+    $eventDispatcher = new class implements \Symfony\Contracts\EventDispatcher\EventDispatcherInterface {
+        public function dispatch(object $event, ?string $eventName = null): object
+        {
+            throw new \RuntimeException('Simulated event dispatch failure');
+        }
+    };
+
+    $handler = new \CrazyGoat\WorkermanBundle\Scheduler\TaskHandler($container, $eventDispatcher);
+
+    $pid = pcntl_fork();
+    if ($pid === -1) {
+        fail('Fork failed');
+    }
+
+    if ($pid === 0) {
+        $pidFile = sprintf(
+            '%s/workerman.task.%s.pid',
+            dirname(\Workerman\Worker::$pidFile),
+            hash('xxh64', $service->toString()),
+        );
+        touch($pidFile);
+
+        try {
+            $handleChild($pidFile, $service, $taskName, $handler);
+        } catch (\Throwable $e) {
+            fwrite(STDERR, 'handleChild did not exit: ' . $e->getMessage() . "\n");
+            exit(255);
+        }
+        exit(255);
+    }
+
+    $status = 0;
+    $deadline = microtime(true) + 10;
+    $reaped = false;
+    while (microtime(true) < $deadline && !$reaped) {
+        $result = pcntl_waitpid($pid, $status, WNOHANG);
+        if ($result === $pid || $result === -1) {
+            $reaped = true;
+        }
+        usleep(10_000);
+    }
+
+    if (!$reaped) {
+        fail('Child process did not terminate within timeout');
+    }
+
+    if (!pcntl_wifexited($status)) {
+        fail('Child should have exited normally');
+    }
+
+    $exitCode = pcntl_wexitstatus($status);
+    if ($exitCode !== 1) {
+        fail("Child should exit with code 1 when handler throws, got $exitCode");
+    }
+
+    $logs = file_get_contents($logFilePath) ?: '';
+    if (!str_contains($logs, 'failed')) {
+        fail('Log must contain failure indicator');
+    }
+    if (!str_contains($logs, $taskName)) {
+        fail('Log must contain task name');
+    }
+
+    fclose($logStream);
+    @unlink($logFilePath);
+
+    fwrite(STDOUT, "PASS\n");
+    exit(0);
 }
 
 function createSchedulerWorkerInstance(): \CrazyGoat\WorkermanBundle\Worker\SchedulerWorker

--- a/tests/SchedulerWorkerSigchldTest.php
+++ b/tests/SchedulerWorkerSigchldTest.php
@@ -69,46 +69,18 @@ final class SchedulerWorkerSigchldTest extends TestCase
     }
 
     /**
-     * Structural test: verify SchedulerWorker logs exceptions in child process.
-     * This is a regression safety net for Issue #157 — if someone removes the
-     * exception logging or reverts to silently swallowing exceptions, this test
-     * catches it immediately.
+     * Behavioral test: verify SchedulerWorker logs exceptions in child process
+     * and exits with code 1.
+     *
+     * Forks a child that invokes SchedulerWorker::handleChild via reflection
+     * with a TaskHandler that throws. Asserts the child exits with code 1
+     * and the exception is logged via Worker::log().
+     *
+     * Replaces the old source-grep structural test (Issue #306).
      */
     public function testSchedulerWorkerLogsExceptionsInChildProcess(): void
     {
-        $sourceFile = dirname(__DIR__) . '/src/Worker/SchedulerWorker.php';
-        $this->assertFileExists($sourceFile);
-
-        $content = file_get_contents($sourceFile);
-        $this->assertNotFalse($content);
-
-        // Verify the catch block captures the exception variable
-        $this->assertStringContainsString(
-            'catch (\Throwable $e)',
-            $content,
-            'Catch block must capture exception variable for logging (Issue #157)',
-        );
-
-        // Verify the exception is logged via Worker::log()
-        $this->assertStringContainsString(
-            '$this->worker->log(sprintf(',
-            $content,
-            'Exception must be logged via Worker::log() in child process (Issue #157)',
-        );
-
-        // Verify the log message includes exception type
-        $this->assertStringContainsString(
-            '$e::class',
-            $content,
-            'Log message must include exception type for quick identification (Issue #157)',
-        );
-
-        // Verify the log message includes stack trace
-        $this->assertStringContainsString(
-            '$e->getTraceAsString()',
-            $content,
-            'Log message must include stack trace for full diagnostic information (Issue #157)',
-        );
+        $this->runIsolatedTest('scheduler_worker_exception_logging');
     }
 
     // --- PID file handle caching structural tests (Issue #297) ---


### PR DESCRIPTION
## Description

Closes #306

## Changes

- Replace `testSchedulerWorkerLogsExceptionsInChildProcess` (which read `SchedulerWorker.php` as a string and asserted on substrings) with a behavioral test that forks a child, invokes `SchedulerWorker::handleChild` via reflection with a `TaskHandler` that throws, and asserts the child exits with code 1 and the exception is logged via `Worker::log()`

## Changelog

Tests: Replace source-grep exception logging test with behavioral test

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed