### PR TITLE
feat: add PHPBench benchmark suite (closes #328)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,9 +83,29 @@ jobs:
       - name: Run tests
         run: composer test
 
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run benchmarks
+        run: composer bench
+
   ci:
     name: CI
-    needs: [lint, tests]
+    needs: [lint, tests, benchmark]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -93,3 +113,5 @@ jobs:
         run: |
           if [ "${{ needs.lint.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.tests.result }}" != "success" ]; then exit 1; fi
+          # Benchmark is advisory initially — log status but do not block merge
+          echo "Benchmark status: ${{ needs.benchmark.result }}"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,6 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests')
+    ->in(__DIR__ . '/benchmarks')
 ;
 
 $rules = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::extractHeaders`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
+- Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::convert`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::extractHeaders`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
+
 ### Fixed
 
 - Make `ProcessInspector::isProcessAlive()` portable across POSIX systems — on macOS and other non-Linux platforms where `/proc` is unavailable, the function now uses `posix_kill($pid, 0)` for the primary liveness check and falls back to a non-blocking `pcntl_waitpid()` to distinguish running processes from zombies. The Linux `/proc/{pid}/status` zombie check is preserved as a Linux-only refinement. `getParentPid()`, `isMasterRunning()`, and `killOrphanedIntermediateFork()` are likewise gated on `PHP_OS_FAMILY === 'Linux'` so they no longer crash on macOS. Fixes `ServerManager::stop()` returning `false` on macOS because `waitForProcessToStop()` never observed the process dying ([#530](https://github.com/crazy-goat/workerman-bundle/issues/530))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,34 @@ rm .git/hooks/pre-push
    > - On macOS, ports below 1024 require root. Ports 8888 and 9999 are above
    >   that threshold and should work without special privileges.
 
-3. Ensure all checks pass before pushing
+3. Run benchmarks locally (optional but recommended for performance-related changes):
+   ```bash
+   composer bench
+   ```
 
-4. Update CHANGELOG.md:
+   The benchmark suite uses PHPBench and covers the documented hot paths:
+   - `RequestConverter::toSymfonyRequest`
+   - `ResponseConverter::extractHeaders`
+   - `MemoryRebootStrategy::shouldReboot`
+   - `PeriodicalTrigger::getNextRunDate`
+   - `HttpRequestHandler::__invoke` (composed middleware chain)
+
+   Benchmarks run with 1000 revolutions × 5 iterations after a 1-iteration warmup.
+   Results are printed as an aggregate report showing memory peak, mode, and
+   relative standard deviation per subject.
+
+   > **Interpreting results**
+   > - `mode` — the most common execution time (lower is better)
+   > - `mem_peak` — peak memory allocated during the benchmark
+   > - `rstdev` — relative standard deviation (lower means more stable results)
+   >
+   > When making performance changes, compare the before/after mode values for
+   > the relevant benchmark subjects. A regression is suspected when mode
+   > increases by more than 5 % on the same hardware.
+
+4. Ensure all checks pass before pushing
+
+5. Update CHANGELOG.md:
    - Add entry under `[Unreleased]` section
    - Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
    - Include issue number (e.g., `(#65)`)
@@ -91,6 +116,7 @@ The CI workflow (`.github/workflows/tests.yaml`) runs on every pull request:
 
 - **Lint job**: Validates `composer.json`, runs security audit, and checks code style
 - **Tests job**: Runs PHPUnit tests across the supported PHP (8.2–8.5) and Symfony (6.4–8.0) version matrix
+- **Benchmark job**: Runs the PHPBench suite in advisory mode (results are logged but do not block merge)
 
 ## Code Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ rm .git/hooks/pre-push
 
    The benchmark suite uses PHPBench and covers the documented hot paths:
    - `RequestConverter::toSymfonyRequest`
-   - `ResponseConverter::extractHeaders`
+   - `ResponseConverter::convert`
    - `MemoryRebootStrategy::shouldReboot`
    - `PeriodicalTrigger::getNextRunDate`
    - `HttpRequestHandler::__invoke` (composed middleware chain)

--- a/benchmarks/BenchKernel.php
+++ b/benchmarks/BenchKernel.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
+
+/**
+ * Minimal kernel implementation for benchmarking.
+ */
+final class BenchKernel implements KernelInterface, TerminableInterface
+{
+    public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
+    {
+    }
+
+    public function boot(): void
+    {
+    }
+
+    public function shutdown(): void
+    {
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(\Symfony\Component\Config\Loader\LoaderInterface $loader): void
+    {
+    }
+
+    public function handle(\Symfony\Component\HttpFoundation\Request $request, int $type = 1, bool $catch = true): \Symfony\Component\HttpFoundation\Response
+    {
+        return new SymfonyResponse('Bench response');
+    }
+
+    public function getBundles(): array
+    {
+        return [];
+    }
+
+    public function getBundle(string $name): \Symfony\Component\HttpKernel\Bundle\BundleInterface
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function locateResource(string $name): string
+    {
+        return '';
+    }
+
+    public function getEnvironment(): string
+    {
+        return 'bench';
+    }
+
+    public function isDebug(): bool
+    {
+        return false;
+    }
+
+    public function getProjectDir(): string
+    {
+        return '/tmp';
+    }
+
+    public function getCacheDir(): string
+    {
+        return '/tmp/cache';
+    }
+
+    public function getBuildDir(): string
+    {
+        return '/tmp/build';
+    }
+
+    public function getShareDir(): ?string
+    {
+        return null;
+    }
+
+    public function getLogDir(): string
+    {
+        return '/tmp/log';
+    }
+
+    public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function getStartTime(): float
+    {
+        return 0.0;
+    }
+
+    public function getCharset(): string
+    {
+        return 'UTF-8';
+    }
+}

--- a/benchmarks/BenchMiddleware.php
+++ b/benchmarks/BenchMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Http\Request;
+use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
+use Workerman\Protocols\Http\Response as WorkermanResponse;
+
+/**
+ * Simple header-adding middleware for benchmarking.
+ */
+final readonly class BenchMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private string $header,
+        private string $value,
+    ) {
+    }
+
+    public function __invoke(Request $request, callable $next): WorkermanResponse
+    {
+        $request->setHeader($this->header, $this->value);
+
+        return $next($request);
+    }
+}

--- a/benchmarks/BenchRebootStrategy.php
+++ b/benchmarks/BenchRebootStrategy.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
+
+/**
+ * No-op reboot strategy for benchmarking.
+ */
+final class BenchRebootStrategy implements RebootStrategyInterface
+{
+    public function shouldReboot(): bool
+    {
+        return false;
+    }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
+}

--- a/benchmarks/BenchTcpConnection.php
+++ b/benchmarks/BenchTcpConnection.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use Workerman\Connection\TcpConnection;
+
+/**
+ * Minimal TcpConnection stub for benchmarking — avoids socket operations
+ * and provides no-op send/close implementations.
+ */
+final class BenchTcpConnection extends TcpConnection
+{
+    public function __construct()
+    {
+        // Avoid parent constructor socket operations
+    }
+
+    public function send(mixed $sendBuffer, bool $raw = false): bool
+    {
+        return true;
+    }
+
+    public function close(mixed $data = null, bool $raw = false): void
+    {
+    }
+}

--- a/benchmarks/HttpRequestHandlerBench.php
+++ b/benchmarks/HttpRequestHandlerBench.php
@@ -8,18 +8,12 @@ use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
-use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
-use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use PhpBench\Benchmark\Metadata\Annotations\Warmup;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\HttpKernel\TerminableInterface;
 use Workerman\Connection\TcpConnection;
-use Workerman\Protocols\Http\Response as WorkermanResponse;
 
 /**
  * Benchmark HttpRequestHandler::__invoke — the composed middleware chain
@@ -81,137 +75,5 @@ final class HttpRequestHandlerBench
     public function benchWithMiddleware(): void
     {
         ($this->handlerWithMiddleware)($this->connection, $this->request);
-    }
-}
-
-/**
- * Minimal kernel implementation for benchmarking.
- */
-final class BenchKernel implements KernelInterface, TerminableInterface
-{
-    public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
-    {
-    }
-
-    public function boot(): void
-    {
-    }
-
-    public function shutdown(): void
-    {
-    }
-
-    public function registerBundles(): iterable
-    {
-        return [];
-    }
-
-    public function registerContainerConfiguration(\Symfony\Component\Config\Loader\LoaderInterface $loader): void
-    {
-    }
-
-    public function handle(\Symfony\Component\HttpFoundation\Request $request, int $type = 1, bool $catch = true): \Symfony\Component\HttpFoundation\Response
-    {
-        return new SymfonyResponse('Bench response');
-    }
-
-    public function getBundles(): array
-    {
-        return [];
-    }
-
-    public function getBundle(string $name): \Symfony\Component\HttpKernel\Bundle\BundleInterface
-    {
-        throw new \RuntimeException('Not implemented');
-    }
-
-    public function locateResource(string $name): string
-    {
-        return '';
-    }
-
-    public function getEnvironment(): string
-    {
-        return 'bench';
-    }
-
-    public function isDebug(): bool
-    {
-        return false;
-    }
-
-    public function getProjectDir(): string
-    {
-        return '/tmp';
-    }
-
-    public function getCacheDir(): string
-    {
-        return '/tmp/cache';
-    }
-
-    public function getBuildDir(): string
-    {
-        return '/tmp/build';
-    }
-
-    public function getShareDir(): ?string
-    {
-        return null;
-    }
-
-    public function getLogDir(): string
-    {
-        return '/tmp/log';
-    }
-
-    public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
-    {
-        throw new \RuntimeException('Not implemented');
-    }
-
-    public function getStartTime(): float
-    {
-        return 0.0;
-    }
-
-    public function getCharset(): string
-    {
-        return 'UTF-8';
-    }
-}
-
-/**
- * No-op reboot strategy for benchmarking.
- */
-final class BenchRebootStrategy implements RebootStrategyInterface
-{
-    public function shouldReboot(): bool
-    {
-        return false;
-    }
-
-    public function needsPeakMemory(): bool
-    {
-        return false;
-    }
-}
-
-/**
- * Simple header-adding middleware for benchmarking.
- */
-final readonly class BenchMiddleware implements MiddlewareInterface
-{
-    public function __construct(
-        private string $header,
-        private string $value,
-    ) {
-    }
-
-    public function __invoke(Request $request, callable $next): WorkermanResponse
-    {
-        $request->setHeader($this->header, $this->value);
-
-        return $next($request);
     }
 }

--- a/benchmarks/HttpRequestHandlerBench.php
+++ b/benchmarks/HttpRequestHandlerBench.php
@@ -50,21 +50,7 @@ final class HttpRequestHandlerBench
             );
 
         $this->request = new Request("GET / HTTP/1.1\r\nHost: test\r\n\r\n");
-        $this->connection = new class extends TcpConnection {
-            public function __construct()
-            {
-                // Avoid parent constructor socket operations
-            }
-
-            public function send(mixed $sendBuffer, bool $raw = false): bool
-            {
-                return true;
-            }
-
-            public function close(mixed $data = null, bool $raw = false): void
-            {
-            }
-        };
+        $this->connection = new BenchTcpConnection();
     }
 
     public function benchNoMiddleware(): void

--- a/benchmarks/HttpRequestHandlerBench.php
+++ b/benchmarks/HttpRequestHandlerBench.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
+use CrazyGoat\WorkermanBundle\Http\Request;
+use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
+use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
+use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
+use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http\Response as WorkermanResponse;
+
+/**
+ * Benchmark HttpRequestHandler::__invoke — the composed middleware chain
+ * that represents the full per-request dispatch hot path.
+ *
+ * The pipeline is built once and cached; only the controller closure
+ * (capturing the connection) is created per-request.
+ *
+ * @BeforeMethods("init")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class HttpRequestHandlerBench
+{
+    private HttpRequestHandler $handlerNoMiddleware;
+    private HttpRequestHandler $handlerWithMiddleware;
+    private Request $request;
+    private TcpConnection $connection;
+
+    public function init(): void
+    {
+        $kernel = new BenchKernel();
+        $responseConverter = new ResponseConverter([new DefaultResponseStrategy()]);
+        $controller = new SymfonyController($kernel, $responseConverter);
+        $rebootStrategy = new BenchRebootStrategy();
+
+        $this->handlerNoMiddleware = new HttpRequestHandler($controller, $rebootStrategy);
+        $this->handlerWithMiddleware = (new HttpRequestHandler($controller, $rebootStrategy))
+            ->withMiddlewares(
+                new BenchMiddleware('X-Bench-1', 'value-1'),
+                new BenchMiddleware('X-Bench-2', 'value-2'),
+                new BenchMiddleware('X-Bench-3', 'value-3'),
+            );
+
+        $this->request = new Request("GET / HTTP/1.1\r\nHost: test\r\n\r\n");
+        $this->connection = new class extends TcpConnection {
+            public function __construct()
+            {
+                // Avoid parent constructor socket operations
+            }
+
+            public function send(mixed $sendBuffer, bool $raw = false): bool
+            {
+                return true;
+            }
+
+            public function close(mixed $data = null, bool $raw = false): void
+            {
+            }
+        };
+    }
+
+    public function benchNoMiddleware(): void
+    {
+        ($this->handlerNoMiddleware)($this->connection, $this->request);
+    }
+
+    public function benchWithMiddleware(): void
+    {
+        ($this->handlerWithMiddleware)($this->connection, $this->request);
+    }
+}
+
+/**
+ * Minimal kernel implementation for benchmarking.
+ */
+final class BenchKernel implements KernelInterface, TerminableInterface
+{
+    public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
+    {
+    }
+
+    public function boot(): void
+    {
+    }
+
+    public function shutdown(): void
+    {
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(\Symfony\Component\Config\Loader\LoaderInterface $loader): void
+    {
+    }
+
+    public function handle(\Symfony\Component\HttpFoundation\Request $request, int $type = 1, bool $catch = true): \Symfony\Component\HttpFoundation\Response
+    {
+        return new SymfonyResponse('Bench response');
+    }
+
+    public function getBundles(): array
+    {
+        return [];
+    }
+
+    public function getBundle(string $name): \Symfony\Component\HttpKernel\Bundle\BundleInterface
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function locateResource(string $name): string
+    {
+        return '';
+    }
+
+    public function getEnvironment(): string
+    {
+        return 'bench';
+    }
+
+    public function isDebug(): bool
+    {
+        return false;
+    }
+
+    public function getProjectDir(): string
+    {
+        return '/tmp';
+    }
+
+    public function getCacheDir(): string
+    {
+        return '/tmp/cache';
+    }
+
+    public function getBuildDir(): string
+    {
+        return '/tmp/build';
+    }
+
+    public function getShareDir(): ?string
+    {
+        return null;
+    }
+
+    public function getLogDir(): string
+    {
+        return '/tmp/log';
+    }
+
+    public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function getStartTime(): float
+    {
+        return 0.0;
+    }
+
+    public function getCharset(): string
+    {
+        return 'UTF-8';
+    }
+}
+
+/**
+ * No-op reboot strategy for benchmarking.
+ */
+final class BenchRebootStrategy implements RebootStrategyInterface
+{
+    public function shouldReboot(): bool
+    {
+        return false;
+    }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
+}
+
+/**
+ * Simple header-adding middleware for benchmarking.
+ */
+final readonly class BenchMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private string $header,
+        private string $value,
+    ) {
+    }
+
+    public function __invoke(Request $request, callable $next): WorkermanResponse
+    {
+        $request->setHeader($this->header, $this->value);
+
+        return $next($request);
+    }
+}

--- a/benchmarks/MemoryRebootStrategyBench.php
+++ b/benchmarks/MemoryRebootStrategyBench.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Reboot\Strategy\MemoryRebootStrategy;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Benchmark MemoryRebootStrategy::shouldReboot — the per-request check that
+ * decides whether a worker should be gracefully restarted based on memory
+ * consumption.
+ *
+ * @BeforeMethods("init")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class MemoryRebootStrategyBench
+{
+    private MemoryRebootStrategy $strategyBelowLimit;
+    private MemoryRebootStrategy $strategyAboveLimit;
+    private MemoryRebootStrategy $strategyWithGc;
+
+    public function init(): void
+    {
+        // Current memory usage is typically well below 1 GiB in a benchmark
+        $this->strategyBelowLimit = new MemoryRebootStrategy(
+            limit: 1024 * 1024 * 1024, // 1 GiB
+            gcLimit: null,
+        );
+
+        // Set limit to 1 byte so every call triggers the > check
+        $this->strategyAboveLimit = new MemoryRebootStrategy(
+            limit: 1,
+            gcLimit: null,
+        );
+
+        // Strategy with GC path — gcLimit below typical usage, cooldown long enough
+        // that GC is only scheduled once during warmup
+        $this->strategyWithGc = new MemoryRebootStrategy(
+            limit: 1024 * 1024 * 1024,
+            gcLimit: 1,
+            gcCooldown: 3600,
+        );
+    }
+
+    public function benchBelowLimit(): void
+    {
+        $this->strategyBelowLimit->shouldReboot();
+    }
+
+    public function benchAboveLimit(): void
+    {
+        $this->strategyAboveLimit->shouldReboot();
+    }
+
+    public function benchWithGcPath(): void
+    {
+        $this->strategyWithGc->shouldReboot();
+    }
+}

--- a/benchmarks/PeriodicalTriggerBench.php
+++ b/benchmarks/PeriodicalTriggerBench.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Scheduler\Trigger\PeriodicalTrigger;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Benchmark PeriodicalTrigger::getNextRunDate — the scheduler hot path that
+ * calculates the next execution time for periodic tasks.
+ *
+ * @BeforeMethods("init")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class PeriodicalTriggerBench
+{
+    private PeriodicalTrigger $secondsTrigger;
+    private PeriodicalTrigger $isoTrigger;
+    private PeriodicalTrigger $stringTrigger;
+    private \DateTimeImmutable $now;
+
+    public function init(): void
+    {
+        $this->secondsTrigger = new PeriodicalTrigger(60);
+        $this->isoTrigger = new PeriodicalTrigger('PT1H');
+        $this->stringTrigger = new PeriodicalTrigger('+1 day');
+        $this->now = new \DateTimeImmutable('2024-01-15 12:00:00');
+    }
+
+    public function benchSecondsInterval(): void
+    {
+        $this->secondsTrigger->getNextRunDate($this->now);
+    }
+
+    public function benchIsoInterval(): void
+    {
+        $this->isoTrigger->getNextRunDate($this->now);
+    }
+
+    public function benchStringInterval(): void
+    {
+        $this->stringTrigger->getNextRunDate($this->now);
+    }
+}

