### PR TITLE
fix(http): prevent cached request header leakage (closes #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Prevent middleware header mutations from persisting in Workerman's request cache and being replayed to later requests with the same raw buffer. Headers are restored after each request dispatch, preventing cross-request identity, proxy, and tenant-state leakage ([#576](https://github.com/crazy-goat/workerman-bundle/issues/576))
+
 - Fix remote unauthenticated denial-of-service: a single control byte in
   any request header value killed the worker process. The request
   lifecycle in `HttpRequestHandler::__invoke()` is now wrapped in a

--- a/benchmarks/RequestConverterBench.md
+++ b/benchmarks/RequestConverterBench.md
@@ -1,0 +1,26 @@
+# RequestConverter benchmark
+
+Environment: PHP 8.5.8, PHPBench 1.7.0, xdebug disabled, opcache disabled, 1000 revisions, 5 iterations, 1 warmup.
+
+The `RequestConverterBench` benchmark includes request conversion plus a direct measurement of the added `Request::resetHeaders()` operation. The converter subjects remain request-path proxies; `benchResetHeaders` measures the fix's added operation directly.
+
+## Before
+
+Source commit: `0cef5f2` (parent of the fix commit)
+
+| Subject | Mode |
+| --- | ---: |
+| `benchSimpleRequest` | 2.921 μs |
+| `benchHeaderHeavyRequest` | 5.915 μs |
+| `benchMultipartRequest` | 6.310 μs |
+
+## After
+
+Working tree after the request-header cache fix and E2E coverage.
+
+| Subject | Mode |
+| --- | ---: |
+| `benchSimpleRequest` | 3.167 μs |
+| `benchHeaderHeavyRequest` | 5.943 μs |
+| `benchMultipartRequest` | 5.361 μs |
+| `benchResetHeaders` | 0.108 μs |

--- a/benchmarks/RequestConverterBench.php
+++ b/benchmarks/RequestConverterBench.php
@@ -25,6 +25,7 @@ final class RequestConverterBench
     private Request $simpleRequest;
     private Request $headerHeavyRequest;
     private Request $multipartRequest;
+    private Request $resetHeadersRequest;
 
     public function init(): void
     {
@@ -54,6 +55,7 @@ final class RequestConverterBench
         $buffer .= 'Content-Length: ' . strlen($body) . "\r\n";
         $buffer .= "\r\n";
         $this->multipartRequest = new Request($buffer . $body);
+        $this->resetHeadersRequest = new Request("GET /test HTTP/1.1\r\nHost: localhost\r\nX-Forwarded-For: 198.51.100.10\r\n\r\n");
     }
 
     public function benchSimpleRequest(): void
@@ -69,5 +71,10 @@ final class RequestConverterBench
     public function benchMultipartRequest(): void
     {
         RequestConverter::toSymfonyRequest($this->multipartRequest);
+    }
+
+    public function benchResetHeaders(): void
+    {
+        $this->resetHeadersRequest->resetHeaders();
     }
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,7 +55,7 @@ The bundle exposes `Request::setHeader()` (and its deprecated alias `withHeader(
 
 Trust-sensitive headers — `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Ssl`, and the standardised `Forwarded` header — communicate **client-supplied network information** that downstream code uses to reconstruct the original request origin. Symfony's `Request::setTrustedProxies()` / `setTrustedHosts()` filtering exists precisely to prevent untrusted clients from spoofing these values.
 
-Because `setHeader()` mutates the request **after** the bundle's own header sanitization has run, any middleware that re-injects these headers from untrusted input re-creates the trusted-proxy bypass class of bugs the bundle works to avoid. The trust boundary is the middleware contract: callers must understand that these methods bypass any earlier sanitization.
+Because `setHeader()` mutates the request **after** the bundle's own header sanitization has run, any middleware that re-injects these headers from untrusted input re-creates the trusted-proxy bypass class of bugs the bundle works to avoid. The trust boundary is the middleware contract: callers must understand that these methods bypass any earlier sanitization. Header mutations are restored after each request dispatch, preventing Workerman's request cache from replaying them to a later request with the same raw buffer.
 
 ### Recommended pattern
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -57,7 +57,8 @@ class Request extends \Workerman\Protocols\Http\Request
      * `setTrustedHosts()` filtering, ensure that filtering runs **after** any
      * middleware that calls this method, or scope-limit which middleware is
      * allowed to set forwarding headers. See `docs/security.md` for the full
-     * trust model.
+     * trust model. Header mutations are reset after dispatch so they cannot
+     * persist in Workerman's request cache and affect a later request.
      */
     public function setHeader(string $name, string $value): self
     {
@@ -69,6 +70,11 @@ class Request extends \Workerman\Protocols\Http\Request
         $this->data['headers'][$name] = $value;
 
         return $this;
+    }
+
+    public function resetHeaders(): void
+    {
+        $this->parseHeaders();
     }
 
     /**

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -133,7 +133,11 @@ final readonly class ServerWorker
                     unset($connection->context->keepaliveTimerId);
                 }
 
-                $handler($connection, $request);
+                try {
+                    $handler($connection, $request);
+                } finally {
+                    $request->resetHeaders();
+                }
 
                 if ($keepaliveTimeout > 0) {
                     $connection->context ??= new \stdClass();

--- a/tests/ControlByteWorkerDosE2ETest.php
+++ b/tests/ControlByteWorkerDosE2ETest.php
@@ -62,6 +62,24 @@ final class ControlByteWorkerDosE2ETest extends TestCase
         }
     }
 
+    public function testCachedAndUncachedRequestHeadersAreResetBetweenConnections(): void
+    {
+        $this->startWorker('cache576');
+
+        foreach ([
+            "GET /cache HTTP/1.1\r\nHost: x\r\nX-Forwarded-For: 198.51.100.10\r\nConnection: close\r\n\r\n",
+            "GET /cache HTTP/1.1\r\nHost: x\r\nX-Forwarded-For: 198.51.100.10\r\nX-Large: " . str_repeat('a', 3000) . "\r\nConnection: close\r\n\r\n",
+        ] as $request) {
+            $first = $this->sendRaw($request);
+            $second = $this->sendRaw($request);
+
+            $this->assertStringContainsString('200 OK', $first);
+            $this->assertStringContainsString('200 OK', $second);
+            $this->assertStringContainsString("\r\n\r\nyes|198.51.100.99", $first);
+            $this->assertStringContainsString("\r\n\r\nmissing|198.51.100.10", $second);
+        }
+    }
+
     /**
      * AC: control byte → 400 and worker PID unchanged.
      */

--- a/tests/Fixtures/control_byte_dos_e2e_runner.php
+++ b/tests/Fixtures/control_byte_dos_e2e_runner.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * argv:
  *   1 = vendor/autoload.php path
  *   2 = listen port (int)
- *   3 = mode: "handler" | "backstop"
+ *   3 = mode: "handler" | "backstop" | "cache576"
  *   4 = ready file path (written from onWorkerStart)
  *   5 = worker pid file path (written from onWorkerStart with getmypid())
  *   6 = work dir for Workerman pid/log/status files
@@ -40,8 +40,8 @@ if ($port < 1 || $port > 65535) {
     fwrite(STDERR, "invalid port: {$port}\n");
     exit(2);
 }
-if (!in_array($mode, ['handler', 'backstop'], true)) {
-    fwrite(STDERR, "mode must be handler|backstop, got: {$mode}\n");
+if (!in_array($mode, ['handler', 'backstop', 'cache576'], true)) {
+    fwrite(STDERR, "mode must be handler|backstop|cache576, got: {$mode}\n");
     exit(2);
 }
 
@@ -52,8 +52,10 @@ use CrazyGoat\WorkermanBundle\Http\HttpRequestHandler;
 use CrazyGoat\WorkermanBundle\Http\Request as BundleRequest;
 use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
 use CrazyGoat\WorkermanBundle\Middleware\SymfonyController;
 use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -77,9 +79,20 @@ Worker::$stdoutFile = $workDir . '/stdout.log';
 Worker::$command = 'start';
 
 $kernel = new class implements KernelInterface {
+    private ?\Symfony\Component\DependencyInjection\ContainerInterface $container = null;
+
+    public function setContainer(\Symfony\Component\DependencyInjection\ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
+
     public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
     {
-        return new SymfonyResponse('ok', SymfonyResponse::HTTP_OK);
+        return new SymfonyResponse(
+            ($request->headers->get('x-request-processed', 'missing')) . '|'
+            . ($request->headers->get('x-forwarded-for', 'missing')),
+            SymfonyResponse::HTTP_OK,
+        );
     }
 
     public function boot(): void
@@ -122,7 +135,11 @@ $kernel = new class implements KernelInterface {
 
     public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
     {
-        throw new \RuntimeException('n/a');
+        if (!$this->container instanceof \Symfony\Component\DependencyInjection\ContainerInterface) {
+            throw new \RuntimeException('Container not initialized');
+        }
+
+        return $this->container;
     }
 
     public function getStartTime(): float
@@ -180,6 +197,45 @@ $rebootStrategy = new class implements RebootStrategyInterface {
 $responseConverter = new ResponseConverter([new DefaultResponseStrategy()]);
 $controller = new SymfonyController($kernel, $responseConverter);
 $handler = new HttpRequestHandler($controller, $rebootStrategy);
+$handler->withMiddlewares(new class implements MiddlewareInterface {
+    /** @var array<int, int> */
+    private static array $requestsBySize = [];
+
+    public function __invoke(BundleRequest $request, callable $next): \Workerman\Protocols\Http\Response
+    {
+        $size = strlen($request->rawHead());
+        $requests = self::$requestsBySize[$size] ?? 0;
+        self::$requestsBySize[$size] = $requests + 1;
+        if ($requests === 0) {
+            $request->setHeader('X-Request-Processed', 'yes');
+            $request->setHeader('X-Forwarded-For', '198.51.100.99');
+        }
+
+        return $next($request);
+    }
+});
+
+if ($mode === 'cache576') {
+    $container = new ContainerBuilder();
+    $container->set('workerman.http_request_handler', $handler);
+    $kernel->setContainer($container);
+    $kernelFactory = new \CrazyGoat\WorkermanBundle\KernelFactory(static fn(): KernelInterface => $kernel, []);
+    new \CrazyGoat\WorkermanBundle\Worker\ServerWorker(
+        $kernelFactory,
+        null,
+        null,
+        [
+            'name' => 'sec576-e2e',
+            'listen' => sprintf('http://127.0.0.1:%d', $port),
+            'processes' => 1,
+            'reuse_port' => false,
+        ],
+    );
+    file_put_contents($pidFile, (string) getmypid());
+    file_put_contents($readyFile, sprintf("ready pid=%d mode=%s\\n", getmypid(), $mode));
+    Worker::runAll();
+    exit(0);
+}
 
 $worker = new Worker(sprintf('http://127.0.0.1:%d', $port));
 $worker->name = 'sec577-e2e';

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -127,6 +127,18 @@ final class RequestTest extends TestCase
         $this->assertSame($request, $result);
     }
 
+    public function testResetHeadersRestoresOriginalHeaders(): void
+    {
+        $request = $this->createRequest('GET', '/', ['X-Original' => 'value']);
+
+        $request->setHeader('X-Internal', 'secret');
+        $request->setHeader('X-Original', 'changed');
+        $request->resetHeaders();
+
+        $this->assertSame('value', $request->header('x-original'));
+        $this->assertNull($request->header('x-internal'));
+    }
+
     public function testHeaderLookupIsCaseInsensitive(): void
     {
         $request = $this->createRequest('GET', '/', ['X-Custom-Header' => 'value']);

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\Exception\InvalidMiddlewareException;
 use CrazyGoat\WorkermanBundle\Http\MiddlewareDispatchInterface;
+use CrazyGoat\WorkermanBundle\Http\Request;
 use CrazyGoat\WorkermanBundle\Http\StaticFileHandlerInterface;
 use CrazyGoat\WorkermanBundle\KernelFactory;
 use CrazyGoat\WorkermanBundle\Middleware\MiddlewareInterface;
@@ -494,6 +495,63 @@ final class ServerWorkerTest extends TestCase
 
         $this->assertNotNull($worker->onMessage, 'onMessage should be set after onWorkerStart');
         $this->assertInstanceOf(\Closure::class, $worker->onMessage, 'onMessage should be a closure that wraps the handler');
+    }
+
+    public function testOnMessageResetsHeadersAfterHandlerReturnsAndThrows(): void
+    {
+        $requests = [];
+        $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withStaticFileConfig', 'withRootDirectory'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $handler->method('withStaticFileConfig')->willReturnSelf();
+        $handler->method('withRootDirectory')->willReturnSelf();
+        $handler->method('__invoke')->willReturnCallback(function ($connection, Request $request) use (&$requests): void {
+            $requests[] = $request->header('x-internal');
+            $request->setHeader('X-Internal', 'secret');
+            if (count($requests) === 2) {
+                throw new \RuntimeException('handler failure');
+            }
+        });
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('workerman.http_request_handler')->willReturn($handler);
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        $kernelFactory = new KernelFactory(fn(): KernelInterface => $kernel, []);
+
+        new ServerWorker(
+            $kernelFactory,
+            null,
+            null,
+            ['name' => 'ows-header-reset', 'listen' => 'http://127.0.0.1:8107'],
+        );
+
+        $worker = $this->findWorkerByName('[Server] ows-header-reset');
+        $this->assertNotNull($worker);
+        $onWorkerStart = $worker->onWorkerStart;
+        $this->assertNotNull($onWorkerStart);
+        $onWorkerStart($worker);
+
+        $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
+        $connection->context = new \stdClass();
+        $connection->context->connectionTimerId = null;
+        $connection->context->keepaliveTimerId = null;
+        $onMessage = $worker->onMessage;
+        $this->assertNotNull($onMessage);
+        $request = new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+        $onMessage($connection, $request);
+        try {
+            $onMessage($connection, $request);
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('handler failure', $exception->getMessage());
+        }
+        $onMessage($connection, $request);
+
+        $this->assertSame([null, null, null], $requests);
+        $this->assertNull($request->header('x-internal'));
     }
 
     public function testOnWorkerStartResolvesMiddlewares(): void


### PR DESCRIPTION
## Description

Closes #576

## Changes

- Restore parsed request headers after every handler dispatch, including when the handler throws.
- Prevent middleware mutations from persisting in Workerman's request cache.
- Add regression coverage for normal and exceptional handler paths.
- Update security documentation and changelog.

## Verification

- composer lint
- composer test
- Code review completed; no blocker findings

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed