### PR TITLE
docs(utils): add @api annotation to Utils::reload() (closes #352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `docs/security.md` Static Files Protection examples to use the `StaticFilesMiddleware` service approach instead of the deprecated `serve_files` and `root_dir` server options. All YAML examples now show the recommended service registration pattern ([#345](https://github.com/crazy-goat/workerman-bundle/issues/345))
 
+- Add explicit `@api` annotation to `Utils::reload()` to clarify that it is the canonical public API for programmatic worker reload, resolving the remaining ambiguity from the `@internal` removal in 0.21.0 ([#352](https://github.com/crazy-goat/workerman-bundle/issues/352))
+
 ### Tests
 
 - Replace `testRunnerUsesCorrectForkErrorHandling` (which read `Runner.php` as a string) with `testForkFailureThrowsRuntimeException` — a behavioral test that stubs the `fork()` method via a readonly subclass and asserts `RuntimeException` is thrown when `pcntl_fork()` returns `-1`. Removes the dead `fork_failure` case from the isolated test fixture ([#313](https://github.com/crazy-goat/workerman-bundle/issues/313))

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -56,6 +56,8 @@ final class Utils
      * runtime condition (e.g., memory pressure, config change) requires a
      * clean worker state.
      *
+     * @api
+     *
      * @param bool $reloadAllWorkers When true, SIGUSR1 is sent to the parent
      *                               process, which reloads all workers. When
      *                               false (default), only the current process


### PR DESCRIPTION
## Description

Closes #352

Add explicit  annotation to  to clarify that it is the canonical public API for programmatic worker reload.

## Changes

- Added  annotation to  method PHPDoc
- Added CHANGELOG entry documenting the change

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed