### PR TITLE
docs: add link to build-packaging.md in CHANGELOG [0.18.0] PHAR/BIN entry (closes #356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PHAR and standalone binary packaging support — new `workerman:build:phar` and `workerman:build:bin` commands, `PharHelper` utility, and `build` configuration section for PHAR exclusions, custom php.ini, and SFX sources. See [docs/build-packaging.md](docs/build-packaging.md) for full documentation ([#191](https://github.com/crazy-goat/workerman-bundle/issues/191))
+
 - Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::convert`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
 
 - Add a cross-platform middleware dispatch contract test (`MiddlewareDispatchContractTest`). A dedicated test server on port 9991 runs a counting middleware that increments a shared counter file under `flock()` and tags every response with `X-Dispatch-Count`. The contract asserts that exactly one dispatch is observed per incoming HTTP request (single + sequential request cases), so any regression of the issue #533 dispatch-count class — including the macOS-specific triple-dispatch — fails CI immediately and on every supported OS ([#542](https://github.com/crazy-goat/workerman-bundle/issues/542))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- PHAR and standalone binary packaging support — new `workerman:build:phar` and `workerman:build:bin` commands, `PharHelper` utility, and `build` configuration section for PHAR exclusions, custom php.ini, and SFX sources. See [docs/build-packaging.md](docs/build-packaging.md) for full documentation ([#191](https://github.com/crazy-goat/workerman-bundle/issues/191))
-
 - Add PHPBench benchmark suite covering the five documented hot paths: `RequestConverter::toSymfonyRequest`, `ResponseConverter::convert`, `MemoryRebootStrategy::shouldReboot`, `PeriodicalTrigger::getNextRunDate`, and `HttpRequestHandler::__invoke` (composed middleware chain). Run via `composer bench`. CI executes the suite on every PR in advisory mode (results are logged but do not block merge). Documented measurement protocol in `CONTRIBUTING.md` ([#328](https://github.com/crazy-goat/workerman-bundle/issues/328))
 
 - Add a cross-platform middleware dispatch contract test (`MiddlewareDispatchContractTest`). A dedicated test server on port 9991 runs a counting middleware that increments a shared counter file under `flock()` and tags every response with `X-Dispatch-Count`. The contract asserts that exactly one dispatch is observed per incoming HTTP request (single + sequential request cases), so any regression of the issue #533 dispatch-count class — including the macOS-specific triple-dispatch — fails CI immediately and on every supported OS ([#542](https://github.com/crazy-goat/workerman-bundle/issues/542))
@@ -309,6 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--kernel-class` CLI option for overriding kernel class in PHAR stub
   - File monitor automatically disabled in PHAR mode
   - `ConfigLoader` fallback when cache is missing for PHAR scenarios
+  - See [docs/build-packaging.md](docs/build-packaging.md) for full documentation and examples
 
 ### Changed
 


### PR DESCRIPTION
## Description

Closes #356

## Changes

- Removed duplicate PHAR/BIN entry from  section (feature was already documented in )
- Added link to  in the  PHAR/BIN entry for full documentation and examples

## Changelog

- Updated  section in CHANGELOG.md to cross-link 

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed
- [x] All linters pass (
Found 0 of 217 files that can be fixed in 0.497 seconds, 18.00 MB memory used

 [OK] No errors                                                                 



 [OK] Rector is done!                                                           )
- [x] All tests pass (Workerman[index.php] restart
Workerman[index.php] is stopping ...
Workerman[index.php] stop success
------------------------------------------------------------------- WORKERMAN --------------------------------------------------------------------
Workerman/5.2.2         PHP/8.5.7 (JIT off)           Darwin/25.5.0
-------------------------------------------------------------------- WORKERS ---------------------------------------------------------------------
event-loop  proto       user           worker                                               listen                   count       state            
PHPUnit 10.5.63 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.7
Configuration: /Users/piotr.halas/work/workerman-bundle/phpunit.xml

.............................................................   61 / 1497 (  4%)
................S............................................  122 / 1497 (  8%)
.............................................................  183 / 1497 ( 12%)
.............................................................  244 / 1497 ( 16%)
.............................................................  305 / 1497 ( 20%)
.............................................................  366 / 1497 ( 24%)
.............................................................  427 / 1497 ( 28%)
........SSSS.................SSSSSSSSS..................SSSSS  488 / 1497 ( 32%)
SSSSSS.S.....................................................  549 / 1497 ( 36%)
...................................SSS.......................  610 / 1497 ( 40%)
.......SSSSSSSSS.............................................  671 / 1497 ( 44%)
.............................................................  732 / 1497 ( 48%)
............................................................W  793 / 1497 ( 52%)
.............................................................  854 / 1497 ( 57%)
.............................................................  915 / 1497 ( 61%)
.............................................................  976 / 1497 ( 65%)
...........................SSS............................... 1037 / 1497 ( 69%)
............................................................. 1098 / 1497 ( 73%)
............................................................. 1159 / 1497 ( 77%)
............................................................. 1220 / 1497 ( 81%)
............................................................. 1281 / 1497 ( 85%)
............................................................. 1342 / 1497 ( 89%)
............................................................. 1403 / 1497 ( 93%)
.....SS...................................................... 1464 / 1497 ( 97%)
.................................                             1497 / 1497 (100%)

Time: 00:33.894, Memory: 48.00 MB

OK, but there were issues!
Tests: 1497, Assertions: 3051, Warnings: 1, Skipped: 43.
Workerman[index.php] stop
Workerman[index.php] not run)