### PR TITLE
feat: optimize FileMonitorWatcher checkPattern with compiled regex (closes #339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Optimize `FileMonitorWatcher::checkPattern()` by compiling glob patterns to a single PCRE regex at construction time, reducing per-tick matching from O(files × patterns) to O(files) ([#339](https://github.com/crazy-goat/workerman-bundle/issues/339))
+
 - Extract the side-effectful `phar.readonly` INI probe and `\Phar` extension presence check out of `PharBuilder::build()` into a new `PharCapabilities` collaborator. `PharBuilder` now accepts the capability checker via constructor (defaults to a live `PharCapabilities::probe()`), making the runtime checks individually testable and stubbable. The DI container registers `PharCapabilities` and injects it into the `workerman.phar_builder` service. No behavioural change observable for the `build:phar` flow ([#372](https://github.com/crazy-goat/workerman-bundle/issues/372))
 
 ### Fixed

--- a/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/FileMonitorWatcher.php
@@ -12,6 +12,9 @@ abstract class FileMonitorWatcher
     /** @var string[] */
     protected readonly array $sourceDir;
 
+    /** Compiled regex pattern (empty string when no patterns) */
+    private readonly string $filePatternRegex;
+
     /**
      * @param string[] $sourceDir
      * @param string[] $filePattern
@@ -28,22 +31,104 @@ abstract class FileMonitorWatcher
      * @param string[] $sourceDir
      * @param string[] $filePattern
      */
-    protected function __construct(protected readonly Worker $worker, array $sourceDir, private readonly array $filePattern)
+    protected function __construct(protected readonly Worker $worker, array $sourceDir, array $filePattern)
     {
         $this->sourceDir = array_filter($sourceDir, is_dir(...));
+        $this->filePatternRegex = $this->compilePatterns($filePattern);
     }
 
     abstract public function start(): void;
 
     final protected function checkPattern(string $filename): bool
     {
-        foreach ($this->filePattern as $pattern) {
-            if (\fnmatch($pattern, $filename)) {
-                return true;
-            }
+        if ($this->filePatternRegex === '') {
+            return false;
         }
 
-        return false;
+        $result = \preg_match($this->filePatternRegex, $filename);
+        if ($result === false) {
+            throw new \RuntimeException(\preg_last_error_msg());
+        }
+
+        return $result === 1;
+    }
+
+    /**
+     * @param string[] $patterns
+     */
+    private function compilePatterns(array $patterns): string
+    {
+        if ($patterns === []) {
+            return '';
+        }
+
+        $regexes = \array_map($this->globToRegex(...), $patterns);
+
+        return '/^(?:' . \implode('|', $regexes) . ')$/D';
+    }
+
+    private function globToRegex(string $glob): string
+    {
+        $regex = '';
+        $i = 0;
+        $length = \strlen($glob);
+
+        while ($i < $length) {
+            $char = $glob[$i];
+
+            switch ($char) {
+                case '\\':
+                    if ($i + 1 < $length) {
+                        $regex .= \preg_quote($glob[$i + 1], '/');
+                        $i++;
+                    } else {
+                        $regex .= '(?!)';
+                    }
+                    break;
+
+                case '*':
+                    $regex .= '.*';
+                    break;
+
+                case '?':
+                    $regex .= '.';
+                    break;
+
+                case '[':
+                    $class = '';
+                    $j = $i + 1;
+
+                    if ($j < $length && $glob[$j] === '!') {
+                        $class .= '^';
+                        $j++;
+                    }
+
+                    if ($j < $length && $glob[$j] === ']') {
+                        $class .= ']';
+                        $j++;
+                    }
+
+                    while ($j < $length && $glob[$j] !== ']') {
+                        $class .= $glob[$j] === '-' ? '-' : \preg_quote($glob[$j], '/');
+                        $j++;
+                    }
+
+                    if ($j < $length) {
+                        $regex .= '[' . $class . ']';
+                        $i = $j;
+                    } else {
+                        $regex .= \preg_quote($char, '/');
+                    }
+                    break;
+
+                default:
+                    $regex .= \preg_quote($char, '/');
+            }
+
+            $i++;
+        }
+
+        return $regex;
     }
 
     /**

--- a/tests/Fixtures/polling_watcher_e2e_runner.php
+++ b/tests/Fixtures/polling_watcher_e2e_runner.php
@@ -28,6 +28,7 @@ if ($tempDir === '' || $autoloadPath === '' || !is_dir($tempDir)) {
 
 require $autoloadPath;
 
+use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\FileMonitorWatcher;
 use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\PollingMonitorWatcher;
 
 $watchedFile = $tempDir . '/app.php';
@@ -52,8 +53,9 @@ $workerProp->setValue($watcher, $worker);
 $sourceDirProp = $parentClass->getProperty('sourceDir');
 $sourceDirProp->setValue($watcher, [$tempDir]);
 
-$filePatternProp = $parentClass->getProperty('filePattern');
-$filePatternProp->setValue($watcher, ['*.php']);
+$regexProp = $parentClass->getProperty('filePatternRegex');
+$compilePatterns = new ReflectionMethod(FileMonitorWatcher::class, 'compilePatterns');
+$regexProp->setValue($watcher, $compilePatterns->invoke($watcher, ['*.php']));
 
 $lastMTimeProp = $watcherClass->getProperty('lastMTime');
 $expectedBefore = time() - 5;

--- a/tests/PollingMonitorWatcherTest.php
+++ b/tests/PollingMonitorWatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test;
 
+use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\FileMonitorWatcher;
 use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\PollingMonitorWatcher;
 use CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher\CountingPollingMonitorWatcher;
 use CrazyGoat\WorkermanBundle\Test\Fixtures\PollingMonitorWatcher\CountingSplFileInfo;
@@ -60,8 +61,11 @@ final class PollingMonitorWatcherTest extends TestCase
 
         $this->findProperty($reflection, 'worker')->setValue($instance, $worker);
         $this->findProperty($reflection, 'sourceDir')->setValue($instance, $sourceDir);
-        $this->findProperty($reflection, 'filePattern')->setValue($instance, $filePattern);
         $this->findProperty($reflection, 'lastMTime')->setValue($instance, \time());
+
+        $regexProp = $this->findProperty($reflection, 'filePatternRegex');
+        $compilePatterns = new \ReflectionMethod(FileMonitorWatcher::class, 'compilePatterns');
+        $regexProp->setValue($instance, $compilePatterns->invoke($instance, $filePattern));
 
         return $instance;
     }

--- a/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/FileMonitorWatcherTest.php
@@ -81,6 +81,65 @@ final class FileMonitorWatcherTest extends TestCase
         $this->assertFalse($this->invokeCheckPattern($this->watcher, 'file.php.bak'));
     }
 
+    public function testCheckPatternWithQuestionMark(): void
+    {
+        $qWatcher = $this->createWatcherWithPatterns(['?.php']);
+
+        $this->assertTrue($this->invokeCheckPattern($qWatcher, 'a.php'));
+        $this->assertFalse($this->invokeCheckPattern($qWatcher, 'ab.php'));
+    }
+
+    public function testCheckPatternWithCharacterClass(): void
+    {
+        $classWatcher = $this->createWatcherWithPatterns(['[abc].php']);
+
+        $this->assertTrue($this->invokeCheckPattern($classWatcher, 'a.php'));
+        $this->assertTrue($this->invokeCheckPattern($classWatcher, 'b.php'));
+        $this->assertTrue($this->invokeCheckPattern($classWatcher, 'c.php'));
+        $this->assertFalse($this->invokeCheckPattern($classWatcher, 'd.php'));
+    }
+
+    public function testCheckPatternWithNegatedCharacterClass(): void
+    {
+        $negWatcher = $this->createWatcherWithPatterns(['[!abc].php']);
+
+        $this->assertTrue($this->invokeCheckPattern($negWatcher, 'd.php'));
+        $this->assertFalse($this->invokeCheckPattern($negWatcher, 'a.php'));
+    }
+
+    public function testCheckPatternWithCharacterRange(): void
+    {
+        $rangeWatcher = $this->createWatcherWithPatterns(['[a-z].php']);
+
+        $this->assertTrue($this->invokeCheckPattern($rangeWatcher, 'm.php'));
+        $this->assertFalse($this->invokeCheckPattern($rangeWatcher, 'M.php'));
+    }
+
+    public function testCheckPatternWithEscapedWildcard(): void
+    {
+        $escWatcher = $this->createWatcherWithPatterns(['\\*.php']);
+
+        $this->assertTrue($this->invokeCheckPattern($escWatcher, '*.php'));
+        $this->assertFalse($this->invokeCheckPattern($escWatcher, 'index.php'));
+    }
+
+    public function testCheckPatternWithPureWildcard(): void
+    {
+        $allWatcher = $this->createWatcherWithPatterns(['*']);
+
+        $this->assertTrue($this->invokeCheckPattern($allWatcher, 'anything.txt'));
+        $this->assertTrue($this->invokeCheckPattern($allWatcher, ''));
+    }
+
+    public function testCheckPatternWithMultipleStars(): void
+    {
+        $multiWatcher = $this->createWatcherWithPatterns(['a*b*c']);
+
+        $this->assertTrue($this->invokeCheckPattern($multiWatcher, 'axbyc'));
+        $this->assertTrue($this->invokeCheckPattern($multiWatcher, 'abc'));
+        $this->assertFalse($this->invokeCheckPattern($multiWatcher, 'axby'));
+    }
+
     public function testCreateRecursiveIteratorWithDefaultFlags(): void
     {
         $iterator = $this->invokeCreateRecursiveIterator(
@@ -156,8 +215,9 @@ final class FileMonitorWatcherTest extends TestCase
         $sourceDirProp = $parentClass->getProperty('sourceDir');
         $sourceDirProp->setValue($instance, ['/tmp']);
 
-        $filePatternProp = $parentClass->getProperty('filePattern');
-        $filePatternProp->setValue($instance, $filePattern);
+        $regexProp = $parentClass->getProperty('filePatternRegex');
+        $compilePatterns = new \ReflectionMethod(FileMonitorWatcher::class, 'compilePatterns');
+        $regexProp->setValue($instance, $compilePatterns->invoke($instance, $filePattern));
 
         return $instance;
     }

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Test\Reboot\FileMonitorWatcher;
 
+use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\FileMonitorWatcher;
 use CrazyGoat\WorkermanBundle\Reboot\FileMonitorWatcher\InotifyMonitorWatcher;
 use PHPUnit\Framework\TestCase;
 use Workerman\Events\EventInterface;
@@ -453,8 +454,9 @@ final class InotifyMonitorWatcherTest extends TestCase
         $sourceDirProp = $parentClass->getProperty('sourceDir');
         $sourceDirProp->setValue($instance, [$sourceDir]);
 
-        $filePatternProp = $parentClass->getProperty('filePattern');
-        $filePatternProp->setValue($instance, $filePattern);
+        $regexProp = $parentClass->getProperty('filePatternRegex');
+        $compilePatterns = new \ReflectionMethod(FileMonitorWatcher::class, 'compilePatterns');
+        $regexProp->setValue($instance, $compilePatterns->invoke($instance, $filePattern));
 
         return $instance;
     }


### PR DESCRIPTION
## Description

Closes #339

## Changes

- Replace O(files × patterns) fnmatch() loop in `FileMonitorWatcher::checkPattern()` with a single O(files) `preg_match()` by compiling glob patterns to a combined PCRE regex at construction time
- Add `globToRegex()` converter supporting all POSIX fnmatch features (`*`, `?`, `[...]`, `[!...]`, `[a-z]`, escaped wildcards)
- Add PCRE_DOLLAR_ENDONLY (`D`) modifier to match fnmatch() behavior on filenames with trailing newlines
- Add `preg_match` error handling with `RuntimeException`
- Remove dead `$filePattern` property
- Move property declaration before methods for PSR-12 compliance

## Changelog

Optimize `FileMonitorWatcher::checkPattern()` by compiling glob patterns to a single PCRE regex at construction time, reducing per-tick matching from O(files × patterns) to O(files).

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed