### PR TITLE
fix(ci): enforce non-zero coverage gate threshold (closes #589)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,9 +86,11 @@ jobs:
         run: composer test:coverage
 
       - name: Check coverage threshold
-        run: |
-          composer coverage:check
-          php bin/check-coverage.php var/coverage.xml 0.0
+        # Gate on the lowest supported matrix leg only. The threshold is
+        # defined once in composer.json (coverage:check) and per-leg coverage
+        # is stable within ~0.1pp, so nine identical gates are wasted signal.
+        if: matrix.php-version == '8.2' && matrix.symfony-version == '6.4.*'
+        run: composer coverage:check
 
       - name: Sanitize artifact name
         id: artifact
@@ -135,5 +137,6 @@ jobs:
         run: |
           if [ "${{ needs.lint.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.tests.result }}" != "success" ]; then exit 1; fi
-          # Benchmark is advisory initially — log status but do not block merge
+          # Benchmark is intentionally advisory: CI runner timing varies too
+          # much to gate merges on it — log status but do not block merge
           echo "Benchmark status: ${{ needs.benchmark.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make the CI coverage gate effective: the threshold was `0.0` (passing
+  trivially at ~82% actual coverage) and the check ran twice per matrix leg.
+  The threshold (80%) is now defined once in `composer.json`
+  (`coverage:check`), the duplicate invocation in
+  `.github/workflows/tests.yaml` is removed, and the gate runs only on the
+  lowest supported matrix leg (PHP 8.2 / Symfony 6.4) — per-leg coverage
+  reports are still uploaded as artifacts
+  ([#589](https://github.com/crazy-goat/workerman-bundle/issues/589))
+
 ## [0.24.1] - 2026-07-28
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,9 @@ rm .git/hooks/pre-push
    ```
 
    The `test:coverage` script writes a Clover report to `var/coverage.xml` and
-   `coverage:check` parses it to enforce the configured line-coverage threshold.
-   CI uses the same scripts with PCOV so the gate is reproducible locally.
+   `coverage:check` parses it to enforce the line-coverage threshold (**80%**),
+   defined once in `composer.json`. CI runs the same check with PCOV on the
+   PHP 8.2 / Symfony 6.4 matrix leg, so the gate is reproducible locally.
 
    > **Troubleshooting "Address already in use"**
    > - Find the process occupying the port: `lsof -i :8888` or `ss -tlnp | grep 8888`
@@ -138,7 +139,7 @@ rm .git/hooks/pre-push
 The CI workflow (`.github/workflows/tests.yaml`) runs on every pull request:
 
 - **Lint job**: Validates `composer.json`, runs security audit, and checks code style
-- **Tests job**: Runs PHPUnit tests across the supported PHP (8.2–8.5) and Symfony (6.4–8.0) version matrix
+- **Tests job**: Runs PHPUnit tests across the supported PHP (8.2–8.5) and Symfony (6.4–8.0) version matrix; the PHP 8.2 / Symfony 6.4 leg also enforces the line-coverage threshold (80%, defined in `composer.json` → `coverage:check`)
 - **Benchmark job**: Runs the PHPBench suite in advisory mode (results are logged but do not block merge)
 
 ## Code Standards

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
             "APP_RUNTIME=CrazyGoat\\\\WorkermanBundle\\\\Runtime php tests/App/index.php stop"
         ],
         "coverage:check": [
-            "php bin/check-coverage.php var/coverage.xml 0.0"
+            "php bin/check-coverage.php var/coverage.xml 80.0"
         ],
         "lint-fix": [
             "vendor/bin/php-cs-fixer fix -v",

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -139,7 +139,16 @@ composer lint-fix
 
 # Run tests (boots a real Workerman daemon on ports 8888 and 9999)
 composer test
+
+# (Optional) Verify the coverage gate locally — requires PCOV or Xdebug:
+composer test:coverage
+composer coverage:check
 ```
+
+> **Note:** CI enforces a line-coverage floor of **80%**, defined once in
+> `composer.json` (`coverage:check`) and checked on the PHP 8.2 / Symfony 6.4
+> matrix leg. If your PR adds meaningful logic, verify the gate locally so CI
+> doesn't tell you first.
 
 > **Note:** `composer test` boots a real Workerman daemon binding ports 8888
 > and 9999 for E2E tests. If you see "Address already in use" errors, ensure

--- a/tests/CoverageCiGateTest.php
+++ b/tests/CoverageCiGateTest.php
@@ -89,7 +89,7 @@ final class CoverageCiGateTest extends TestCase
         self::assertStringContainsString('simplexml_load_file', $scriptContents);
     }
 
-    private static function readWorkflow(): string
+    private function readWorkflow(): string
     {
         $workflowFile = __DIR__ . '/../.github/workflows/tests.yaml';
         self::assertFileIsReadable($workflowFile);

--- a/tests/CoverageCiGateTest.php
+++ b/tests/CoverageCiGateTest.php
@@ -23,11 +23,25 @@ final class CoverageCiGateTest extends TestCase
 
         self::assertSame(
             1,
-            substr_count($workflow, 'composer coverage:check'),
-            'The coverage gate must run exactly once (single designated matrix leg)',
+            substr_count($workflow, 'run: composer coverage:check'),
+            'The coverage gate must be invoked exactly once (single designated matrix leg)',
         );
-        self::assertStringContainsString("matrix.php-version == '8.2'", $workflow);
-        self::assertStringContainsString("matrix.symfony-version == '6.4.*'", $workflow);
+        self::assertMatchesRegularExpression(
+            '/- name: Check coverage threshold(?:(?!- name:).)*if: matrix\.php-version == \'8\.2\' && matrix\.symfony-version == \'6\.4\.\*\'/s',
+            $workflow,
+            'The coverage gate step must be restricted to the lowest supported matrix leg (PHP 8.2 / Symfony 6.4)',
+        );
+    }
+
+    public function testCoverageReportUploadRunsEvenWhenGateFails(): void
+    {
+        $workflow = self::readWorkflow();
+
+        self::assertMatchesRegularExpression(
+            '/- name: Upload coverage report(?:(?!- name:).)*if: always\(\)/s',
+            $workflow,
+            'The coverage report artifact must still upload when the gate fails (if: always())',
+        );
     }
 
     public function testThresholdIsDefinedOnlyInComposerScript(): void
@@ -55,7 +69,7 @@ final class CoverageCiGateTest extends TestCase
 
         $matched = preg_match(
             '/check-coverage\.php\s+\S+\s+(?<threshold>\d+(?:\.\d+)?)/',
-            (string) $scripts[0],
+            (string) reset($scripts),
             $matches,
         );
         self::assertSame(1, $matched, 'coverage:check must pass an explicit threshold to check-coverage.php');

--- a/tests/CoverageCiGateTest.php
+++ b/tests/CoverageCiGateTest.php
@@ -10,16 +10,60 @@ final class CoverageCiGateTest extends TestCase
 {
     public function testCiWorkflowRunsCoverageAndThresholdCheck(): void
     {
-        $workflowFile = __DIR__ . '/../.github/workflows/tests.yaml';
-        self::assertFileIsReadable($workflowFile);
-
-        $workflow = file_get_contents($workflowFile);
-        self::assertIsString($workflow);
+        $workflow = self::readWorkflow();
 
         self::assertStringContainsString('coverage: pcov', $workflow);
         self::assertStringContainsString('composer test:coverage', $workflow);
         self::assertStringContainsString('composer coverage:check', $workflow);
-        self::assertStringContainsString('check-coverage.php', $workflow);
+    }
+
+    public function testCoverageGateRunsOnceOnLowestMatrixLegOnly(): void
+    {
+        $workflow = self::readWorkflow();
+
+        self::assertSame(
+            1,
+            substr_count($workflow, 'composer coverage:check'),
+            'The coverage gate must run exactly once (single designated matrix leg)',
+        );
+        self::assertStringContainsString("matrix.php-version == '8.2'", $workflow);
+        self::assertStringContainsString("matrix.symfony-version == '6.4.*'", $workflow);
+    }
+
+    public function testThresholdIsDefinedOnlyInComposerScript(): void
+    {
+        $workflow = self::readWorkflow();
+
+        self::assertStringNotContainsString(
+            'bin/check-coverage.php',
+            $workflow,
+            'CI must not invoke check-coverage.php directly — the threshold is defined once in composer.json',
+        );
+    }
+
+    public function testComposerCoverageCheckDefinesNonZeroThreshold(): void
+    {
+        $composerFile = __DIR__ . '/../composer.json';
+        self::assertFileIsReadable($composerFile);
+
+        $composer = json_decode((string) file_get_contents($composerFile), true);
+        self::assertIsArray($composer);
+
+        $scripts = $composer['scripts']['coverage:check'] ?? null;
+        self::assertIsArray($scripts);
+        self::assertCount(1, $scripts, 'coverage:check must be a single command so the threshold lives in one place');
+
+        $matched = preg_match(
+            '/check-coverage\.php\s+\S+\s+(?<threshold>\d+(?:\.\d+)?)/',
+            (string) $scripts[0],
+            $matches,
+        );
+        self::assertSame(1, $matched, 'coverage:check must pass an explicit threshold to check-coverage.php');
+        self::assertGreaterThan(
+            0.0,
+            (float) $matches['threshold'],
+            'The coverage gate threshold must be non-zero so the gate can actually fail',
+        );
     }
 
     public function testCoverageScriptExistsAndIsExecutable(): void
@@ -29,5 +73,16 @@ final class CoverageCiGateTest extends TestCase
         $scriptContents = file_get_contents($script);
         self::assertIsString($scriptContents);
         self::assertStringContainsString('simplexml_load_file', $scriptContents);
+    }
+
+    private static function readWorkflow(): string
+    {
+        $workflowFile = __DIR__ . '/../.github/workflows/tests.yaml';
+        self::assertFileIsReadable($workflowFile);
+
+        $workflow = file_get_contents($workflowFile);
+        self::assertIsString($workflow);
+
+        return $workflow;
     }
 }


