### PR TITLE
docs(security): update static files examples to use StaticFilesMiddleware service (closes #345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix race condition in `ServerManager::getStatus()` / `getConnections()` where PHP's stat cache and stale status files from interrupted runs could cause `waitForFile()` to read an empty or incomplete file written by Workerman's SIGIOT/SIGIO handler. `StatusFileReader::waitForFile()` now calls `clearstatcache()` before each poll and rejects 0-byte files. `ServerManager` deletes the stale status/connections file before signaling, ensuring `waitForFile()` always waits for fresh output from the current signal. Fixes `WorkermanCommandTest` failures on macOS where slower filesystem operations widened the race window ([#535](https://github.com/crazy-goat/workerman-bundle/issues/535))
 
+### Docs
+
+- Update `docs/security.md` Static Files Protection examples to use the `StaticFilesMiddleware` service approach instead of the deprecated `serve_files` and `root_dir` server options. All YAML examples now show the recommended service registration pattern ([#345](https://github.com/crazy-goat/workerman-bundle/issues/345))
+
 ### Tests
 
 - Replace `testRunnerUsesCorrectForkErrorHandling` (which read `Runner.php` as a string) with `testForkFailureThrowsRuntimeException` — a behavioral test that stubs the `fork()` method via a readonly subclass and asserts `RuntimeException` is thrown when `pcntl_fork()` returns `-1`. Removes the dead `fork_failure` case from the isolated test fixture ([#313](https://github.com/crazy-goat/workerman-bundle/issues/313))

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,7 +99,7 @@ Configure `trusted_hosts` when your application generates absolute URLs based on
 
 ## Static Files Protection
 
-When `serve_files` is enabled on a server, `StaticFilesMiddleware` serves files from the configured root directory. This middleware applies security hardening to prevent accidental exposure of sensitive files:
+`StaticFilesMiddleware` serves files from a configured root directory. Register it as a service and add it to the server's `middlewares` list. This middleware applies security hardening to prevent accidental exposure of sensitive files:
 
 ### Built-in Denylist
 
@@ -115,28 +115,37 @@ The following are **always blocked** (requests return 404):
 To restrict which file types are served, configure an explicit extension allowlist:
 
 ```yaml
+# config/services.yaml
+services:
+    workerman.middleware.static_files:
+        class: CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware
+        arguments:
+            $rootDirectory: '%kernel.project_dir%/public'
+            $allowedExtensions:
+                - 'css'
+                - 'js'
+                - 'png'
+                - 'jpg'
+                - 'jpeg'
+                - 'gif'
+                - 'webp'
+                - 'svg'
+                - 'woff'
+                - 'woff2'
+                - 'ico'
+                - 'html'
+                - 'json'
+                - 'txt'
+```
+
+```yaml
+# config/packages/workerman.yaml
 workerman:
     servers:
         - name: 'Web'
           listen: 'http://0.0.0.0:80'
-          serve_files: true
-          root_dir: '%kernel.project_dir%/public'
-          static_files:
-              allowed_extensions:
-                  - 'css'
-                  - 'js'
-                  - 'png'
-                  - 'jpg'
-                  - 'jpeg'
-                  - 'gif'
-                  - 'webp'
-                  - 'svg'
-                  - 'woff'
-                  - 'woff2'
-                  - 'ico'
-                  - 'html'
-                  - 'json'
-                  - 'txt'
+          middlewares:
+              - workerman.middleware.static_files
 ```
 
 When `allowed_extensions` is set, only files with one of the listed extensions are served — all others return 404. The denylist (dotfiles, `.php`, etc.) takes precedence and is always enforced regardless of the allowlist setting.
@@ -145,26 +154,35 @@ When `allowed_extensions` is set, only files with one of the listed extensions a
 
 By default, `StaticFilesMiddleware` refuses to serve files that are accessed through a symlink under the static root directory (`follow_symlinks: false`). This prevents an attacker or a compromised tool from creating a symlink inside the public directory to expose files outside the intended root.
 
-To restore the previous behaviour and allow symlinks to be followed, set `follow_symlinks: true`:
+To restore the previous behaviour and allow symlinks to be followed, set `$followSymlinks: true`:
 
 ```yaml
+# config/services.yaml
+services:
+    workerman.middleware.static_files:
+        class: CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware
+        arguments:
+            $rootDirectory: '%kernel.project_dir%/public'
+            $followSymlinks: true
+```
+
+```yaml
+# config/packages/workerman.yaml
 workerman:
     servers:
         - name: 'Web'
           listen: 'http://0.0.0.0:80'
-          serve_files: true
-          root_dir: '%kernel.project_dir%/public'
-          static_files:
-              follow_symlinks: true
+          middlewares:
+              - workerman.middleware.static_files
 ```
 
 When `follow_symlinks` is `false` (default), any path component inside the root directory that is a symlink will cause the request to be treated as a non-existent file, passing control to the next middleware.
 
 ### Security Considerations
 
-- **Keep `root_dir` isolated**: Point `root_dir` to a dedicated public directory (e.g., `%kernel.project_dir%/public`). Never set it to the project root or a directory containing `.env`, source code, or VCS metadata.
+- **Keep `$rootDirectory` isolated**: Point `$rootDirectory` to a dedicated public directory (e.g., `%kernel.project_dir%/public`). Never set it to the project root or a directory containing `.env`, source code, or VCS metadata.
 - **Use the allowlist**: Configure `allowed_extensions` to only permit the file types your application actually serves as static assets.
-- **Disable symlinks**: Keep `follow_symlinks: false` (default) to prevent symlink-based file disclosure unless your application explicitly requires symlinks inside the public directory.
+- **Disable symlinks**: Keep `$followSymlinks: false` (default) to prevent symlink-based file disclosure unless your application explicitly requires symlinks inside the public directory.
 - **404 for blocked files**: Denied files always return a 404 response (identical to non-existent files). This prevents attackers from probing whether a blocked file exists.
 
 ## Connection Timeouts (Slowloris Protection)


### PR DESCRIPTION
## Description

Closes #345

## Changes

- Updated  Static Files Protection section:
  - Changed intro text to describe  service registration pattern instead of the deprecated `serve_files` server option
  - Updated Extension Allowlist YAML example to use `StaticFilesMiddleware` service with `` and `` constructor arguments
  - Updated Symlink Protection YAML example to use `StaticFilesMiddleware` service with `` and `` constructor arguments
  - Updated Security Considerations to reference `` and `` instead of deprecated `root_dir` and `follow_symlinks`
- Added CHANGELOG.md entry under [Unreleased] → Docs

## Acceptance Criteria

- [x] README no longer presents `serve_files` as a current feature (was already fixed by #268 and #342)
- [x] The deprecation status matches the code (`serve_files` and `root_dir` are deprecated since 0.9.3)
- [x] No remaining contradiction between docs and `@deprecated` annotations in `src/`
- [x] CHANGELOG.md entry added under [Unreleased]

## Code Review

- [x] Passed code review
- [x] All review comments addressed