### PR TITLE
docs(changelog): release 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-28
+
 ### Security
 
 - Prevent middleware header mutations from persisting in Workerman's request cache and being replayed to later requests with the same raw buffer. Headers are restored after each request dispatch, preventing cross-request identity, proxy, and tenant-state leakage ([#576](https://github.com/crazy-goat/workerman-bundle/issues/576))


### PR DESCRIPTION
Promote [Unreleased] security fixes (#576 header cache leakage, #577 control-byte worker DoS) to the 0.24.1 patch release section dated 2026-07-28. Changelog-only change, no code touched.