### PR TITLE
fix(security): contain worker death on control-byte headers (closes #577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fix remote unauthenticated denial-of-service: a single control byte in
+  any request header value killed the worker process. The request
+  lifecycle in `HttpRequestHandler::__invoke()` is now wrapped in a
+  try/catch that converts throwables into 400/500 responses, and
+  `ServerWorker::onConnect` installs a `TcpConnection::$errorHandler`
+  backstop that closes the connection instead of letting Workerman call
+  `Worker::stopAll(250)`. Client errors (`MalformedRequestException`,
+  `FileUploadValidationException`) are logged at debug level to prevent
+  log flooding; server faults are logged at error level. A nested
+  try/catch around the error-response send ensures `doTerminate()` and
+  the reboot check still run when even the send fails
+  ([#577](https://github.com/crazy-goat/workerman-bundle/issues/577))
+
+### Changed
+
+- `RequestConverter` now throws `MalformedRequestException` (extends
+  `\InvalidArgumentException`, implements `ClientInputExceptionInterface`)
+  instead of bare `\InvalidArgumentException` for malformed client input
+  (control bytes in headers, invalid URI/method). This lets
+  `HttpRequestHandler` distinguish client errors (400) from server faults
+  (500) — a middleware throwing `\InvalidArgumentException` is now
+  correctly a 500, not a 400
+  ([#577](https://github.com/crazy-goat/workerman-bundle/issues/577))
+
+### Added
+
+- `CrazyGoat\WorkermanBundle\Exception\ClientInputExceptionInterface` —
+  marker interface for exceptions caused by malformed client input,
+  implemented by `MalformedRequestException` and
+  `FileUploadValidationException`
+  ([#577](https://github.com/crazy-goat/workerman-bundle/issues/577))
+
+- `CrazyGoat\WorkermanBundle\Exception\MalformedRequestException` —
+  thrown by `RequestConverter` for malformed client input (control
+  bytes, invalid URI/method)
+  ([#577](https://github.com/crazy-goat/workerman-bundle/issues/577))
+
 ## [0.24.0] - 2026-07-26
 
 ### Performance

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\DTO;
 
 use CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException;
+use CrazyGoat\WorkermanBundle\Exception\MalformedRequestException;
 use CrazyGoat\WorkermanBundle\Validator\FileUploadValidator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +29,7 @@ final class RequestConverter
     private static function validateUri(string $uri): void
     {
         if (preg_match('/[\x00-\x1F\x7F]/', $uri)) {
-            throw new \InvalidArgumentException(
+            throw new MalformedRequestException(
                 \sprintf('Request URI contains control characters: %s', \addcslashes($uri, "\x00..\x1F\x7F")),
             );
         }
@@ -43,13 +44,13 @@ final class RequestConverter
     private static function validateMethod(string $method): void
     {
         if (\strlen($method) > self::MAX_METHOD_LENGTH) {
-            throw new \InvalidArgumentException(
+            throw new MalformedRequestException(
                 \sprintf('HTTP method exceeds maximum length of %d: %s', self::MAX_METHOD_LENGTH, $method),
             );
         }
 
         if (preg_match(self::METHOD_REGEX, $method) !== 1) {
-            throw new \InvalidArgumentException(
+            throw new MalformedRequestException(
                 \sprintf('HTTP method contains invalid characters: %s', $method),
             );
         }
@@ -178,7 +179,7 @@ final class RequestConverter
             // Validate header value for control characters
             $stringValue = (string) $value;
             if (\preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $stringValue)) {
-                throw new \InvalidArgumentException(
+                throw new MalformedRequestException(
                     \sprintf('Header "%s" contains control characters: "%s"', $nameLower, \addcslashes($stringValue, "\x00..\x1F\x7F")),
                 );
             }

--- a/src/Exception/ClientInputExceptionInterface.php
+++ b/src/Exception/ClientInputExceptionInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Exception;
+
+/**
+ * Marker interface for exceptions caused by malformed client input.
+ *
+ * Exceptions thrown during request conversion (control bytes in header
+ * values, invalid URI/method, malformed multipart uploads) implement this
+ * interface so that HttpRequestHandler can classify them as 400 client
+ * errors — logged at debug level to prevent log flooding by an
+ * unauthenticated attacker (see issue #577).
+ *
+ * A middleware or application that throws \InvalidArgumentException for
+ * a server-side reason does NOT implement this interface and is therefore
+ * correctly classified as a 500 server fault.
+ */
+interface ClientInputExceptionInterface extends WorkermanExceptionInterface
+{
+}

--- a/src/Exception/FileUploadValidationException.php
+++ b/src/Exception/FileUploadValidationException.php
@@ -6,7 +6,11 @@ namespace CrazyGoat\WorkermanBundle\Exception;
 
 /**
  * Exception thrown when file upload validation fails.
+ *
+ * Implements ClientInputExceptionInterface so HttpRequestHandler
+ * classifies it as a 400 client error (malformed multipart input),
+ * not a 500 server fault. See issue #577.
  */
-final class FileUploadValidationException extends ValidationException
+final class FileUploadValidationException extends ValidationException implements ClientInputExceptionInterface
 {
 }

--- a/src/Exception/MalformedRequestException.php
+++ b/src/Exception/MalformedRequestException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Exception;
+
+/**
+ * Thrown when a client request is structurally malformed and cannot be
+ * converted to a Symfony Request.
+ *
+ * Extends \InvalidArgumentException to preserve semantic correctness for
+ * callers who catch \InvalidArgumentException, and implements
+ * ClientInputExceptionInterface so HttpRequestHandler classifies it as a
+ * 400 client error (not a 500 server fault).
+ *
+ * See issue #577: control bytes in header values, invalid URI/method.
+ */
+final class MalformedRequestException extends \InvalidArgumentException implements ClientInputExceptionInterface
+{
+}

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Http;
 
-use CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException;
+use CrazyGoat\WorkermanBundle\Exception\ClientInputExceptionInterface;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
@@ -201,32 +201,21 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
      *
      * Client errors are caused by malformed input that the bundle rejects
      * during request conversion (control bytes in headers, malformed
-     * multipart uploads, invalid URI/method). They MUST NOT be logged at
-     * error level — otherwise an unauthenticated attacker can flood the
-     * log with a few hundred bytes per request (see issue #577).
+     * multipart uploads, invalid URI/method). They are marked with
+     * ClientInputExceptionInterface and logged at debug level to prevent
+     * log flooding by an unauthenticated attacker (see issue #577).
      *
      * Server faults are everything else: middleware bugs, response
      * conversion failures, misconfiguration, kernel errors that escaped
      * HttpKernel::handle()'s own try block, etc. They are logged at error
-     * level because they indicate a real defect.
+     * level because they indicate a real defect. Notably a middleware
+     * throwing \InvalidArgumentException is a server fault — only
+     * bundle-internal conversion exceptions implement
+     * ClientInputExceptionInterface.
      */
     private function isClientError(\Throwable $e): bool
     {
-        // FileUploadValidationException extends ValidationException
-        // extends \InvalidArgumentException — malformed multipart data.
-        if ($e instanceof FileUploadValidationException) {
-            return true;
-        }
-        // RequestConverter::validateUri()/validateMethod()/buildServerHeaders()
-        // throw \InvalidArgumentException directly for malformed client
-        // input (control bytes, invalid method/URI). Application code that
-        // throws \InvalidArgumentException from inside the kernel is
-        // caught by HttpKernel::handle() and converted to a 500 before we
-        // ever see it, so this branch only fires for pre-handle
-        // conversion failures. NoResponseStrategyException extends
-        // \LogicException (not \InvalidArgumentException), so it naturally
-        // falls through to the server-fault classification below.
-        return $e instanceof \InvalidArgumentException;
+        return $e instanceof ClientInputExceptionInterface;
     }
 
     /**
@@ -312,7 +301,17 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
         } catch (\Throwable $e) {
             $clientError = $this->isClientError($e);
             $this->logThrowable($e, $clientError);
-            $this->sendResponse($connection, $this->buildErrorResponse($clientError));
+            try {
+                $this->sendResponse($connection, $this->buildErrorResponse($clientError));
+            } catch (\Throwable $sendError) {
+                // Best-effort: if even the error-response send fails, log
+                // and close. We must not let the throwable escape __invoke()
+                // — otherwise doTerminate() and the reboot check (which
+                // run after this block) would be skipped, regressing #572,
+                // and Workerman's TcpConnection error handler would fire.
+                $this->logThrowable($sendError, false);
+                $connection->close();
+            }
         }
 
         // Terminate synchronously on both success and failure paths.

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle\Http;
 
+use CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
@@ -12,6 +13,7 @@ use CrazyGoat\WorkermanBundle\Utils;
 use Psr\Log\LoggerInterface;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
+use Workerman\Protocols\Http\Response as WorkermanResponse;
 
 /**
  * Handles the per-request lifecycle for the HTTP worker.
@@ -195,7 +197,99 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
     }
 
     /**
+     * Classify a throwable as a client-caused error (400) or a server fault (500).
+     *
+     * Client errors are caused by malformed input that the bundle rejects
+     * during request conversion (control bytes in headers, malformed
+     * multipart uploads, invalid URI/method). They MUST NOT be logged at
+     * error level — otherwise an unauthenticated attacker can flood the
+     * log with a few hundred bytes per request (see issue #577).
+     *
+     * Server faults are everything else: middleware bugs, response
+     * conversion failures, misconfiguration, kernel errors that escaped
+     * HttpKernel::handle()'s own try block, etc. They are logged at error
+     * level because they indicate a real defect.
+     */
+    private function isClientError(\Throwable $e): bool
+    {
+        // FileUploadValidationException extends ValidationException
+        // extends \InvalidArgumentException — malformed multipart data.
+        if ($e instanceof FileUploadValidationException) {
+            return true;
+        }
+        // RequestConverter::validateUri()/validateMethod()/buildServerHeaders()
+        // throw \InvalidArgumentException directly for malformed client
+        // input (control bytes, invalid method/URI). Application code that
+        // throws \InvalidArgumentException from inside the kernel is
+        // caught by HttpKernel::handle() and converted to a 500 before we
+        // ever see it, so this branch only fires for pre-handle
+        // conversion failures. NoResponseStrategyException extends
+        // \LogicException (not \InvalidArgumentException), so it naturally
+        // falls through to the server-fault classification below.
+        return $e instanceof \InvalidArgumentException;
+    }
+
+    /**
+     * Build a Workerman error response for a throwable caught in the
+     * request lifecycle.
+     */
+    private function buildErrorResponse(bool $clientError): WorkermanResponse
+    {
+        if ($clientError) {
+            return new WorkermanResponse(400, [], 'Bad Request');
+        }
+
+        return new WorkermanResponse(500, [], 'Internal Server Error');
+    }
+
+    /**
+     * Log a throwable caught in the request lifecycle.
+     *
+     * Client errors are logged at debug level so an attacker cannot flood
+     * the log. Server faults are logged at error level with the full
+     * exception. When no PSR-3 logger is configured, only server faults
+     * fall back to error_log(); client errors are silent.
+     */
+    private function logThrowable(\Throwable $e, bool $clientError): void
+    {
+        if ($this->logger instanceof LoggerInterface) {
+            if ($clientError) {
+                $this->logger->debug('Client request rejected: ' . $e->getMessage(), [
+                    'exception' => $e,
+                ]);
+            } else {
+                $this->logger->error('Request lifecycle failed', [
+                    'exception' => $e,
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+            }
+        } elseif (!$clientError) {
+            error_log(sprintf(
+                'Request lifecycle failed: %s in %s:%d',
+                $e->getMessage(),
+                $e->getFile(),
+                $e->getLine(),
+            ));
+        }
+    }
+
+    /**
      * Handle one Workerman HTTP request through the full lifecycle.
+     *
+     * The entire pipeline → send → terminate → close → reboot chain is
+     * wrapped in a single try/catch so that any throwable — whether from
+     * request conversion, a middleware, response conversion, or response
+     * preparation — is converted into a 400/500 response instead of
+     * escaping into Workerman's TcpConnection error handler, which (in
+     * the absence of an installed errorHandler) terminates the worker
+     * process. See issue #577.
+     *
+     * On the failure path, doTerminate() and the reboot check still run,
+     * because the kernel may have partially handled the request before
+     * the throwable escaped, and services_resetter must be invoked to
+     * avoid state leakage into the next request (see issue #572).
      *
      * @param TcpConnection $connection The incoming TCP connection.
      * @param Request       $request    The Workerman HTTP request (extended by
@@ -209,23 +303,29 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
             \memory_reset_peak_usage();
         }
 
-        // 1. Dispatch through middleware chain → controller
         $controllerCall = fn(Request $input): Http\Response => ($this->controller)($input, $connection);
         $pipeline = $this->getPipeline();
-        $response = $pipeline($request, $controllerCall);
 
-        // 2. Send response
-        $this->sendResponse($connection, $response);
+        try {
+            $response = $pipeline($request, $controllerCall);
+            $this->sendResponse($connection, $response);
+        } catch (\Throwable $e) {
+            $clientError = $this->isClientError($e);
+            $this->logThrowable($e, $clientError);
+            $this->sendResponse($connection, $this->buildErrorResponse($clientError));
+        }
 
-        // 3. Terminate synchronously (send() is non-blocking, no timer needed)
+        // Terminate synchronously on both success and failure paths.
+        // On the failure path the controller may not have set its
+        // request/response, in which case terminateIfNeeded() is a no-op.
         $this->doTerminate();
 
-        // 4. Close connection if protocol demands it
+        // Close connection if protocol demands it.
         if ($this->shouldCloseConnection($request)) {
             $connection->close();
         }
 
-        // 5. Reload if strategy signals — terminates synchronously before reload
+        // Reload if strategy signals — runs on both success and failure paths.
         if ($this->rebootStrategy->shouldReboot()) {
             Utils::reload();
         }

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -76,6 +76,17 @@ final readonly class ServerWorker
                 [],
                 false,
             );
+
+            // Defence-in-depth backstop: if a throwable escapes
+            // HttpRequestHandler's own try/catch (e.g. from a future
+            // throw site added after this fix, or from a Workerman
+            // callback that never passes through the handler), close
+            // the connection cleanly instead of letting Workerman call
+            // Worker::stopAll(250) which terminates the whole worker
+            // process. See issue #577.
+            $connection->errorHandler = static function (\Throwable $e) use ($connection): void {
+                $connection->close();
+            };
         };
 
         $worker->onWorkerStart = function (Worker $worker) use ($kernelFactory, $serverConfig, $keepaliveTimeout): void {

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -85,6 +85,27 @@ final readonly class ServerWorker
             // Worker::stopAll(250) which terminates the whole worker
             // process. See issue #577.
             $connection->errorHandler = static function (\Throwable $e) use ($connection): void {
+                // Log unconditionally — an escaped throwable should never
+                // happen and operators need visibility. Use error_log()
+                // because the PSR-3 logger is not easily reachable here.
+                error_log(sprintf(
+                    'Unhandled throwable escaped HttpRequestHandler; closing connection: %s in %s:%d',
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine(),
+                ));
+
+                // Clean up per-connection timers so they don't keep
+                // firing on a defunct connection after close().
+                if (isset($connection->context->keepaliveTimerId)) {
+                    Timer::del($connection->context->keepaliveTimerId);
+                    unset($connection->context->keepaliveTimerId);
+                }
+                if (isset($connection->context->connectionTimerId)) {
+                    Timer::del($connection->context->connectionTimerId);
+                    unset($connection->context->connectionTimerId);
+                }
+
                 $connection->close();
             };
         };

--- a/tests/ControlByteWorkerDosE2ETest.php
+++ b/tests/ControlByteWorkerDosE2ETest.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * E2E acceptance criteria for issue #577.
+ *
+ * Spawns a real single-worker Workerman process, sends control-byte
+ * requests over a real socket, and asserts the worker PID never changes.
+ *
+ * @see https://github.com/crazy-goat/workerman-bundle/issues/577
+ *
+ * @group e2e
+ */
+final class ControlByteWorkerDosE2ETest extends TestCase
+{
+    private const RUNNER = __DIR__ . '/Fixtures/control_byte_dos_e2e_runner.php';
+
+    private string $tempDir = '';
+    private string $autoloadPath = '';
+
+    /** @var resource|null */
+    private $process;
+
+    /** @var array{0: resource, 1: resource, 2: resource}|null */
+    private ?array $pipes = null;
+
+    private int $port = 0;
+
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('pcntl') || !\extension_loaded('posix')) {
+            self::markTestSkipped('pcntl and posix extensions are required.');
+        }
+
+        $autoloadPath = \realpath(__DIR__ . '/../vendor/autoload.php');
+        if ($autoloadPath === false) {
+            self::markTestSkipped('vendor/autoload.php not found.');
+        }
+        $this->autoloadPath = $autoloadPath;
+
+        $this->tempDir = \sys_get_temp_dir() . '/workerman_577_e2e_' . \bin2hex(\random_bytes(4));
+        if (!\mkdir($this->tempDir, 0700) && !\is_dir($this->tempDir)) {
+            self::markTestSkipped('Cannot create temp dir: ' . $this->tempDir);
+        }
+
+        $this->port = $this->allocatePort();
+        $this->process = null;
+        $this->pipes = null;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopWorker();
+
+        if ($this->tempDir !== '' && \is_dir($this->tempDir)) {
+            $this->removeTree($this->tempDir);
+        }
+    }
+
+    /**
+     * AC: control byte → 400 and worker PID unchanged.
+     */
+    public function testControlByteReturns400AndWorkerPidUnchanged(): void
+    {
+        $workerPid = $this->startWorker('handler');
+
+        $before = $this->readWorkerPid();
+        $this->assertSame($workerPid, $before, 'PID file must match ready-reported pid');
+
+        $response = $this->sendRaw(
+            "GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n",
+        );
+
+        $this->assertStringContainsString(
+            '400',
+            $response,
+            'Control-byte request must receive HTTP 400, got: ' . $this->summarize($response),
+        );
+        $this->assertStringContainsString('Bad Request', $response);
+
+        // Brief settle so a crashing worker would have exited / been respawned.
+        \usleep(200_000);
+
+        $after = $this->readWorkerPid();
+        $this->assertSame(
+            $before,
+            $after,
+            'Worker PID must be unchanged after a control-byte request (issue #577)',
+        );
+        $this->assertTrue(
+            \posix_kill($after, 0),
+            'Worker process must still be alive after control-byte request',
+        );
+    }
+
+    /**
+     * AC: soak 10 000 malformed requests; PID never changes.
+     */
+    public function testSoak10kMalformedRequestsKeepsWorkerPidStable(): void
+    {
+        $workerPid = $this->startWorker('handler');
+
+        $malformed = "GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n";
+        $okCount = 0;
+
+        for ($i = 0; $i < 10_000; ++$i) {
+            $response = $this->sendRaw($malformed);
+            if (\str_contains($response, '400')) {
+                ++$okCount;
+            } else {
+                $this->fail(sprintf(
+                    'Request #%d did not return 400 (PID may have died). Response: %s',
+                    $i,
+                    $this->summarize($response),
+                ));
+            }
+
+            if ($i > 0 && $i % 1000 === 0) {
+                $current = $this->readWorkerPid();
+                $this->assertSame(
+                    $workerPid,
+                    $current,
+                    sprintf('Worker PID changed during soak at request #%d', $i),
+                );
+            }
+        }
+
+        $this->assertSame(10_000, $okCount);
+        $this->assertSame(
+            $workerPid,
+            $this->readWorkerPid(),
+            'Worker PID must be unchanged after 10k malformed requests',
+        );
+        $this->assertTrue(\posix_kill($workerPid, 0), 'Worker must still be alive after soak');
+    }
+
+    /**
+     * AC: with handler-level try removed, errorHandler alone keeps the worker alive.
+     */
+    public function testBackstopAloneKeepsWorkerAliveOnControlByte(): void
+    {
+        $workerPid = $this->startWorker('backstop');
+
+        // No 400 expected — the throw escapes onMessage into errorHandler,
+        // which closes the connection without a response body.
+        $response = $this->sendRaw(
+            "GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n",
+            expectMaybeEmpty: true,
+        );
+
+        // Should not be a clean 200 from the happy path.
+        $this->assertStringNotContainsString(
+            '200 OK',
+            $response,
+            'Backstop mode must not complete the happy-path 200 for a control-byte request',
+        );
+
+        \usleep(300_000);
+
+        $after = $this->readWorkerPid();
+        $this->assertSame(
+            $workerPid,
+            $after,
+            'With only errorHandler backstop (no handler try), worker PID must stay alive',
+        );
+        $this->assertTrue(
+            \posix_kill($after, 0),
+            'Worker process must still be alive with backstop-only path',
+        );
+
+        // A subsequent benign request should still be served (worker not dead).
+        $ok = $this->sendRaw("GET /hello HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+        $this->assertStringContainsString(
+            '200',
+            $ok,
+            'Worker must still serve a benign request after backstop handled a throw',
+        );
+    }
+
+    /**
+     * @return int Worker child PID
+     */
+    private function startWorker(string $mode): int
+    {
+        $readyFile = $this->tempDir . '/ready';
+        $pidFile = $this->tempDir . '/worker.pid';
+        $workDir = $this->tempDir . '/wm';
+        @\unlink($readyFile);
+        @\unlink($pidFile);
+
+        $command = [
+            PHP_BINARY,
+            self::RUNNER,
+            $this->autoloadPath,
+            (string) $this->port,
+            $mode,
+            $readyFile,
+            $pidFile,
+            $workDir,
+        ];
+
+        $process = \proc_open(
+            $command,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            null,
+            null,
+            ['bypass_shell' => true],
+        );
+
+        if (!\is_resource($process)) {
+            $this->fail('Failed to start E2E worker process');
+        }
+        $this->process = $process;
+        /** @var array{0: resource, 1: resource, 2: resource} $pipes */
+        $this->pipes = $pipes;
+        \fclose($this->pipes[0]);
+
+        $deadline = \microtime(true) + 15.0;
+        while (\microtime(true) < $deadline) {
+            if (\is_file($readyFile) && \is_file($pidFile)) {
+                $status = \proc_get_status($this->process);
+                if ($status['running'] === false) {
+                    break;
+                }
+                $pid = (int) \trim((string) \file_get_contents($pidFile));
+                if ($pid > 0 && $this->portIsOpen()) {
+                    return $pid;
+                }
+            }
+            \usleep(50_000);
+        }
+
+        $stderr = \stream_get_contents($this->pipes[2]) ?: '';
+        $stdout = \stream_get_contents($this->pipes[1]) ?: '';
+        $this->fail(sprintf(
+            "Worker did not become ready within 15s.\nstderr: %s\nstdout: %s",
+            $stderr,
+            $stdout,
+        ));
+    }
+
+    private function stopWorker(): void
+    {
+        if ($this->process === null) {
+            return;
+        }
+
+        $status = \proc_get_status($this->process);
+        if ($status['running']) {
+            // Kill process group / children: SIGTERM master then wait.
+            $pid = $status['pid'];
+            @\posix_kill($pid, SIGTERM);
+            // Also signal worker child if known.
+            $workerPidFile = $this->tempDir . '/worker.pid';
+            if (\is_file($workerPidFile)) {
+                $child = (int) \trim((string) \file_get_contents($workerPidFile));
+                if ($child > 0) {
+                    @\posix_kill($child, SIGTERM);
+                }
+            }
+            $deadline = \microtime(true) + 3.0;
+            while (\microtime(true) < $deadline) {
+                $s = \proc_get_status($this->process);
+                if (!$s['running']) {
+                    break;
+                }
+                \usleep(50_000);
+            }
+            if (\proc_get_status($this->process)['running']) {
+                @\posix_kill($pid, SIGKILL);
+            }
+        }
+
+        if ($this->pipes !== null) {
+            foreach ([1, 2] as $fd) {
+                if (\is_resource($this->pipes[$fd])) {
+                    \stream_set_blocking($this->pipes[$fd], false);
+                    \stream_get_contents($this->pipes[$fd]);
+                    \fclose($this->pipes[$fd]);
+                }
+            }
+            $this->pipes = null;
+        }
+
+        @\proc_close($this->process);
+        $this->process = null;
+    }
+
+    private function readWorkerPid(): int
+    {
+        $pidFile = $this->tempDir . '/worker.pid';
+        $this->assertFileExists($pidFile, 'Worker PID file must exist');
+        $pid = (int) \trim((string) \file_get_contents($pidFile));
+        $this->assertGreaterThan(0, $pid, 'Worker PID must be positive');
+
+        return $pid;
+    }
+
+    private function sendRaw(string $payload, bool $expectMaybeEmpty = false): string
+    {
+        $errno = 0;
+        $errstr = '';
+        $socket = @\fsockopen('127.0.0.1', $this->port, $errno, $errstr, 2.0);
+        if ($socket === false) {
+            $this->fail(sprintf('fsockopen failed: %s (%d)', $errstr, $errno));
+        }
+
+        \stream_set_timeout($socket, 2);
+        $written = \fwrite($socket, $payload);
+        if ($written === false || $written !== \strlen($payload)) {
+            \fclose($socket);
+            $this->fail('Failed to write full request payload');
+        }
+
+        $response = '';
+        while (!\feof($socket)) {
+            $chunk = \fread($socket, 8192);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            $response .= $chunk;
+            // Enough for status line / small body.
+            if (\strlen($response) > 4096) {
+                break;
+            }
+        }
+        \fclose($socket);
+
+        if ($response === '' && !$expectMaybeEmpty) {
+            $this->fail('Empty response from worker (connection closed without body?)');
+        }
+
+        return $response;
+    }
+
+    private function portIsOpen(): bool
+    {
+        $errno = 0;
+        $errstr = '';
+        $socket = @\fsockopen('127.0.0.1', $this->port, $errno, $errstr, 0.2);
+        if ($socket === false) {
+            return false;
+        }
+        \fclose($socket);
+
+        return true;
+    }
+
+    private function allocatePort(): int
+    {
+        $socket = \stream_socket_server('tcp://127.0.0.1:0');
+        if ($socket === false) {
+            $this->fail('Cannot allocate free port');
+        }
+        $name = \stream_socket_get_name($socket, false);
+        \fclose($socket);
+        if ($name === false || !\str_contains($name, ':')) {
+            $this->fail('Cannot parse allocated port');
+        }
+        $port = (int) \substr($name, (int) \strrpos($name, ':') + 1);
+        $this->assertGreaterThan(0, $port);
+
+        return $port;
+    }
+
+    private function summarize(string $response): string
+    {
+        $trimmed = \preg_replace('/[^\x20-\x7E\r\n]/', '.', $response) ?? $response;
+
+        return \strlen($trimmed) > 200 ? \substr($trimmed, 0, 200) . '…' : $trimmed;
+    }
+
+    private function removeTree(string $dir): void
+    {
+        $entries = \scandir($dir);
+        if ($entries === false) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (\is_dir($path)) {
+                $this->removeTree($path);
+            } else {
+                @\unlink($path);
+            }
+        }
+        @\rmdir($dir);
+    }
+}

--- a/tests/Fixtures/control_byte_dos_e2e_runner.php
+++ b/tests/Fixtures/control_byte_dos_e2e_runner.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Minimal Workerman HTTP worker for issue #577 E2E acceptance criteria.
+ *
+ * argv:
+ *   1 = vendor/autoload.php path
+ *   2 = listen port (int)
+ *   3 = mode: "handler" | "backstop"
+ *   4 = ready file path (written from onWorkerStart)
+ *   5 = worker pid file path (written from onWorkerStart with getmypid())
+ *   6 = work dir for Workerman pid/log/status files
+ *
+ * handler  — full production path: HttpRequestHandler try/catch + errorHandler
+ * backstop — no handler try; RequestConverter throws out of onMessage into
+ *            $connection->errorHandler (proves backstop independence)
+ */
+
+/** @var list<string> $argv */
+
+if (($argc ?? 0) < 7) {
+    fwrite(STDERR, "Usage: control_byte_dos_e2e_runner.php <autoload> <port> <mode> <ready> <pid> <workdir>\n");
+    exit(2);
+}
+
+$autoload = $argv[1];
+$port = (int) $argv[2];
+$mode = $argv[3];
+$readyFile = $argv[4];
+$pidFile = $argv[5];
+$workDir = $argv[6];
+
+if (!is_file($autoload)) {
+    fwrite(STDERR, "autoload not found: {$autoload}\n");
+    exit(2);
+}
+if ($port < 1 || $port > 65535) {
+    fwrite(STDERR, "invalid port: {$port}\n");
+    exit(2);
+}
+if (!in_array($mode, ['handler', 'backstop'], true)) {
+    fwrite(STDERR, "mode must be handler|backstop, got: {$mode}\n");
+    exit(2);
+}
+
+require $autoload;
+
+use CrazyGoat\WorkermanBundle\DTO\RequestConverter;
+use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
+use CrazyGoat\WorkermanBundle\Http\Request as BundleRequest;
+use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
+use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http;
+use Workerman\Timer;
+use Workerman\Worker;
+
+if (!is_dir($workDir) && !mkdir($workDir, 0700, true) && !is_dir($workDir)) {
+    fwrite(STDERR, "cannot create workdir: {$workDir}\n");
+    exit(2);
+}
+
+Worker::$pidFile = $workDir . '/workerman.pid';
+Worker::$logFile = $workDir . '/workerman.log';
+Worker::$statusFile = $workDir . '/workerman.status';
+Worker::$daemonize = false;
+Worker::$stdoutFile = $workDir . '/stdout.log';
+// Workerman parses CLI argv for start/stop/... — force start without relying
+// on script argv (we already consumed it for our own options).
+Worker::$command = 'start';
+
+$kernel = new class implements KernelInterface {
+    public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
+    {
+        return new SymfonyResponse('ok', SymfonyResponse::HTTP_OK);
+    }
+
+    public function boot(): void
+    {
+    }
+
+    public function shutdown(): void
+    {
+    }
+
+    public function getBundles(): array
+    {
+        return [];
+    }
+
+    public function getBundle(string $name, bool $throw = true): \Symfony\Component\HttpKernel\Bundle\BundleInterface
+    {
+        throw new \RuntimeException('n/a');
+    }
+
+    public function locateResource(string $name): string
+    {
+        return '';
+    }
+
+    public function getEnvironment(): string
+    {
+        return 'test';
+    }
+
+    public function isDebug(): bool
+    {
+        return false;
+    }
+
+    public function getProjectDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+
+    public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
+    {
+        throw new \RuntimeException('n/a');
+    }
+
+    public function getStartTime(): float
+    {
+        return 0.0;
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+
+    public function getBuildDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+
+    public function getShareDir(): ?string
+    {
+        return null;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+
+    public function getCharset(): string
+    {
+        return 'UTF-8';
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(\Symfony\Component\Config\Loader\LoaderInterface $loader): void
+    {
+    }
+};
+
+$rebootStrategy = new class implements RebootStrategyInterface {
+    public function shouldReboot(): bool
+    {
+        return false;
+    }
+
+    public function needsPeakMemory(): bool
+    {
+        return false;
+    }
+};
+
+$responseConverter = new ResponseConverter([new DefaultResponseStrategy()]);
+$controller = new SymfonyController($kernel, $responseConverter);
+$handler = new HttpRequestHandler($controller, $rebootStrategy);
+
+$worker = new Worker(sprintf('http://127.0.0.1:%d', $port));
+$worker->name = 'sec577-e2e';
+$worker->count = 1;
+$worker->reusePort = false;
+
+// Mirror ServerWorker::onConnect errorHandler backstop (issue #577).
+$worker->onConnect = static function (TcpConnection $connection): void {
+    $connection->context ??= new \stdClass();
+    $connection->errorHandler = static function (\Throwable $e) use ($connection): void {
+        error_log(sprintf(
+            'Unhandled throwable escaped HttpRequestHandler; closing connection: %s in %s:%d',
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine(),
+        ));
+        if (isset($connection->context->keepaliveTimerId)) {
+            Timer::del($connection->context->keepaliveTimerId);
+            unset($connection->context->keepaliveTimerId);
+        }
+        if (isset($connection->context->connectionTimerId)) {
+            Timer::del($connection->context->connectionTimerId);
+            unset($connection->context->connectionTimerId);
+        }
+        $connection->close();
+    };
+};
+
+$worker->onWorkerStart = static function () use ($pidFile, $readyFile, $mode): void {
+    file_put_contents($pidFile, (string) getmypid());
+    file_put_contents($readyFile, sprintf("ready pid=%d mode=%s\n", getmypid(), $mode));
+    Http::requestClass(BundleRequest::class);
+};
+
+if ($mode === 'handler') {
+    $worker->onMessage = static function (TcpConnection $connection, BundleRequest $request) use ($handler): void {
+        $handler($connection, $request);
+    };
+} else {
+    // Backstop-only: throwable from RequestConverter escapes onMessage into
+    // TcpConnection::error() → $connection->errorHandler. No handler try.
+    $worker->onMessage = static function (TcpConnection $connection, BundleRequest $request): void {
+        RequestConverter::toSymfonyRequest($request);
+        $connection->send("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+        $connection->close();
+    };
+}
+
+Worker::runAll();

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -25,7 +25,7 @@ use Workerman\Timer;
 /**
  * Mock TcpConnection for testing
  */
-final class MockTcpConnection extends TcpConnection
+class MockTcpConnection extends TcpConnection
 {
     /** @var list<string> */
     public array $sentData = [];
@@ -1170,7 +1170,7 @@ final class HttpRequestHandlerTest extends TestCase
         };
     }
 
-    public function testControlByteInHeaderValueReturns400AndKeepsWorkerAlive(): void
+    public function testControlByteInHeaderValueReturns400(): void
     {
         // Reproduces the exact trigger from issue #577: a single 0x01 byte
         // in a header value causes RequestConverter to throw
@@ -1213,7 +1213,7 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertStringContainsString('400', $connection->sentData[0], 'FileUploadValidationException must yield 400');
     }
 
-    public function testThrowingMiddlewareReturns500AndKeepsWorkerAlive(): void
+    public function testThrowingMiddlewareReturns500(): void
     {
         // A middleware that throws a server-side error must produce a 500,
         // not kill the worker. This covers "any middleware in the pipeline"
@@ -1230,6 +1230,33 @@ final class HttpRequestHandlerTest extends TestCase
         $this->assertNotEmpty($connection->sentData, 'A 500 response must be sent, not silent worker death');
         $this->assertStringContainsString('500', $connection->sentData[0], 'Server fault must yield 500');
         $this->assertStringContainsString('Internal Server Error', $connection->sentData[0]);
+    }
+
+    public function testMiddlewareThrowingInvalidArgumentExceptionIsServerFaultNotClientError(): void
+    {
+        // Major finding from review: a middleware that throws
+        // \InvalidArgumentException is a server-side defect (buggy
+        // middleware), NOT a client error. The classification must not
+        // be based on the broad \InvalidArgumentException type — only
+        // bundle-internal conversion exceptions are client errors.
+        // We assert a middleware throwing \InvalidArgumentException
+        // produces a 500 and is logged at error (not debug) level.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('debug');
+        $logger->expects($this->once())->method('error');
+
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, $logger);
+        $handler->withMiddlewares(
+            $this->throwingMiddleware(new \InvalidArgumentException('middleware bad config')),
+        );
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        $handler($connection, $request);
+
+        $this->assertStringContainsString('500', $connection->sentData[0], 'Middleware \\InvalidArgumentException must be a 500 server fault, not 400');
     }
 
     public function testResponseWithNoMatchingStrategyReturns500(): void
@@ -1260,34 +1287,42 @@ final class HttpRequestHandlerTest extends TestCase
     public function testDoTerminateStillRunsWhenPipelineThrows(): void
     {
         // Acceptance criteria from #572/#577: doTerminate() must run on the
-        // failure path so services_resetter is invoked and the kernel
-        // terminate lifecycle is not skipped. When the throw happens before
-        // the controller sets its request/response, terminateIfNeeded() is
-        // a no-op — but the handler must still *reach* it and not skip it
-        // or let the throwable escape. We assert the handler completes
-        // normally (no escape) and a response is sent.
-        $this->handler->withMiddlewares(
+        // failure path. We use a spy reboot strategy whose shouldReboot()
+        // is expected to be called exactly once — doTerminate() runs
+        // before shouldReboot(), so if doTerminate() threw or were
+        // skipped, shouldReboot() would never be reached. We assert the
+        // strategy was consulted AND a 500 was sent.
+        $strategy = $this->createMock(RebootStrategyInterface::class);
+        $strategy->expects($this->once())->method('shouldReboot')->willReturn(false);
+        $strategy->method('needsPeakMemory')->willReturn(false);
+
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $strategy);
+        $handler->withMiddlewares(
             $this->throwingMiddleware(new \RuntimeException('boom')),
         );
 
         $connection = new MockTcpConnection();
         $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
 
-        // If doTerminate() were skipped or the throwable escaped, this
-        // call would throw and the test would error out.
-        ($this->handler)($connection, $request);
+        $handler($connection, $request);
 
-        $this->assertNotEmpty($connection->sentData, 'Handler must send an error response and run doTerminate on the failure path');
+        $this->assertNotEmpty($connection->sentData, 'Handler must send an error response on the failure path');
         $this->assertStringContainsString('500', $connection->sentData[0]);
     }
 
     public function testRebootCheckStillRunsWhenPipelineThrows(): void
     {
-        // The reboot strategy must be consulted on the failure path too,
-        // because a recurring error should still be able to trigger a
-        // graceful worker reload.
-        $this->rebootStrategy->shouldReboot = true;
-        $this->handler->withMiddlewares(
+        // Acceptance criteria: the reboot strategy must be consulted on the
+        // failure path. Using a mock with expects(once())->shouldReboot()
+        // proves the handler reached the reboot check after doTerminate().
+        $strategy = $this->createMock(RebootStrategyInterface::class);
+        $strategy->expects($this->once())->method('shouldReboot')->willReturn(true);
+        $strategy->method('needsPeakMemory')->willReturn(false);
+
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $strategy);
+        $handler->withMiddlewares(
             $this->throwingMiddleware(new \RuntimeException('boom')),
         );
 
@@ -1295,14 +1330,15 @@ final class HttpRequestHandlerTest extends TestCase
         $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
 
         // Utils::reload() sends SIGUSR1 which may fail outside Workerman;
-        // we only care that the handler reached the reboot check.
+        // the mock assertion proves the check ran regardless.
         try {
-            ($this->handler)($connection, $request);
+            $handler($connection, $request);
         } catch (\Throwable) {
-            // posix_kill may fail in test env — that's fine
+            // posix_kill may fail in test env — the strategy mock already
+            // asserted shouldReboot() was called.
         }
 
-        $this->addToAssertionCount(1);
+        $this->assertStringContainsString('500', $connection->sentData[0]);
     }
 
     public function testClientErrorIsLoggedAtDebugNotError(): void
@@ -1447,10 +1483,54 @@ final class HttpRequestHandlerTest extends TestCase
             ($this->handler)($connection, new Request($raw));
         }
 
-        // Every request produced a 400 response; the loop never threw.
-        $this->assertSame(10000, $connection->closed ? 10000 : 10000);
-        $this->assertNotEmpty($connection->sentData);
-        $this->assertStringContainsString('400', $connection->sentData[0]);
-        $this->addToAssertionCount(1);
+        // Every one of the 10 000 requests must have produced a 400 response.
+        $this->assertCount(10000, $connection->sentData, 'Every malformed request must produce a response');
+        foreach ($connection->sentData as $i => $data) {
+            $this->assertStringContainsString('400', $data, "Request #{$i} must yield 400");
+        }
+    }
+
+    public function testFailureToSendErrorResponseDoesNotEscapeHandler(): void
+    {
+        // Blocker from code review: if sendResponse() itself throws while
+        // sending the error response, the throwable must NOT escape
+        // __invoke() — otherwise doTerminate() and the reboot check are
+        // skipped (the #572 regression) and the throwable reaches
+        // Workerman's TcpConnection error handler. We use a connection
+        // whose send() throws to verify the handler contains it.
+        $connection = new class extends MockTcpConnection {
+            public bool $errorSendThrowing = false;
+
+            public function send(mixed $sendBuffer, bool $raw = false): bool
+            {
+                if ($this->errorSendThrowing) {
+                    throw new \RuntimeException('send buffer exploded');
+                }
+
+                return parent::send($sendBuffer, $raw);
+            }
+        };
+
+        // First request: trigger a 500 (throwing middleware), and make the
+        // error-response send throw too. The handler must not escape.
+        $this->handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('middleware boom')),
+        );
+        $connection->errorSendThrowing = true;
+
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        $threw = false;
+        try {
+            ($this->handler)($connection, $request);
+        } catch (\Throwable) {
+            $threw = true;
+        }
+
+        $this->assertFalse(
+            $threw,
+            'Handler must not escape when sendResponse() throws during error response (blocker from review)',
+        );
+        $this->assertTrue($connection->closed, 'Connection must be closed when error-response send fails');
     }
 }

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Test\App\TestMiddleware;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Workerman\Connection\TcpConnection;
 use Workerman\Events\EventInterface;
+use Workerman\Protocols\Http\Response as WorkermanResponse;
 use Workerman\Timer;
 
 /**
@@ -1136,5 +1138,319 @@ final class HttpRequestHandlerTest extends TestCase
 
         $this->assertStringContainsString('X-Auth: token123', $connection->sentData[0]);
         $this->assertStringContainsString('X-Cache: miss', $connection->sentData[0]);
+    }
+
+    // ──────────────────────────────────────────────
+    // Issue #577 — control byte / throw-site containment
+    //
+    // A single control byte in any request header value must NOT kill the
+    // worker process. The handler must catch every throwable from the
+    // pipeline (request conversion, middleware, response conversion,
+    // response preparation) and turn it into a 400 (client error) or
+    // 500 (server fault) response. doTerminate() and the reboot check
+    // must still run on the failure path (#572).
+    // ──────────────────────────────────────────────
+
+    /**
+     * A middleware that always throws, simulating a buggy third-party
+     * middleware or any throw site the handler does not specifically
+     * classify as a client error.
+     */
+    private function throwingMiddleware(\Throwable $e): MiddlewareInterface
+    {
+        return new class ($e) implements MiddlewareInterface {
+            public function __construct(private readonly \Throwable $e)
+            {
+            }
+
+            public function __invoke(Request $request, callable $next): WorkermanResponse
+            {
+                throw $this->e;
+            }
+        };
+    }
+
+    public function testControlByteInHeaderValueReturns400AndKeepsWorkerAlive(): void
+    {
+        // Reproduces the exact trigger from issue #577: a single 0x01 byte
+        // in a header value causes RequestConverter to throw
+        // \InvalidArgumentException during SymfonyController::__invoke().
+        // The handler must catch it and return 400 — not let it escape.
+        $connection = new MockTcpConnection();
+        // 0x01 is a control byte rejected by buildServerHeaders()
+        $request = new Request("GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n");
+
+        ($this->handler)($connection, $request);
+
+        $this->assertNotEmpty($connection->sentData, 'A 400 response must be sent, not silent worker death');
+        $this->assertStringContainsString('400', $connection->sentData[0], 'Control byte in header must yield 400');
+        $this->assertStringContainsString('Bad Request', $connection->sentData[0]);
+    }
+
+    public function testMalformedMultipartUploadReturns400(): void
+    {
+        // FileUploadValidationException is thrown by FileUploadValidator
+        // when multipart upload data is structurally malformed. It extends
+        // ValidationException extends \InvalidArgumentException, so it must
+        // be classified as a client error (400), not a server fault (500).
+        // Reproducing the exact parser path is brittle (Workerman's parser
+        // tolerates a lot), so we inject the exception via a middleware to
+        // verify the handler's classification logic.
+        $this->handler->withMiddlewares(
+            $this->throwingMiddleware(
+                new \CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException(
+                    'Malformed file upload data for field "file": expected array, got string',
+                ),
+            ),
+        );
+
+        $connection = new MockTcpConnection();
+        $request = new Request("POST /upload HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        ($this->handler)($connection, $request);
+
+        $this->assertNotEmpty($connection->sentData, 'Malformed upload must produce a response, not kill the worker');
+        $this->assertStringContainsString('400', $connection->sentData[0], 'FileUploadValidationException must yield 400');
+    }
+
+    public function testThrowingMiddlewareReturns500AndKeepsWorkerAlive(): void
+    {
+        // A middleware that throws a server-side error must produce a 500,
+        // not kill the worker. This covers "any middleware in the pipeline"
+        // from the issue's reachable throw sites list.
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        $this->handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('middleware boom')),
+        );
+
+        ($this->handler)($connection, $request);
+
+        $this->assertNotEmpty($connection->sentData, 'A 500 response must be sent, not silent worker death');
+        $this->assertStringContainsString('500', $connection->sentData[0], 'Server fault must yield 500');
+        $this->assertStringContainsString('Internal Server Error', $connection->sentData[0]);
+    }
+
+    public function testResponseWithNoMatchingStrategyReturns500(): void
+    {
+        // NoResponseStrategyException is thrown by ResponseConverter when
+        // no strategy supports the response type. It extends \LogicException
+        // (a server misconfiguration), so it must be a 500 — not a 400.
+        // DefaultResponseStrategy::supports() always returns true, so to
+        // trigger the exception we use a ResponseConverter with no
+        // strategies at all.
+        $emptyConverter = new ResponseConverter([]);
+        $weirdResponse = new class extends SymfonyResponse {
+        };
+
+        $kernel = new HttpHandlerTestKernel($weirdResponse);
+        $controller = new SymfonyController($kernel, $emptyConverter);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        $handler($connection, $request);
+
+        $this->assertNotEmpty($connection->sentData);
+        $this->assertStringContainsString('500', $connection->sentData[0], 'No-strategy response is a server fault (500)');
+    }
+
+    public function testDoTerminateStillRunsWhenPipelineThrows(): void
+    {
+        // Acceptance criteria from #572/#577: doTerminate() must run on the
+        // failure path so services_resetter is invoked and the kernel
+        // terminate lifecycle is not skipped. When the throw happens before
+        // the controller sets its request/response, terminateIfNeeded() is
+        // a no-op — but the handler must still *reach* it and not skip it
+        // or let the throwable escape. We assert the handler completes
+        // normally (no escape) and a response is sent.
+        $this->handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('boom')),
+        );
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        // If doTerminate() were skipped or the throwable escaped, this
+        // call would throw and the test would error out.
+        ($this->handler)($connection, $request);
+
+        $this->assertNotEmpty($connection->sentData, 'Handler must send an error response and run doTerminate on the failure path');
+        $this->assertStringContainsString('500', $connection->sentData[0]);
+    }
+
+    public function testRebootCheckStillRunsWhenPipelineThrows(): void
+    {
+        // The reboot strategy must be consulted on the failure path too,
+        // because a recurring error should still be able to trigger a
+        // graceful worker reload.
+        $this->rebootStrategy->shouldReboot = true;
+        $this->handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('boom')),
+        );
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        // Utils::reload() sends SIGUSR1 which may fail outside Workerman;
+        // we only care that the handler reached the reboot check.
+        try {
+            ($this->handler)($connection, $request);
+        } catch (\Throwable) {
+            // posix_kill may fail in test env — that's fine
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testClientErrorIsLoggedAtDebugNotError(): void
+    {
+        // Acceptance criteria: the 400 path must not be usable to flood the
+        // error log. Client errors are logged at debug level only.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+        $logger->expects($this->once())->method('debug')->with(
+            $this->stringContains('Client request rejected'),
+            $this->callback(fn(array $ctx): bool => isset($ctx['exception'])),
+        );
+
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, $logger);
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n");
+
+        $handler($connection, $request);
+
+        $this->assertStringContainsString('400', $connection->sentData[0]);
+    }
+
+    public function testServerFaultIsLoggedAtError(): void
+    {
+        // Server faults (500) must be logged at error level with the full
+        // exception, so operators can diagnose defects.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('debug');
+        $logger->expects($this->once())->method('error')->with(
+            'Request lifecycle failed',
+            $this->callback(fn(array $ctx): bool => isset($ctx['exception'])
+                && $ctx['exception'] instanceof \RuntimeException
+                && $ctx['exception']->getMessage() === 'middleware boom'
+                && isset($ctx['message'], $ctx['file'], $ctx['line'])),
+        );
+
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, $logger);
+        $handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('middleware boom')),
+        );
+
+        $connection = new MockTcpConnection();
+        $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+
+        $handler($connection, $request);
+
+        $this->assertStringContainsString('500', $connection->sentData[0]);
+    }
+
+    public function testServerFaultWithoutLoggerFallsBackToErrorLog(): void
+    {
+        // When no PSR-3 logger is configured, server faults must still be
+        // surfaced via error_log() — mirroring doTerminate()'s fallback.
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        // No logger argument → null
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+        $handler->withMiddlewares(
+            $this->throwingMiddleware(new \RuntimeException('server-fault-for-errorlog')),
+        );
+
+        $logFile = tempnam(sys_get_temp_dir(), 'test_handler_');
+        $this->assertNotFalse($logFile);
+        ini_set('error_log', $logFile);
+        try {
+            $connection = new MockTcpConnection();
+            $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+            $handler($connection, $request);
+        } finally {
+            ini_restore('error_log');
+        }
+
+        $logContent = file_get_contents($logFile);
+        @unlink($logFile);
+
+        $this->assertIsString($logContent);
+        $this->assertStringContainsString('server-fault-for-errorlog', $logContent);
+        $this->assertStringContainsString('Request lifecycle failed', $logContent);
+    }
+
+    public function testClientErrorWithoutLoggerIsSilent(): void
+    {
+        // Without a logger, client errors (400) must NOT write to error_log,
+        // otherwise an attacker can flood the log. Only server faults fall
+        // back to error_log.
+        $controller = new SymfonyController($this->kernel, $this->responseConverter);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+
+        $logFile = tempnam(sys_get_temp_dir(), 'test_handler_silent_');
+        $this->assertNotFalse($logFile);
+        // Truncate so we can detect any write
+        file_put_contents($logFile, '');
+        ini_set('error_log', $logFile);
+        try {
+            $connection = new MockTcpConnection();
+            $request = new Request("GET / HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n");
+            $handler($connection, $request);
+        } finally {
+            ini_restore('error_log');
+        }
+
+        $logContent = file_get_contents($logFile);
+        @unlink($logFile);
+
+        $this->assertSame('', $logContent, 'Client errors must not write to error_log when no logger is configured');
+        $this->assertNotEmpty($connection->sentData);
+        $this->assertStringContainsString('400', $connection->sentData[0]);
+    }
+
+    public function testKeepAliveConnectionServesNextRequestAfterError(): void
+    {
+        // Acceptance criteria: a keep-alive connection must either serve the
+        // next request correctly or be closed cleanly after an error. Here
+        // we verify the handler does not throw out of __invoke, so Workerman
+        // can process the next request on the same connection.
+        $connection = new MockTcpConnection();
+        $request1 = new Request("GET / HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\n\r\n");
+        $request2 = new Request(self::HTTP11);
+
+        ($this->handler)($connection, $request1);
+        // Must not throw — second request on the same connection
+        ($this->handler)($connection, $request2);
+
+        $this->assertCount(2, $connection->sentData, 'Both requests must get a response on the keep-alive connection');
+        $this->assertStringContainsString('400', $connection->sentData[0]);
+        $this->assertStringContainsString('200', $connection->sentData[1], 'Second request must succeed normally');
+        $this->assertFalse($connection->closed, 'Keep-alive connection must not be closed after a 400');
+    }
+
+    public function testSoakTest10kMalformedRequestsDoesNotThrow(): void
+    {
+        // Acceptance criteria: a soak test drives 10 000 malformed requests
+        // and asserts the worker never throws (which would kill the process).
+        // In the unit test we assert the handler returns a 400 for every
+        // request and never lets the throwable escape.
+        $connection = new MockTcpConnection();
+        $raw = "GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\nConnection: close\r\n\r\n";
+
+        for ($i = 0; $i < 10000; ++$i) {
+            ($this->handler)($connection, new Request($raw));
+        }
+
+        // Every request produced a 400 response; the loop never threw.
+        $this->assertSame(10000, $connection->closed ? 10000 : 10000);
+        $this->assertNotEmpty($connection->sentData);
+        $this->assertStringContainsString('400', $connection->sentData[0]);
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -1189,28 +1189,43 @@ final class HttpRequestHandlerTest extends TestCase
 
     public function testMalformedMultipartUploadReturns400(): void
     {
-        // FileUploadValidationException is thrown by FileUploadValidator
-        // when multipart upload data is structurally malformed. It extends
-        // ValidationException extends \InvalidArgumentException, so it must
-        // be classified as a client error (400), not a server fault (500).
-        // Reproducing the exact parser path is brittle (Workerman's parser
-        // tolerates a lot), so we inject the exception via a middleware to
-        // verify the handler's classification logic.
-        $this->handler->withMiddlewares(
-            $this->throwingMiddleware(
-                new \CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException(
-                    'Malformed file upload data for field "file": expected array, got string',
-                ),
-            ),
-        );
-
+        // Drive a real FileUploadValidationException through the full
+        // RequestConverter → SymfonyController → HttpRequestHandler path
+        // (AC #577 throw-site coverage). Workerman's multipart parser is
+        // tolerant of many malformed bodies, so we inject a structurally
+        // incomplete file entry into the Request's internal data — the
+        // same shape FileUploadValidator rejects — then let conversion
+        // throw naturally (no middleware stand-in).
         $connection = new MockTcpConnection();
-        $request = new Request("POST /upload HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
+        $request = new Request("POST /upload HTTP/1.1\r\nHost: test\r\nContent-Type: multipart/form-data; boundary=x\r\nConnection: close\r\n\r\n");
 
-        ($this->handler)($connection, $request);
+        // Workerman's Request::file() drops entries whose tmp_name is not
+        // a real file on disk — so the injected path must exist.
+        $tmpFile = \tempnam(\sys_get_temp_dir(), 'wmb577_');
+        $this->assertNotFalse($tmpFile);
+        \file_put_contents($tmpFile, 'x');
+
+        try {
+            $reflection = new \ReflectionClass($request);
+            $dataProperty = $reflection->getProperty('data');
+            $dataProperty->setValue($request, [
+                'files' => [
+                    'malformed_file' => [
+                        'name' => 'test.txt',
+                        'tmp_name' => $tmpFile,
+                        // missing type, size, error — FileUploadValidator rejects
+                    ],
+                ],
+            ]);
+
+            ($this->handler)($connection, $request);
+        } finally {
+            @\unlink($tmpFile);
+        }
 
         $this->assertNotEmpty($connection->sentData, 'Malformed upload must produce a response, not kill the worker');
         $this->assertStringContainsString('400', $connection->sentData[0], 'FileUploadValidationException must yield 400');
+        $this->assertStringContainsString('Bad Request', $connection->sentData[0]);
     }
 
     public function testThrowingMiddlewareReturns500(): void

--- a/tests/PeriodicalTriggerTest.php
+++ b/tests/PeriodicalTriggerTest.php
@@ -48,7 +48,6 @@ final class PeriodicalTriggerTest extends TestCase
     public function testCreateFromRelativeDateStringInterval(): void
     {
         $interval = \DateInterval::createFromDateString('+1 hour');
-        \assert($interval instanceof \DateInterval);
         $trigger = new PeriodicalTrigger($interval);
 
         $this->assertInstanceOf(PeriodicalTrigger::class, $trigger);

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\DTO\RequestConverter;
+use CrazyGoat\WorkermanBundle\Exception\ClientInputExceptionInterface;
+use CrazyGoat\WorkermanBundle\Exception\FileUploadValidationException;
+use CrazyGoat\WorkermanBundle\Exception\MalformedRequestException;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -268,6 +271,48 @@ final class RequestConverterTest extends TestCase
         ]);
 
         RequestConverter::toSymfonyRequest($rawRequest);
+    }
+
+    /**
+     * AC #577: malformed multipart structure through RequestConverter must
+     * throw FileUploadValidationException (not bare InvalidArgumentException)
+     * and mark it as ClientInputExceptionInterface so the handler classifies
+     * it as a 400 client error.
+     */
+    public function testMalformedMultipartFileStructureThrowsFileUploadValidationException(): void
+    {
+        $tmpFile = $this->createTempFile('test content');
+
+        $buffer = "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data; boundary=x\r\n\r\n";
+        $rawRequest = $this->createRequestWithFiles($buffer, [
+            'malformed_file' => [
+                'name' => 'test.txt',
+                'tmp_name' => $tmpFile,
+                // missing type, size, error — FileUploadValidator rejects this
+            ],
+        ]);
+
+        try {
+            RequestConverter::toSymfonyRequest($rawRequest);
+            $this->fail('Expected FileUploadValidationException');
+        } catch (FileUploadValidationException $e) {
+            $this->assertInstanceOf(ClientInputExceptionInterface::class, $e);
+            $this->assertStringContainsString('missing required field', $e->getMessage());
+        }
+    }
+
+    public function testControlByteInHeaderThrowsMalformedRequestException(): void
+    {
+        $buffer = "GET /boom HTTP/1.1\r\nHost: x\r\nX-A: \x01\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        try {
+            RequestConverter::toSymfonyRequest($rawRequest);
+            $this->fail('Expected MalformedRequestException');
+        } catch (MalformedRequestException $e) {
+            $this->assertInstanceOf(ClientInputExceptionInterface::class, $e);
+            $this->assertStringContainsString('control characters', $e->getMessage());
+        }
     }
 
     public function testNonArrayFileEntryIsNotSilentlyDropped(): void

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -13,6 +13,7 @@ use CrazyGoat\WorkermanBundle\Worker\ServerWorker;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Workerman\Connection\TcpConnection;
 use Workerman\Worker;
 
 final class ServerWorkerTest extends TestCase
@@ -665,6 +666,83 @@ final class ServerWorkerTest extends TestCase
         $worker = $this->findWorkerByName('[Server] ows-no-body-cap');
         $this->assertNotNull($worker);
         $this->assertNotNull($worker->onConnect, 'onConnect should always be set for timeout handling');
+    }
+
+    // ──────────────────────────────────────────────
+    // Issue #577 — defence-in-depth: $connection->errorHandler backstop
+    //
+    // Even if HttpRequestHandler's own try/catch misses a throw site added
+    // in the future, the TcpConnection error handler must be set so that
+    // Workerman closes the connection instead of calling Worker::stopAll()
+    // and killing the whole worker process.
+    // ──────────────────────────────────────────────
+
+    public function testOnConnectSetsErrorHandlerBackstop(): void
+    {
+        $kernelFactory = $this->createKernelFactory();
+
+        new ServerWorker(
+            $kernelFactory,
+            null,
+            null,
+            ['name' => 'ows-error-handler', 'listen' => 'http://127.0.0.1:8095'],
+        );
+
+        $worker = $this->findWorkerByName('[Server] ows-error-handler');
+        $this->assertNotNull($worker);
+        $this->assertNotNull($worker->onConnect, 'onConnect must be set');
+
+        // Instantiate TcpConnection without invoking the constructor so we
+        // don't need a real EventLoop / readable socket. onConnect only
+        // touches $maxPackageSize, $context and $errorHandler.
+        $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
+        $connection->context = new \stdClass();
+
+        $onConnect = $worker->onConnect;
+        $onConnect($connection);
+
+        $this->assertNotNull(
+            $connection->errorHandler,
+            'TcpConnection->errorHandler must be set by onConnect as a worker-death backstop (issue #577)',
+        );
+        $this->assertIsCallable($connection->errorHandler, 'errorHandler must be callable');
+    }
+
+    public function testErrorHandlerBackstopClosesConnectionInsteadOfKillingWorker(): void
+    {
+        // The errorHandler installed by onConnect must close the connection
+        // when invoked with a throwable, NOT rethrow or call Worker::stopAll().
+        $kernelFactory = $this->createKernelFactory();
+
+        new ServerWorker(
+            $kernelFactory,
+            null,
+            null,
+            ['name' => 'ows-error-handler-behavior', 'listen' => 'http://127.0.0.1:8105'],
+        );
+
+        $worker = $this->findWorkerByName('[Server] ows-error-handler-behavior');
+        $this->assertNotNull($worker);
+
+        $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
+        $connection->context = new \stdClass();
+        $connection->context->connectionTimerId = null;
+
+        $onConnect = $worker->onConnect;
+        $this->assertNotNull($onConnect, 'onConnect must be set');
+        $onConnect($connection);
+
+        $handler = $connection->errorHandler;
+        $this->assertNotNull($handler);
+
+        $threw = false;
+        try {
+            $handler(new \RuntimeException('simulated escape from handler'));
+        } catch (\Throwable) {
+            $threw = true;
+        }
+
+        $this->assertFalse($threw, 'errorHandler backstop must not rethrow (would bypass Worker::stopAll guard)');
     }
 
     public function testOnConnectClosureCapturesBodySizeCap(): void

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -745,6 +745,52 @@ final class ServerWorkerTest extends TestCase
         $this->assertFalse($threw, 'errorHandler backstop must not rethrow (would bypass Worker::stopAll guard)');
     }
 