### PR DESCRIPTION
## Description

Closes #589

The CI coverage gate was present in name only: the threshold was `0.0` (trivially green at the measured ~82.17% coverage) and the same check ran twice per matrix leg. This PR makes the gate effective.

## Changes

- **Threshold 0.0 → 80.0**, defined once in `composer.json` (`coverage:check`) — 80% leaves ~2.2pp headroom against the observed 82.17%, while the measured 0.04pp per-leg spread makes flaky failures impossible
- **Removed the duplicate invocation** — `.github/workflows/tests.yaml` now calls `composer coverage:check` only; the verbatim `php bin/check-coverage.php var/coverage.xml 0.0` duplicate is gone, so the threshold lives in exactly one place
- **Gate runs once, not nine times** — the `Check coverage threshold` step is restricted via `if:` to the lowest supported matrix leg (PHP 8.2 / Symfony 6.4.*); per-leg coverage differs by ~0.04pp so the remaining eight gates were wasted signal. Per-leg coverage reports are still uploaded as artifacts (`if: always()` preserved)
- **Benchmark comment clarified** — the `ci` aggregation job's "advisory initially" comment now states the advisory mode is intentional (runner timing is too variable to gate merges on)
- **Regression test hardened** — `CoverageCiGateTest` now asserts: single gate invocation tied to the correct step, the 8.2/6.4.* leg condition, no direct `check-coverage.php` call in the workflow, upload step keeps `if: always()`, and a non-zero threshold defined in `composer.json`
- **Docs** — `docs/workflow.md` step 7 and `CONTRIBUTING.md` now state the 80% floor and where it is defined, so contributors learn about it before CI tells them

Not implemented (explicitly optional in the issue): the coverage ratchet. 80.0 is the recommended safe first step; a ratchet can follow separately.

## Changelog

Added under `[Unreleased]` → `Fixed`: make the CI coverage gate effective (threshold 80% defined once in `composer.json`, duplicate removed, single-leg gate).

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed

## Gate failure demonstration

The gate was demonstrated to fail correctly by a temporary commit (now removed) that excluded three covered test directories (`tests/Command`, `tests/Phar`, `tests/Supervisor`) from the PHPUnit suite. Coverage dropped from ~82% to **68.21%**, and the gate failed on the single 8.2 / 6.4 leg:

```
Coverage: 68.21% (6213/9108 statements). Threshold: 80.00%. FAILED
```

Failing run (8.2/6.4 leg): https://github.com/crazy-goat/workerman-bundle/actions/runs/30379541493/job/90343929802

All other 8 matrix legs stayed green (the gate only runs on the designated leg), `Lint` and `Benchmark` passed, and the coverage report artifact still uploaded (`if: always()`). The temporary commit was removed via force-push; the branch now contains only the three implementation commits.

## Note for reviewer

#597 also touches `.github/workflows/tests.yaml` (per its author's comment on #589) — whichever lands second should rebase.