--- a/benchmarks/PeriodicalTriggerBench.php
+++ b/benchmarks/PeriodicalTriggerBench.php
@@ -36,19 +36,16 @@ final class PeriodicalTriggerBench
 
     public function benchSecondsInterval(): void
     {
-        // @phpstan-ignore method.resultUnused
         $this->secondsTrigger->getNextRunDate($this->now);
     }
 
     public function benchIsoInterval(): void
     {
-        // @phpstan-ignore method.resultUnused
         $this->isoTrigger->getNextRunDate($this->now);
     }
 
     public function benchStringInterval(): void
     {
-        // @phpstan-ignore method.resultUnused
         $this->stringTrigger->getNextRunDate($this->now);
     }
 }

--- a/benchmarks/PeriodicalTriggerBench.php
+++ b/benchmarks/PeriodicalTriggerBench.php
@@ -36,16 +36,19 @@ final class PeriodicalTriggerBench
 
     public function benchSecondsInterval(): void
     {
+        // @phpstan-ignore method.resultUnused
         $this->secondsTrigger->getNextRunDate($this->now);
     }
 
     public function benchIsoInterval(): void
     {
+        // @phpstan-ignore method.resultUnused
         $this->isoTrigger->getNextRunDate($this->now);
     }
 
     public function benchStringInterval(): void
     {
+        // @phpstan-ignore method.resultUnused
         $this->stringTrigger->getNextRunDate($this->now);
     }
 }

--- a/benchmarks/RequestConverterBench.php
+++ b/benchmarks/RequestConverterBench.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\DTO\RequestConverter;
+use CrazyGoat\WorkermanBundle\Http\Request;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Benchmark RequestConverter::toSymfonyRequest — the first hot-path stage
+ * where a Workerman HTTP request is transformed into a Symfony Request.
+ *
+ * @BeforeMethods("init")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class RequestConverterBench
+{
+    private Request $simpleRequest;
+    private Request $headerHeavyRequest;
+    private Request $multipartRequest;
+
+    public function init(): void
+    {
+        $this->simpleRequest = new Request("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: example.com\r\n";
+        $buffer .= "Accept: application/json\r\n";
+        $buffer .= "Authorization: Basic dXNlcjpwYXNz\r\n";
+        $buffer .= "Content-Type: application/json\r\n";
+        $buffer .= "Content-Length: 123\r\n";
+        $buffer .= "X-Custom: custom-value\r\n";
+        $buffer .= "Cookie: session=abc123\r\n";
+        $buffer .= "\r\n";
+        $this->headerHeavyRequest = new Request($buffer);
+
+        $body = '';
+        $body .= "--TestBoundary\r\n";
+        $body .= "Content-Disposition: form-data; name=\"test_file\"; filename=\"test.txt\"\r\n";
+        $body .= "Content-Type: text/plain\r\n\r\n";
+        $body .= "test content\r\n";
+        $body .= "--TestBoundary--\r\n";
+
+        $buffer = "POST /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Content-Type: multipart/form-data; boundary=TestBoundary\r\n";
+        $buffer .= 'Content-Length: ' . strlen($body) . "\r\n";
+        $buffer .= "\r\n";
+        $this->multipartRequest = new Request($buffer . $body);
+    }
+
+    public function benchSimpleRequest(): void
+    {
+        RequestConverter::toSymfonyRequest($this->simpleRequest);
+    }
+
+    public function benchHeaderHeavyRequest(): void
+    {
+        RequestConverter::toSymfonyRequest($this->headerHeavyRequest);
+    }
+
+    public function benchMultipartRequest(): void
+    {
+        RequestConverter::toSymfonyRequest($this->multipartRequest);
+    }
+}

--- a/benchmarks/ResponseConverterBench.php
+++ b/benchmarks/ResponseConverterBench.php
@@ -41,6 +41,15 @@ final class ResponseConverterBench
             {
                 // Avoid parent constructor socket operations
             }
+
+            public function send(mixed $sendBuffer, bool $raw = false): bool
+            {
+                return true;
+            }
+
+            public function close(mixed $data = null, bool $raw = false): void
+            {
+            }
         };
 
         $this->simpleResponse = new Response('Hello World', Response::HTTP_OK, [

--- a/benchmarks/ResponseConverterBench.php
+++ b/benchmarks/ResponseConverterBench.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Symfony\Component\HttpFoundation\Response;
+use Workerman\Connection\TcpConnection;
+
+/**
+ * Benchmark ResponseConverter::convert (and the inner extractHeaders) —
+ * the stage where a Symfony Response is transformed into a Workerman Response.
+ *
+ * The header-normalisation cache is the key optimisation here; the benchmark
+ * exercises both cold-cache and warm-cache paths.
+ *
+ * @BeforeMethods("init")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class ResponseConverterBench
+{
+    private ResponseConverter $converter;
+    private TcpConnection $connection;
+    private Response $simpleResponse;
+    private Response $headerHeavyResponse;
+    private Response $irregularHeadersResponse;
+
+    public function init(): void
+    {
+        $this->converter = new ResponseConverter([new DefaultResponseStrategy()]);
+        $this->connection = new class extends TcpConnection {
+            public function __construct()
+            {
+                // Avoid parent constructor socket operations
+            }
+        };
+
+        $this->simpleResponse = new Response('Hello World', Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+
+        $this->headerHeavyResponse = new Response('Hello World', Response::HTTP_OK, [
+            'Content-Type' => 'application/json',
+            'X-Rate-Limit' => '100',
+            'X-Request-Id' => 'uuid-1234',
+            'Cache-Control' => 'no-cache',
+            'Vary' => 'Accept-Encoding',
+        ]);
+
+        $this->irregularHeadersResponse = new Response('Hello World', Response::HTTP_OK, [
+            'etag' => '"abc123"',
+            'content-md5' => 'deadbeef',
+            'www-authenticate' => 'Bearer',
+            'dnt' => '1',
+        ]);
+    }
+
+    public function benchSimpleResponse(): void
+    {
+        $this->converter->convert($this->simpleResponse, $this->connection);
+    }
+
+    public function benchHeaderHeavyResponse(): void
+    {
+        $this->converter->convert($this->headerHeavyResponse, $this->connection);
+    }
+
+    public function benchIrregularHeadersResponse(): void
+    {
+        $this->converter->convert($this->irregularHeadersResponse, $this->connection);
+    }
+}

--- a/benchmarks/ResponseConverterBench.php
+++ b/benchmarks/ResponseConverterBench.php
@@ -36,21 +36,7 @@ final class ResponseConverterBench
     public function init(): void
     {
         $this->converter = new ResponseConverter([new DefaultResponseStrategy()]);
-        $this->connection = new class extends TcpConnection {
-            public function __construct()
-            {
-                // Avoid parent constructor socket operations
-            }
-
-            public function send(mixed $sendBuffer, bool $raw = false): bool
-            {
-                return true;
-            }
-
-            public function close(mixed $data = null, bool $raw = false): void
-            {
-            }
-        };
+        $this->connection = new BenchTcpConnection();
 
         $this->simpleResponse = new Response('Hello World', Response::HTTP_OK, [
             'Content-Type' => 'text/plain',

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "dragonmantank/cron-expression": "^3.4",
         "guzzlehttp/guzzle": "^7.8",
         "php-cs-fixer/shim": "^3.75",
+        "phpbench/phpbench": "^1.2",
         "phpunit/phpunit": "^10.4",
         "rector/rector": "^2.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0"
@@ -102,6 +103,9 @@
         ],
         "test:build:bin": [
             "@php -d phar.readonly=0 vendor/bin/phpunit --filter='BuildBin' tests/Command/"
+        ],
+        "bench": [
+            "vendor/bin/phpbench run --report=aggregate"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "CrazyGoat\\WorkermanBundle\\Test\\": "tests/"
+            "CrazyGoat\\WorkermanBundle\\Test\\": "tests/",
+            "CrazyGoat\\WorkermanBundle\\Benchmark\\": "benchmarks/"
         }
     },
     "config": {

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,13 @@
+{
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "benchmarks",
+    "runner.revs": 1000,
+    "runner.iterations": 5,
+    "runner.warmup": 1,
+    "report.generators": {
+        "aggregate": {
+            "generator": "expression",
+            "cols": ["benchmark", "subject", "revs", "its", "mem_peak", "mode", "rstdev"]
+        }
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ parameters:
 	paths:
 		- src
 		- tests
+		- benchmarks
 	ignoreErrors:
 		-
 			message: '#never returns string so it can be removed from the return type#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,7 @@ parameters:
 			message: '#never returns string so it can be removed from the return type#'
 			path: tests/
 			reportUnmatched: false
+		-
+			message: '#Call to method.*on a separate line has no effect#'
+			path: benchmarks/
+			reportUnmatched: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,7 +8,9 @@ parameters:
 	ignoreErrors:
 		-
 			message: '#never returns string so it can be removed from the return type#'
-			path: tests/
+			paths:
+				- tests/
+				- benchmarks/
 			reportUnmatched: false
 		-
 			message: '#Call to method.*on a separate line has no effect#'

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
-    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests',])
+    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests', __DIR__ . '/benchmarks',])
     ->withPhpSets(php82: true)
     ->withPreparedSets(deadCode: true, codeQuality: true, typeDeclarations: true, symfonyCodeQuality: true);


### PR DESCRIPTION
## Description

Closes #328

## Changes

- Add PHPBench configuration (phpbench.json) with 1000 revs × 5 iterations and 1-iteration warmup
- Create benchmarks/ directory with 5 hot-path benchmarks:
  - RequestConverter::toSymfonyRequest (simple, header-heavy, multipart requests)
  - ResponseConverter::convert (simple, header-heavy, irregular headers)
  - MemoryRebootStrategy::shouldReboot (below limit, above limit, with GC path)
  - PeriodicalTrigger::getNextRunDate (seconds, ISO, string intervals)
  - HttpRequestHandler::__invoke (no middleware, with 3 middlewares)
- Add composer bench script: vendor/bin/phpbench run --report=aggregate
- Add CI benchmark job (advisory mode — logs status but does not block merge)
- Document measurement protocol in CONTRIBUTING.md
- Update CHANGELOG.md under [Unreleased]
- Include benchmarks/ in php-cs-fixer, phpstan, and rector configurations
- Add CrazyGoat\WorkermanBundle\Benchmark\ namespace to autoload-dev

## Changelog

Added PHPBench benchmark suite covering the five documented hot paths. Run via composer bench. CI executes the suite on every PR in advisory mode.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed