### PR TITLE
fix: lazy inotify directory watches for fast startup (closes #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Optimize `InotifyMonitorWatcher` startup by deferring the recursive directory
+  walk to after the event loop starts. At boot only the top-level source
+  directories are watched; remaining subdirectories are watched lazily via a
+  single deferred pass. This eliminates a synchronous full-directory walk that
+  could delay worker readiness on very large source trees
+  ([#324](https://github.com/crazy-goat/workerman-bundle/issues/324))
+
 ### Tests
 
 - Populate `<coverage/>` in `phpunit.xml` with Clover and text report output,

--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -10,10 +10,13 @@ use Workerman\Worker;
 final class InotifyMonitorWatcher extends FileMonitorWatcher
 {
     private const RELOAD_DELAY = 0.33;
+    private const DEFERRED_WALK_DELAY = 0.01;
     /** @var resource */
     private $fd;
     /** @var array<int, string> */
     private array $pathByWd = [];
+    /** @var array<string, true> */
+    private array $watchedPaths = [];
     private \Closure|null $reloadCallback = null;
 
     public function start(): void
@@ -22,24 +25,44 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
             $this->fd = \inotify_init();
             stream_set_blocking($this->fd, false);
 
+            // Phase 1: Watch only top-level directories for instant startup.
+            // Deep subdirectories are watched lazily after the event loop runs.
             foreach ($this->sourceDir as $dir) {
-                $iterator = $this->createRecursiveIterator(
-                    $dir,
-                    \FilesystemIterator::SKIP_DOTS,
-                    \RecursiveIteratorIterator::SELF_FIRST,
-                );
-
                 $this->watchDir($dir);
+            }
 
-                foreach ($iterator as $file) {
-                    /** @var \SplFileInfo $file */
-                    if ($file->isDir()) {
-                        $this->watchDir($file->getPathname());
+            // Phase 2: Schedule a deferred recursive walk so existing subdirectories
+            // are still watched, but without blocking the event loop at boot.
+            Worker::$globalEvent->delay(self::DEFERRED_WALK_DELAY, $this->deferredWalk(...));
+
+            Worker::$globalEvent->onReadable($this->fd, $this->onNotify(...));
+        }
+    }
+
+    /**
+     * Deferred recursive walk that watches all existing subdirectories.
+     *
+     * Called once after the event loop starts. This avoids a synchronous
+     * full-directory walk at boot, which can be slow on very large source trees.
+     */
+    private function deferredWalk(): void
+    {
+        foreach ($this->sourceDir as $dir) {
+            $iterator = $this->createRecursiveIterator(
+                $dir,
+                \FilesystemIterator::SKIP_DOTS,
+                \RecursiveIteratorIterator::SELF_FIRST,
+            );
+
+            foreach ($iterator as $file) {
+                /** @var \SplFileInfo $file */
+                if ($file->isDir()) {
+                    $path = $file->getPathname();
+                    if (!isset($this->watchedPaths[$path])) {
+                        $this->watchDir($path);
                     }
                 }
             }
-
-            Worker::$globalEvent->onReadable($this->fd, $this->onNotify(...));
         }
     }
 
@@ -56,7 +79,11 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
 
         foreach ($events as $event) {
             if ($this->isFlagSet($event['mask'], IN_IGNORED)) {
+                $path = $this->pathByWd[$event['wd']] ?? null;
                 unset($this->pathByWd[$event['wd']]);
+                if ($path !== null) {
+                    unset($this->watchedPaths[$path]);
+                }
                 continue;
             }
 
@@ -84,6 +111,7 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
     {
         $wd = \inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
         $this->pathByWd[$wd] = $path;
+        $this->watchedPaths[$path] = true;
     }
 
     private function isFlagSet(int $check, int $flag): bool

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -286,6 +286,9 @@ final class InotifyMonitorWatcherTest extends TestCase
 
         $watcher->start();
 
+        // Invoke the deferred walk so that subdir is watched
+        $this->invokeDeferredWalk($watcher);
+
         $pathByWdBefore = $this->getPrivateProperty($watcher, 'pathByWd');
         $this->assertNotEmpty($pathByWdBefore, 'pathByWd should have entries before removal');
 

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -127,6 +127,10 @@ final class InotifyMonitorWatcherTest extends TestCase
         $eventLoop->expects($this->once())
             ->method('onReadable')
             ->with($this->isType('resource'), $this->isType('callable'));
+        $eventLoop->expects($this->once())
+            ->method('delay')
+            ->with($this->isType('float'), $this->isType('callable'))
+            ->willReturn(1);
 
         Worker::$globalEvent = $eventLoop;
 
@@ -142,7 +146,7 @@ final class InotifyMonitorWatcherTest extends TestCase
     /**
      * @requires extension inotify
      */
-    public function testStartRecursivelyWatchesDirectories(): void
+    public function testStartWatchesOnlyTopLevelDirectories(): void
     {
         $tmpDir = $this->createTempDir();
         mkdir($tmpDir . '/sub1', 0700);
@@ -154,6 +158,33 @@ final class InotifyMonitorWatcherTest extends TestCase
         $this->setUpEventLoop();
 
         $watcher->start();
+
+        $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
+
+        // After start(), only the root directory should be watched.
+        // Subdirectories are watched lazily via deferredWalk().
+        $this->assertCount(1, $pathByWd, 'pathByWd should contain only the root directory after start()');
+        $this->assertContains($tmpDir, $pathByWd, 'pathByWd should contain the root source directory');
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testDeferredWalkWatchesAllSubdirectories(): void
+    {
+        $tmpDir = $this->createTempDir();
+        mkdir($tmpDir . '/sub1', 0700);
+        mkdir($tmpDir . '/sub1/sub2', 0700);
+        mkdir($tmpDir . '/other', 0700);
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+        $this->setUpEventLoop();
+
+        $watcher->start();
+
+        // Invoke the deferred walk explicitly
+        $this->invokeDeferredWalk($watcher);
 
         $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
 
@@ -348,10 +379,10 @@ final class InotifyMonitorWatcherTest extends TestCase
         $fd = $this->getPrivateProperty($watcher, 'fd');
 
         $this->invokeOnNotify($watcher, $fd);
-        $this->assertSame(1, $delayCount, 'First onNotify should schedule one reload');
+        $this->assertSame(2, $delayCount, 'First onNotify should schedule one reload (total: 1 from start + 1 from onNotify)');
 
         $this->invokeOnNotify($watcher, $fd);
-        $this->assertSame(1, $delayCount, 'Second onNotify should NOT schedule another reload while callback is set');
+        $this->assertSame(2, $delayCount, 'Second onNotify should NOT schedule another reload while callback is set');
     }
 
     /**
@@ -368,6 +399,9 @@ final class InotifyMonitorWatcherTest extends TestCase
         $this->setUpEventLoop();
 
         $watcher->start();
+
+        // Invoke the deferred walk to populate all subdirectories
+        $this->invokeDeferredWalk($watcher);
 
         $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
 
@@ -388,6 +422,7 @@ final class InotifyMonitorWatcherTest extends TestCase
         $eventLoop = $this->createMock(EventInterface::class);
         $eventLoop->method('onReadable')->willReturnCallback(function (): void {
         });
+        $eventLoop->method('delay')->willReturn(1);
         Worker::$globalEvent = $eventLoop;
     }
 
@@ -417,6 +452,12 @@ final class InotifyMonitorWatcherTest extends TestCase
 
         /** @var bool */
         return $reflection->invoke($watcher, $check, $flag);
+    }
+
+    private function invokeDeferredWalk(InotifyMonitorWatcher $watcher): void
+    {
+        $reflection = new \ReflectionMethod(InotifyMonitorWatcher::class, 'deferredWalk');
+        $reflection->invoke($watcher);
     }
 
     private function invokeOnNotify(InotifyMonitorWatcher $watcher, mixed $fd): void


### PR DESCRIPTION
## Description

Closes #324

## Changes

- **InotifyMonitorWatcher::start()** now watches only top-level source directories at boot instead of doing a synchronous full recursive walk
- **InotifyMonitorWatcher::deferredWalk()** is a new private method that recursively walks and watches all existing subdirectories, scheduled via `Worker::$globalEvent->delay()` after the event loop starts
- Added **`watchedPaths`** reverse-lookup map for O(1) duplicate detection
- **`pathByWd` cleanup on IN_IGNORED** now also removes the path from `watchedPaths`
- Tests updated: `testStartWatchesOnlyTopLevelDirectories` (was `testStartRecursivelyWatchesDirectories`), added `testDeferredWalkWatchesAllSubdirectories`, and updated event-loop mocks

## Changelog

Performance: Optimize InotifyMonitorWatcher startup by deferring the recursive directory walk to after the event loop starts, eliminating synchronous full-directory walk on very large source trees.

## Code Review

- [X] Passed subagent code review
- [X] All review comments addressed