+    public function testErrorHandlerBackstopLogsToErrorLog(): void
+    {
+        // Major finding from review: the backstop must not silently swallow
+        // throwables — operators need visibility when the defence-in-depth
+        // backstop fires. We assert it writes to error_log with the
+        // exception message.
+        $kernelFactory = $this->createKernelFactory();
+
+        new ServerWorker(
+            $kernelFactory,
+            null,
+            null,
+            ['name' => 'ows-error-handler-log', 'listen' => 'http://127.0.0.1:8106'],
+        );
+
+        $worker = $this->findWorkerByName('[Server] ows-error-handler-log');
+        $this->assertNotNull($worker);
+
+        $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
+        $connection->context = new \stdClass();
+        $connection->context->connectionTimerId = null;
+
+        $onConnect = $worker->onConnect;
+        $this->assertNotNull($onConnect);
+        $onConnect($connection);
+
+        $handler = $connection->errorHandler;
+        $this->assertNotNull($handler);
+
+        $logFile = tempnam(sys_get_temp_dir(), 'test_backstop_');
+        $this->assertNotFalse($logFile);
+        file_put_contents($logFile, '');
+        ini_set('error_log', $logFile);
+        try {
+            $handler(new \RuntimeException('backstop-visibility-check'));
+        } finally {
+            ini_restore('error_log');
+        }
+
+        $logContent = file_get_contents($logFile);
+        @unlink($logFile);
+
+        $this->assertIsString($logContent);
+        $this->assertStringContainsString('backstop-visibility-check', $logContent, 'Backstop must log the escaped throwable to error_log');
+    }
+
     public function testOnConnectClosureCapturesBodySizeCap(): void
     {
         $kernelFactory = $this->createKernelFactory();


### PR DESCRIPTION
## Description

Closes #577

A single control byte in any request header value killed the Workerman worker process (remote unauthenticated DoS). The request lifecycle in `HttpRequestHandler::__invoke()` had no try/catch, and `ServerWorker` never assigned `$connection->errorHandler`, so Workerman called `Worker::stopAll(250)`.

## Changes

- Wrap the full request lifecycle in `HttpRequestHandler::__invoke()` with try/catch; client input errors → 400, server faults → 500
- Nested try/catch around error-response `sendResponse()` so send failure cannot escape (doTerminate + reboot still run)
- Introduce `ClientInputExceptionInterface` marker; `MalformedRequestException` (new) and `FileUploadValidationException` implement it
- `RequestConverter` throws `MalformedRequestException` instead of bare `\InvalidArgumentException`
- `ServerWorker::onConnect` installs `$connection->errorHandler` backstop (log + timer cleanup + close)
- Client errors logged at debug (no flood); server faults at error + `error_log` fallback
- Unit tests for control-byte path, middleware throws, classification, doTerminate/reboot on failure, soak 10k, backstop behavior

## Changelog

- **Security**: Fix remote unauthenticated DoS from control byte in request header (#577)
- **Changed**: `RequestConverter` throws `MalformedRequestException` instead of bare `\InvalidArgumentException`
- **Added**: `ClientInputExceptionInterface`, `MalformedRequestException`

## Code Review

- [x] Passed subagent code review (round 1: 16 findings fixed; round 2: clean)
- [x] All review comments addressed