### PR TITLE
test(ci): harden PHAR tests against silent phar.readonly skips (closes #340)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: zip, inotify, pcntl, posix
           coverage: pcov
-          ini-values: pcov.directory=src
+          ini-values: pcov.directory=src,phar.readonly=0
 
       - name: Create var directory
         run: mkdir -p var

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- Harden PHAR-build tests against silent `phar.readonly` skips: add
+  `phar.readonly=0` to `composer test` / `composer test:coverage` scripts and
+  CI workflow ini-values, introduce `PharReadOnlyGuardTest` that fails under CI
+  when `phar.readonly` is set without explicit opt-out
+  (`WORKERMAN_ALLOW_PHAR_READONLY_SKIP=1`), and refactor
+  `testCommandFailsWhenPharReadonlyIsSet` to use injected `PharCapabilities`
+  instead of depending on the runtime INI setting
+  ([#340](https://github.com/crazy-goat/workerman-bundle/issues/340))
+
 - Harden `UtilsTest` signal-logic tests: add `pcntl` and `posix` extensions to
   CI runner, introduce guard test that fails when extensions are missing without
   explicit opt-out (`WORKERMAN_ALLOW_PCNTL_SKIP=1`). macOS contributors can skip

--- a/composer.json
+++ b/composer.json
@@ -81,13 +81,13 @@
         "test": [
             "APP_RUNTIME=CrazyGoat\\\\WorkermanBundle\\\\Runtime php tests/App/index.php restart -d",
             "sleep 1",
-            "vendor/bin/phpunit --no-coverage",
+            "php -d phar.readonly=0 vendor/bin/phpunit --no-coverage",
             "APP_RUNTIME=CrazyGoat\\\\WorkermanBundle\\\\Runtime php tests/App/index.php stop"
         ],
         "test:coverage": [
             "APP_RUNTIME=CrazyGoat\\\\WorkermanBundle\\\\Runtime php tests/App/index.php restart -d",
             "sleep 1",
-            "vendor/bin/phpunit --coverage-clover var/coverage.xml",
+            "php -d phar.readonly=0 vendor/bin/phpunit --coverage-clover var/coverage.xml",
             "APP_RUNTIME=CrazyGoat\\\\WorkermanBundle\\\\Runtime php tests/App/index.php stop"
         ],
         "coverage:check": [

--- a/tests/Command/BuildPharCommandTest.php
+++ b/tests/Command/BuildPharCommandTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\WorkermanBundle\Command\BuildPathResolver;
 use CrazyGoat\WorkermanBundle\Command\BuildPharCommand;
 use CrazyGoat\WorkermanBundle\ConfigLoader;
 use CrazyGoat\WorkermanBundle\Phar\PharBuilder;
+use CrazyGoat\WorkermanBundle\Phar\PharCapabilities;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -137,11 +138,10 @@ final class BuildPharCommandTest extends TestCase
 
     public function testCommandFailsWhenPharReadonlyIsSet(): void
     {
-        if (!(bool) ini_get('phar.readonly')) {
-            self::markTestSkipped('phar.readonly is Off — cannot test readonly error.');
-        }
-
-        $command = $this->createCommand();
+        // Use PharCapabilities with pharReadOnly=true to simulate the error
+        // path without depending on the runtime INI setting.
+        $pharBuilder = new PharBuilder($this->tempDir, 'test', new PharCapabilities(true, true));
+        $command = new BuildPharCommand($this->makeConfigLoader(), $pharBuilder, new BuildPathResolver(), $this->tempDir);
 
         $input = new ArrayInput([]);
         $output = new BufferedOutput();
@@ -205,10 +205,5 @@ final class BuildPharCommandTest extends TestCase
         ]);
 
         return $loader;
-    }
-
-    private function createCommand(): BuildPharCommand
-    {
-        return new BuildPharCommand($this->makeConfigLoader(), new PharBuilder($this->tempDir, 'test'), new BuildPathResolver(), $this->tempDir);
     }
 }

--- a/tests/Phar/PharReadOnlyGuardTest.php
+++ b/tests/Phar/PharReadOnlyGuardTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test\Phar;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guard test that ensures PHAR-build tests are never silently skipped
+ * due to `phar.readonly` being enabled.
+ *
+ * In CI (no WORKERMAN_ALLOW_PHAR_READONLY_SKIP env var), this test fails
+ * if `phar.readonly` is set — catching misconfigured CI runners before
+ * they hide PHAR regressions behind a green build.
+ *
+ * Developers who cannot disable `phar.readonly` locally (e.g. shared
+ * hosting, restricted Docker images) can opt out by setting:
+ *
+ *   WORKERMAN_ALLOW_PHAR_READONLY_SKIP=1
+ */
+final class PharReadOnlyGuardTest extends TestCase
+{
+    public function testPharReadOnlyIsDisabled(): void
+    {
+        $pharReadOnly = (bool) ini_get('phar.readonly');
+
+        if (!$pharReadOnly) {
+            // phar.readonly is Off — PHAR tests will execute normally.
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        $allowSkip = getenv('WORKERMAN_ALLOW_PHAR_READONLY_SKIP');
+        if ($allowSkip !== false && $allowSkip !== '') {
+            self::markTestSkipped(
+                'phar.readonly is On but WORKERMAN_ALLOW_PHAR_READONLY_SKIP is set — skipping guard.',
+            );
+        }
+
+        self::fail(
+            'phar.readonly is enabled in this PHP runtime. '
+            . 'PHAR-build tests will be silently skipped, hiding potential regressions. '
+            . 'Fix: add phar.readonly=0 to php.ini or the PHPUnit command. '
+            . 'Developer opt-out: set WORKERMAN_ALLOW_PHAR_READONLY_SKIP=1.',
+        );
+    }
+}


### PR DESCRIPTION
## Description

Closes #340

PHAR-build tests were silently skipping when `phar.readonly` was set, hiding potential regressions behind a green CI build.

## Changes

- Add `-d phar.readonly=0` to `composer test` and `composer test:coverage` scripts so PHAR tests always run locally
- Add `phar.readonly=0` to CI workflow `ini-values` for visibility in the workflow file
- Add `PharReadOnlyGuardTest` — a guard test that fails under CI when `phar.readonly` is set without the `WORKERMAN_ALLOW_PHAR_READONLY_SKIP` opt-out env var
- Refactor `BuildPharCommandTest::testCommandFailsWhenPharReadonlyIsSet` to use injected `PharCapabilities(true, true)` instead of depending on the runtime INI setting (this test was previously always skipped with `phar.readonly=0`)

## Changelog

- CHANGELOG.md: entry under [Unreleased] > Tests describing the test hardening

## Code Review

- [x] All linters pass (php-cs-fixer, phpstan, rector)
- [x] All 1510 tests pass with 0 failures
- [x] PHAR tests execute (not skip) when `phar.readonly=0`