### PR TITLE
refactor(phar): extract PharCapabilities from PharBuilder (closes #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::convert`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
 
+### Changed
+
+- Extract the side-effectful `phar.readonly` INI probe and `\Phar` extension presence check out of `PharBuilder::build()` into a new `PharCapabilities` collaborator. `PharBuilder` now accepts the capability checker via constructor (defaults to a live `PharCapabilities::probe()`), making the runtime checks individually testable and stubbable. The DI container registers `PharCapabilities` and injects it into the `workerman.phar_builder` service. No behavioural change observable for the `build:phar` flow ([#372](https://github.com/crazy-goat/workerman-bundle/issues/372))
+
 ### Fixed
 
 - Make `ProcessInspector::isProcessAlive()` portable across POSIX systems — on macOS and other non-Linux platforms where `/proc` is unavailable, the function now uses `posix_kill($pid, 0)` for the primary liveness check and falls back to a non-blocking `pcntl_waitpid()` to distinguish running processes from zombies. The Linux `/proc/{pid}/status` zombie check is preserved as a Linux-only refinement. `getParentPid()`, `isMasterRunning()`, and `killOrphanedIntermediateFork()` are likewise gated on `PHP_OS_FAMILY === 'Linux'` so they no longer crash on macOS. Fixes `ServerManager::stop()` returning `false` on macOS because `waitForProcessToStop()` never observed the process dying ([#530](https://github.com/crazy-goat/workerman-bundle/issues/530))

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -17,6 +17,7 @@ use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
 use CrazyGoat\WorkermanBundle\Phar\BinaryComposer;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
+use CrazyGoat\WorkermanBundle\Phar\PharCapabilities;
 use CrazyGoat\WorkermanBundle\Phar\SfxDownloader;
 use CrazyGoat\WorkermanBundle\Phar\SfxSourceResolver;
 use CrazyGoat\WorkermanBundle\ProcessInspector;
@@ -200,10 +201,15 @@ final readonly class ServicesConfigurator
     private function configureBuildServices(ContainerBuilder $container): void
     {
         $container
+            ->register(PharCapabilities::class)
+        ;
+
+        $container
             ->register('workerman.phar_builder', PharBuilder::class)
             ->setArguments([
                 $container->getParameter('kernel.project_dir'),
                 $container->getParameter('kernel.environment'),
+                new Reference(PharCapabilities::class),
             ])
         ;
 

--- a/src/Phar/PharBuilder.php
+++ b/src/Phar/PharBuilder.php
@@ -16,10 +16,14 @@ namespace CrazyGoat\WorkermanBundle\Phar;
  */
 final readonly class PharBuilder
 {
+    private PharCapabilities $capabilities;
+
     public function __construct(
         private string $projectDir,
         private string $environment,
+        ?PharCapabilities $capabilities = null,
     ) {
+        $this->capabilities = $capabilities ?? PharCapabilities::probe();
     }
 
     /**
@@ -46,13 +50,7 @@ final readonly class PharBuilder
      */
     public function build(array $buildConfig, string $pharPath, bool $includeTests = false): string
     {
-        if ((bool) ini_get('phar.readonly')) {
-            throw new \RuntimeException('phar.readonly must be disabled in php.ini. Set phar.readonly=0 and try again.');
-        }
-
-        if (!class_exists(\Phar::class)) {
-            throw new \RuntimeException('The Phar extension is required to build PHAR archives.');
-        }
+        $this->capabilities->assertCanBuild();
 
         $buildDir = \dirname($pharPath);
         if (!is_dir($buildDir) && !mkdir($buildDir, 0755, true) && !is_dir($buildDir)) {

--- a/src/Phar/PharCapabilities.php
+++ b/src/Phar/PharCapabilities.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Phar;
+
+/**
+ * Probes the runtime environment for PHAR-building capabilities.
+ *
+ * Centralises the side-effectful checks that `PharBuilder` previously
+ * performed inline (`phar.readonly` INI probe, `\Phar` extension presence).
+ * Extracting them into a dedicated collaborator makes the checks
+ * individually testable and lets `PharBuilder` accept a stub in unit tests.
+ *
+ * @internal
+ */
+final readonly class PharCapabilities
+{
+    public function __construct(
+        private bool $pharReadOnly,
+        private bool $pharExtensionLoaded,
+    ) {
+    }
+
+    /**
+     * Probe the live PHP runtime.
+     */
+    public static function probe(): self
+    {
+        return new self(
+            (bool) ini_get('phar.readonly'),
+            class_exists(\Phar::class),
+        );
+    }
+
+    public function isPharReadOnly(): bool
+    {
+        return $this->pharReadOnly;
+    }
+
+    public function isPharExtensionLoaded(): bool
+    {
+        return $this->pharExtensionLoaded;
+    }
+
+    /**
+     * Assert that the runtime can build PHAR archives.
+     *
+     * @throws \RuntimeException when a required capability is missing
+     */
+    public function assertCanBuild(): void
+    {
+        if ($this->pharReadOnly) {
+            throw new \RuntimeException('phar.readonly must be disabled in php.ini. Set phar.readonly=0 and try again.');
+        }
+
+        if (!$this->pharExtensionLoaded) {
+            throw new \RuntimeException('The Phar extension is required to build PHAR archives.');
+        }
+    }
+}

--- a/tests/Phar/PharBuilderTest.php
+++ b/tests/Phar/PharBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test\Phar;
 
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
+use CrazyGoat\WorkermanBundle\Phar\PharCapabilities;
 use PHPUnit\Framework\TestCase;
 
 final class PharBuilderTest extends TestCase
@@ -294,5 +295,60 @@ final class PharBuilderTest extends TestCase
         $stub = (new PharBuilder('/p', 'test'))->generateStub([]);
 
         self::assertStringContainsString('new App\\Kernel(', $stub);
+    }
+
+    public function testBuildUsesInjectedCapabilities(): void
+    {
+        if ((bool) ini_get('phar.readonly')) {
+            self::markTestSkipped('phar.readonly is On — cannot build PHARs.');
+        }
+
+        mkdir($this->tempDir . '/src', 0755, true);
+        mkdir($this->tempDir . '/vendor', 0755, true);
+        file_put_contents($this->tempDir . '/src/App.php', '<?php');
+        file_put_contents($this->tempDir . '/vendor/autoload.php', '<?php');
+
+        $pharPath = $this->tempDir . '/build/test.phar';
+        (new PharBuilder($this->tempDir, 'test', new PharCapabilities(false, true)))->build([
+            'kernel_class' => 'App\\Kernel',
+            'exclude_patterns' => [],
+            'exclude_files' => [],
+        ], $pharPath);
+
+        self::assertFileExists($pharPath);
+
+        $phar = new \Phar($pharPath);
+        self::assertTrue(isset($phar['src/App.php']));
+
+        unset($phar);
+        \Phar::unlinkArchive($pharPath);
+    }
+
+    public function testBuildThrowsWhenInjectedCapabilitiesReportReadOnly(): void
+    {
+        $builder = new PharBuilder($this->tempDir, 'test', new PharCapabilities(true, true));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('phar.readonly must be disabled');
+
+        $builder->build([
+            'kernel_class' => 'App\\Kernel',
+            'exclude_patterns' => [],
+            'exclude_files' => [],
+        ], $this->tempDir . '/build/test.phar');
+    }
+
+    public function testBuildThrowsWhenInjectedCapabilitiesReportMissingExtension(): void
+    {
+        $builder = new PharBuilder($this->tempDir, 'test', new PharCapabilities(false, false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Phar extension is required');
+
+        $builder->build([
+            'kernel_class' => 'App\\Kernel',
+            'exclude_patterns' => [],
+            'exclude_files' => [],
+        ], $this->tempDir . '/build/test.phar');
     }
 }

--- a/tests/Phar/PharCapabilitiesTest.php
+++ b/tests/Phar/PharCapabilitiesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Phar;
+
+use CrazyGoat\WorkermanBundle\Phar\PharCapabilities;
+use PHPUnit\Framework\TestCase;
+
+final class PharCapabilitiesTest extends TestCase
+{
+    public function testProbeReflectsLiveRuntime(): void
+    {
+        $capabilities = PharCapabilities::probe();
+
+        self::assertSame((bool) ini_get('phar.readonly'), $capabilities->isPharReadOnly());
+        self::assertSame(class_exists(\Phar::class), $capabilities->isPharExtensionLoaded());
+    }
+
+    public function testAssertCanBuildSucceedsWhenCapabilitiesAreSatisfied(): void
+    {
+        $capabilities = new PharCapabilities(false, true);
+
+        $capabilities->assertCanBuild();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testAssertCanBuildThrowsWhenPharReadOnlyIsEnabled(): void
+    {
+        $capabilities = new PharCapabilities(true, true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('phar.readonly must be disabled');
+
+        $capabilities->assertCanBuild();
+    }
+
+    public function testAssertCanBuildThrowsWhenPharExtensionIsMissing(): void
+    {
+        $capabilities = new PharCapabilities(false, false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Phar extension is required');
+
+        $capabilities->assertCanBuild();
+    }
+
+    public function testAssertCanBuildThrowsReadOnlyBeforeExtensionCheck(): void
+    {
+        $capabilities = new PharCapabilities(true, false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('phar.readonly must be disabled');
+
+        $capabilities->assertCanBuild();
+    }
+}


### PR DESCRIPTION
## Description

Closes #372

Extract the side-effectful `phar.readonly` INI probe and `\Phar` extension presence check out of `PharBuilder::build()` into a dedicated `PharCapabilities` collaborator. `PharBuilder` now accepts the capability checker via constructor (defaults to a live probe), making the runtime checks individually testable and stubbable.

## Changes

- New `src/Phar/PharCapabilities.php` owns the `phar.readonly` / `\Phar` extension probes and exposes `assertCanBuild()` that throws the same `RuntimeException` messages `PharBuilder` used to throw inline.
- `PharBuilder` constructor accepts an optional `PharCapabilities` (null → live probe) and delegates the runtime check to it.
- `ServicesConfigurator` registers `PharCapabilities` and injects it into the `workerman.phar_builder` service.
- New `tests/Phar/PharCapabilitiesTest.php` covers the capability checker in isolation (live probe, success, read-only failure, missing-extension failure, both-failing case).
- New `PharBuilderTest` cases verify the builder honours an injected capability checker for the success path and both failure paths.
- `CHANGELOG.md` receives an entry under [Unreleased] / Changed.

## Changelog

```
### Changed
- Extract the side-effectful phar.readonly INI probe and \Phar extension presence check out of PharBuilder::build() into a new PharCapabilities collaborator. PharBuilder now accepts the capability checker via constructor (defaults to a live PharCapabilities::probe()), making the runtime checks individually testable and stubbable. The DI container registers PharCapabilities and injects it into the workerman.phar_builder service. No behavioural change observable for the build:phar flow (#372)
```

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed (no issues found)