### PR TITLE
feat(tests): harden UtilsTest signal-logic tests with CI guard and pcntl/posix extensions (closes #346)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: zip, inotify
+          extensions: zip, inotify, pcntl, posix
           coverage: pcov
           ini-values: pcov.directory=src
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- Harden `UtilsTest` signal-logic tests: add `pcntl` and `posix` extensions to
+  CI runner, introduce guard test that fails when extensions are missing without
+  explicit opt-out (`WORKERMAN_ALLOW_PCNTL_SKIP=1`). macOS contributors can skip
+  these tests locally by setting the env var
+  ([#346](https://github.com/crazy-goat/workerman-bundle/issues/346))
+
 - Populate `<coverage/>` in `phpunit.xml` with Clover and text report output,
   add `composer test:coverage` and `composer coverage:check` scripts, and
   enforce a line-coverage threshold in CI using `bin/check-coverage.php`. CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,18 @@ rm .git/hooks/pre-push
    > - On macOS, ports below 1024 require root. Ports 8888 and 9999 are above
    >   that threshold and should work without special privileges.
 
+   > **Signal-logic tests and pcntl/posix extensions**
+   > Three tests in `UtilsTest` (`testReloadSendsSigusr1`,
+   > `testDeprecatedRebootTriggersDeprecation`, `testDeprecatedRebootDelegatesToReload`)
+   > require the `pcntl` and `posix` PHP extensions. On macOS these extensions are
+   > often disabled by default. To skip them locally, set:
+   > ```bash
+   > export WORKERMAN_ALLOW_PCNTL_SKIP=1
+   > ```
+   > CI always loads `pcntl` and `posix` and these tests are executed there.
+   > A guard test (`testSignalExtensionsAvailable`) will fail if the extensions
+   > are missing and the env var is not set.
+
 3. Run benchmarks locally (optional but recommended for performance-related changes):
    ```bash
    composer bench

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -81,8 +81,6 @@ final class UtilsTest extends TestCase
             $this->fail('pcntl and posix extensions are required but not loaded. '
                 . 'Set WORKERMAN_ALLOW_PCNTL_SKIP=1 to allow skipping this on developer machines.');
         }
-
-        $this->assertTrue(true);
     }
 
     public function testReloadSendsSigusr1(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -81,6 +81,8 @@ final class UtilsTest extends TestCase
             $this->fail('pcntl and posix extensions are required but not loaded. '
                 . 'Set WORKERMAN_ALLOW_PCNTL_SKIP=1 to allow skipping this on developer machines.');
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function testReloadSendsSigusr1(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -70,6 +70,21 @@ final class UtilsTest extends TestCase
         new Utils();
     }
 
+    public function testSignalExtensionsAvailable(): void
+    {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $allowSkip = getenv('WORKERMAN_ALLOW_PCNTL_SKIP');
+            if ($allowSkip !== false && $allowSkip !== '') {
+                $this->markTestSkipped('pcntl and posix extensions are required for this test (skipped via WORKERMAN_ALLOW_PCNTL_SKIP).');
+            }
+
+            $this->fail('pcntl and posix extensions are required but not loaded. '
+                . 'Set WORKERMAN_ALLOW_PCNTL_SKIP=1 to allow skipping this on developer machines.');
+        }
+
+        $this->assertTrue(true);
+    }
+
     public function testReloadSendsSigusr1(): void
     {
         if (!extension_loaded('pcntl') || !extension_loaded('posix')) {


### PR DESCRIPTION
## Description

Closes #346

## Changes

- Add `pcntl` and `posix` extensions to CI test runner via `shivammathur/setup-php`
- Add `testSignalExtensionsAvailable` guard test that fails when extensions are missing unless `WORKERMAN_ALLOW_PCNTL_SKIP=1` is set
- Document the skip behavior in `CONTRIBUTING.md` for macOS contributors
- Update `CHANGELOG.md` under [Unreleased]

## Changelog

Harden UtilsTest signal-logic tests with CI guard and pcntl/posix extensions.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed