### PR TITLE
fix: make ProcessInspector portable across POSIX systems (closes #530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `ProcessInspector::isProcessAlive()` portable across POSIX systems — on macOS and other non-Linux platforms where `/proc` is unavailable, the function now uses `posix_kill($pid, 0)` for the primary liveness check and falls back to a non-blocking `pcntl_waitpid()` to distinguish running processes from zombies. The Linux `/proc/{pid}/status` zombie check is preserved as a Linux-only refinement. `getParentPid()`, `isMasterRunning()`, and `killOrphanedIntermediateFork()` are likewise gated on `PHP_OS_FAMILY === 'Linux'` so they no longer crash on macOS. Fixes `ServerManager::stop()` returning `false` on macOS because `waitForProcessToStop()` never observed the process dying ([#530](https://github.com/crazy-goat/workerman-bundle/issues/530))
+
 ### Tests
 
 - Replace `testRunnerUsesCorrectForkErrorHandling` (which read `Runner.php` as a string) with `testForkFailureThrowsRuntimeException` — a behavioral test that stubs the `fork()` method via a readonly subclass and asserts `RuntimeException` is thrown when `pcntl_fork()` returns `-1`. Removes the dead `fork_failure` case from the isolated test fixture ([#313](https://github.com/crazy-goat/workerman-bundle/issues/313))

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -27,19 +27,27 @@ final readonly class ProcessInspector
             return false;
         }
 
-        $statusFile = "/proc/{$pid}/status";
-        if (is_readable($statusFile)) {
-            $status = file_get_contents($statusFile);
-            if (\is_string($status) && preg_match('/^State:\s+Z/m', $status)) {
-                return false;
+        if (self::isLinux()) {
+            $statusFile = "/proc/{$pid}/status";
+            if (is_readable($statusFile)) {
+                $status = file_get_contents($statusFile);
+                if (\is_string($status) && preg_match('/^State:\s+Z/m', $status)) {
+                    return false;
+                }
             }
+
+            return true;
         }
 
-        return true;
+        return $this->isReaped($pid);
     }
 
     public function getParentPid(int $pid): int
     {
+        if (!self::isLinux() || $pid <= 0) {
+            return 0;
+        }
+
         $statusFile = "/proc/{$pid}/status";
         if (!is_readable($statusFile)) {
             return 0;
@@ -59,11 +67,13 @@ final readonly class ProcessInspector
             return false;
         }
 
-        $cmdline = "/proc/{$masterPid}/cmdline";
-        if (is_readable($cmdline)) {
-            $content = file_get_contents($cmdline);
-            if (\is_string($content) && $content !== '') {
-                return str_contains($content, 'WorkerMan') || str_contains($content, 'php');
+        if (self::isLinux()) {
+            $cmdline = "/proc/{$masterPid}/cmdline";
+            if (is_readable($cmdline)) {
+                $content = file_get_contents($cmdline);
+                if (\is_string($content) && $content !== '') {
+                    return str_contains($content, 'WorkerMan') || str_contains($content, 'php');
+                }
             }
         }
 
@@ -73,6 +83,10 @@ final readonly class ProcessInspector
     public function killOrphanedIntermediateFork(int $parentPid): void
     {
         if ($parentPid <= 0 || !$this->isProcessAlive($parentPid)) {
+            return;
+        }
+
+        if (!self::isLinux()) {
             return;
         }
 
@@ -94,5 +108,33 @@ final readonly class ProcessInspector
             : $stopTimeout + self::TIMEOUT_BUFFER;
 
         return Wait::until(fn(): bool => !$this->isProcessAlive($pid), $timeout);
+    }
+
+    /**
+     * Whether the current platform exposes the Linux `/proc` filesystem.
+     *
+     * `/proc` is a Linux-only virtual filesystem. macOS, the BSDs, and
+     * other POSIX systems do not provide it, so any code that reads
+     * `/proc/{pid}/...` must be gated on this check.
+     */
+    private function isLinux(): bool
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
+    /**
+     * On non-Linux POSIX systems, `posix_kill($pid, 0)` returns true for
+     * zombie processes until the parent reaps them. To distinguish a
+     * running process from a zombie, attempt a non-blocking `waitpid`:
+     * a positive return value means the child was reaped (dead), zero
+     * means it is still running, and a negative return means the pid is
+     * not a direct child of this process (in which case we fall back to
+     * the `posix_kill` result, which already passed).
+     */
+    private function isReaped(int $pid): bool
+    {
+        $result = pcntl_waitpid($pid, $status, \WNOHANG);
+
+        return $result === 0;
     }
 }

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -128,13 +128,14 @@ final readonly class ProcessInspector
      * running process from a zombie, attempt a non-blocking `waitpid`:
      * a positive return value means the child was reaped (dead), zero
      * means it is still running, and a negative return means the pid is
-     * not a direct child of this process (in which case we fall back to
-     * the `posix_kill` result, which already passed).
+     * not a direct child of this process — in which case we trust the
+     * `posix_kill` result that already passed at the call site and
+     * treat the process as alive.
      */
     private function isReaped(int $pid): bool
     {
         $result = pcntl_waitpid($pid, $status, \WNOHANG);
 
-        return $result === 0;
+        return $result <= 0;
     }
 }

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -206,8 +206,40 @@ final class ProcessInspectorTest extends TestCase
     }
 
     /**
+     * Regression test for issue #530: `isProcessAlive()` must return true
+     * for a process that is not a direct child of the current process.
+     *
+     * On non-Linux platforms, the zombie-detection fallback uses
+     * `pcntl_waitpid()`, which returns `-1` for PIDs that are not direct
+     * children. The helper must treat that case as "alive" (trusting the
+     * `posix_kill` check that already passed) rather than as "dead".
+     *
+     * Uses the parent process's PID (always non-child) as the test target.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsProcessAliveReturnsTrueForNonChildProcess(): void
+    {
+        $parentPid = posix_getppid();
+
+        $this->assertTrue(
+            posix_kill($parentPid, 0),
+            'Parent PID must be signalable for this test to be meaningful',
+        );
+
+        $this->assertTrue(
+            $this->inspector->isProcessAlive($parentPid),
+            'isProcessAlive() must return true for a non-child process on ' . PHP_OS_FAMILY,
+        );
+    }
+
+    /**
      * Regression test for issue #530: `isProcessAlive()` must return false
      * for a non-existent PID on every POSIX platform.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
      */
     public function testIsProcessAliveReturnsFalseForNonExistentPid(): void
     {
@@ -222,15 +254,12 @@ final class ProcessInspectorTest extends TestCase
      * non-Linux platforms where `/proc` is unavailable. It returns 0 as
      * a safe fallback (the caller treats 0 as "no parent").
      *
+     * @requires OS Darwin
      * @requires extension pcntl
      * @requires extension posix
      */
     public function testGetParentPidReturnsZeroOnNonLinux(): void
     {
-        if (PHP_OS_FAMILY === 'Linux') {
-            $this->markTestSkipped('Non-Linux-specific test');
-        }
-
         $pid = pcntl_fork();
         if ($pid === -1) {
             $this->markTestSkipped('pcntl_fork failed');

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -132,4 +132,125 @@ final class ProcessInspectorTest extends TestCase
             );
         }
     }
+
+    /**
+     * Regression test for issue #530: `isProcessAlive()` must return false
+     * for a dead process on every POSIX platform, including macOS where
+     * `/proc` is unavailable.
+     *
+     * Forks a child, kills it (leaving a zombie until reaped), and asserts
+     * that `isProcessAlive()` correctly reports the zombie as dead.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsProcessAliveReturnsFalseForDeadProcess(): void
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            $this->assertTrue($this->inspector->isProcessAlive($pid), 'Child should be alive before kill');
+
+            posix_kill($pid, SIGKILL);
+            // Give the kernel a moment to mark the child as a zombie.
+            usleep(50_000);
+
+            $this->assertFalse(
+                $this->inspector->isProcessAlive($pid),
+                'isProcessAlive() must return false for a dead process on ' . PHP_OS_FAMILY,
+            );
+        } finally {
+            // Reap the zombie so it does not leak into other tests.
+            pcntl_waitpid($pid, $status);
+        }
+    }
+
+    /**
+     * Regression test for issue #530: `isProcessAlive()` must return true
+     * for a running child on every POSIX platform.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsProcessAliveReturnsTrueForRunningProcess(): void
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            $this->assertTrue(
+                $this->inspector->isProcessAlive($pid),
+                'isProcessAlive() must return true for a running process on ' . PHP_OS_FAMILY,
+            );
+        } finally {
+            posix_kill($pid, SIGKILL);
+            pcntl_waitpid($pid, $status);
+        }
+    }
+
+    /**
+     * Regression test for issue #530: `isProcessAlive()` must return false
+     * for a non-existent PID on every POSIX platform.
+     */
+    public function testIsProcessAliveReturnsFalseForNonExistentPid(): void
+    {
+        $this->assertFalse($this->inspector->isProcessAlive(0));
+        $this->assertFalse($this->inspector->isProcessAlive(-1));
+        // Use a PID that is extremely unlikely to exist.
+        $this->assertFalse($this->inspector->isProcessAlive(999_999_999));
+    }
+
+    /**
+     * Regression test for issue #530: `getParentPid()` must not crash on
+     * non-Linux platforms where `/proc` is unavailable. It returns 0 as
+     * a safe fallback (the caller treats 0 as "no parent").
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testGetParentPidReturnsZeroOnNonLinux(): void
+    {
+        if (PHP_OS_FAMILY === 'Linux') {
+            $this->markTestSkipped('Non-Linux-specific test');
+        }
+
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            $this->assertSame(
+                0,
+                $this->inspector->getParentPid($pid),
+                'getParentPid() must return 0 on non-Linux platforms',
+            );
+        } finally {
+            posix_kill($pid, SIGKILL);
+            pcntl_waitpid($pid, $status);
+        }
+    }
 }


### PR DESCRIPTION
## Description

Closes #530

`ProcessInspector::isProcessAlive()` read `/proc/{pid}/status` to detect zombie state. `/proc` is a Linux-only filesystem, so on macOS the function always returned `true` even for dead processes. This broke `ServerManager::stop()` on macOS: `waitForProcessToStop()` polled `isProcessAlive()` and never saw the process die, so it timed out and `stop()` returned `false`.

## Changes

- `isProcessAlive()`: use `posix_kill(, 0)` as the primary liveness check on all POSIX systems; keep the `/proc/{pid}/status` zombie refinement as a Linux-only optimization.
- On non-Linux systems, distinguish running processes from zombies via a non-blocking `pcntl_waitpid()` (WNOHANG). A positive return means reaped (dead), zero means still running, and a negative return means the PID is not a direct child — in which case we trust the `posix_kill` result that already passed.
- Gate `getParentPid()`, `isMasterRunning()`, and `killOrphanedIntermediateFork()` on `PHP_OS_FAMILY === 'Linux'` so they no longer touch `/proc` on macOS.
- Add regression tests covering dead/running/non-existent PIDs, the non-direct-child case, and the non-Linux `getParentPid()` fallback.

## Changelog

`ProcessInspector` is now portable across POSIX systems. On macOS and other non-Linux platforms where `/proc` is unavailable, `isProcessAlive()` uses `posix_kill(, 0)` for the primary liveness check and falls back to a non-blocking `pcntl_waitpid()` to distinguish running processes from zombies. The Linux `/proc/{pid}/status` zombie check is preserved as a Linux-only refinement. `getParentPid()`, `isMasterRunning()`, and `killOrphanedIntermediateFork()` are likewise gated on `PHP_OS_FAMILY === 'Linux'` so they no longer crash on macOS. Fixes `ServerManager::stop()` returning `false` on macOS because `waitForProcessToStop()` never observed the process dying.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed