### PR TITLE
fix: strip transport-owned headers to prevent duplicate Content-Length (closes #579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fix duplicate `Content-Length` on every file download and on responses where
+  the application sets its own `Content-Length`. Workerman's
+  `Response::withHeaders()` merges recursively (`array_merge_recursive`), so
+  application-supplied framing headers were combined with — not replaced by —
+  the values the transport layer computes, emitting the header twice. When the
+  two values disagreed (app declares 5 bytes, body is 11), the conflict is a
+  response-desync primitive that can poison caches and leak responses across
+  keep-alive connections. `ResponseConverter::extractHeaders()` now strips
+  transport-owned headers (`Content-Length`, `Accept-Ranges`,
+  `Transfer-Encoding`) centrally so the transport is the sole authority on
+  message framing, and single-valued headers are flattened from
+  `list<string|null>` (nulls filtered) to `string` (except `Set-Cookie`, which
+  legitimately needs multiple values) to prevent `array_merge_recursive` from
+  ever producing arrays of conflicting values. Headers whose values are all
+  null/empty are dropped so they are not emitted as empty lines on the wire.
+  `Content-Range` and the `206` status on ranged responses are preserved. The
+  existing `strcasecmp` guards in `DefaultResponseStrategy::buildHeaderString()`
+  and `StreamedResponseStrategy::buildHeaderString()` are kept as
+  belt-and-braces
+  ([#579](https://github.com/crazy-goat/workerman-bundle/issues/579))
+
 ### Fixed
 
 - Make the CI coverage gate effective: the threshold was `0.0` (passing

--- a/src/Http/Response/ResponseConverter.php
+++ b/src/Http/Response/ResponseConverter.php
@@ -11,6 +11,17 @@ use Workerman\Protocols\Http\Response as WorkermanResponse;
 
 final readonly class ResponseConverter
 {
+    /**
+     * Headers owned by the transport layer (Workerman's Http::encode() and
+     * Response::__toString()). These are stripped from application input so the
+     * transport is the sole authority on message framing — see issue #579.
+     */
+    private const TRANSPORT_HEADERS = [
+        'content-length',
+        'accept-ranges',
+        'transfer-encoding',
+    ];
+
     /** @var ResponseConverterStrategyInterface[] */
     private array $strategies;
 
@@ -36,16 +47,65 @@ final readonly class ResponseConverter
     }
 
     /**
-     * @return array<string, list<string|null>>
+     * Extracts and normalises Symfony headers for handoff to a Workerman Response.
+     *
+     * Two transformations are applied centrally so every strategy benefits and
+     * the transport layer stays the sole authority on message framing:
+     *
+     * 1. Transport-owned headers are stripped. Workerman's Http::encode() and
+     *    Response::__toString() compute Content-Length, Accept-Ranges and
+     *    Transfer-Encoding themselves and merge (via array_merge_recursive)
+     *    rather than overwrite, which would otherwise emit duplicates — and
+     *    duplicates that disagree are a response-desync primitive (issue #579).
+     *    Content-Range is NOT stripped: Workerman sets it via header() (which
+     *    overwrites), and Symfony's value is correct for ranged responses.
+     *
+     * 2. Single-valued headers are flattened from list<string|null> to a string.
+     *    Workerman's Response::withHeaders() merges recursively, so passing a
+     *    list for a header that encode() also sets produces an array of both
+     *    values. Set-Cookie is the one header that legitimately needs multiple
+     *    values, so it keeps its array shape.
+     *
+     * @return array<string, string|list<string|null>>
      */
     private function extractHeaders(SymfonyResponse $response): array
     {
         $normalized = [];
         foreach ($response->headers->all() as $name => $values) {
-            $normalized[$this->normalizeHeaderName($name)] = $values;
+            $normalizedName = $this->normalizeHeaderName($name);
+
+            if (in_array(strtolower($normalizedName), self::TRANSPORT_HEADERS, true)) {
+                continue;
+            }
+
+            $flattened = $this->flattenHeaderValues($normalizedName, $values);
+            if ($flattened === [] || $flattened === '') {
+                // Drop headers whose values are all null/empty so they are
+                // not emitted as empty lines on the wire.
+                continue;
+            }
+
+            $normalized[$normalizedName] = $flattened;
         }
 
         return $normalized;
+    }
+
+    /**
+     * @param list<string|null> $values
+     * @return string|list<string>
+     */
+    private function flattenHeaderValues(string $name, array $values): string|array
+    {
+        $nonNull = array_values(array_filter($values, static fn(?string $v): bool => $v !== null));
+
+        $isSetCookie = strcasecmp($name, 'Set-Cookie') === 0;
+
+        if (!$isSetCookie && count($nonNull) === 1) {
+            return $nonNull[0];
+        }
+
+        return $nonNull;
     }
 
     /**

--- a/src/Http/Response/ResponseConverterStrategyInterface.php
+++ b/src/Http/Response/ResponseConverterStrategyInterface.php
@@ -18,7 +18,10 @@ interface ResponseConverterStrategyInterface
     /**
      * Convert Symfony response to Workerman response.
      *
-     * @param array<string, list<string|null>> $headers Pre-extracted headers
+     * @param array<string, string|list<string|null>> $headers Pre-extracted headers,
+     *        with transport-owned headers (Content-Length, Accept-Ranges,
+     *        Transfer-Encoding) already stripped and single-valued headers
+     *        flattened to strings (except Set-Cookie)
      */
     public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse;
 }

--- a/src/Http/Response/Strategy/DefaultResponseStrategy.php
+++ b/src/Http/Response/Strategy/DefaultResponseStrategy.php
@@ -42,7 +42,7 @@ final readonly class DefaultResponseStrategy implements ResponseConverterStrateg
     }
 
     /**
-     * @param array<string, list<string|null>> $headers
+     * @param array<string, string|list<string|null>> $headers
      */
     private function sendChunked(string $content, int $contentLength, array $headers, TcpConnection $connection, int $statusCode): void
     {
@@ -63,7 +63,7 @@ final readonly class DefaultResponseStrategy implements ResponseConverterStrateg
     }
 
     /**
-     * @param array<string, list<string|null>> $headers
+     * @param array<string, string|list<string|null>> $headers
      */
     private function buildHeaderString(array $headers, int $contentLength, int $statusCode): string
     {
@@ -74,10 +74,12 @@ final readonly class DefaultResponseStrategy implements ResponseConverterStrateg
             if (strpbrk($name, ":\r\n") !== false) {
                 continue;
             }
+            // Belt-and-braces: ResponseConverter already strips Content-Length,
+            // but keep the guard so a future caller cannot reintroduce it.
             if (strcasecmp($name, 'Content-Length') === 0) {
                 continue;
             }
-            foreach ($values as $value) {
+            foreach ((array) $values as $value) {
                 if ($value !== null && strpbrk($value, "\r\n") !== false) {
                     continue;
                 }

--- a/src/Http/Response/Strategy/StreamedResponseStrategy.php
+++ b/src/Http/Response/Strategy/StreamedResponseStrategy.php
@@ -74,7 +74,7 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
     }
 
     /**
-     * @param array<string, list<string|null>> $headers
+     * @param array<string, string|list<string|null>> $headers
      */
     private function buildHeaderString(array $headers, int $statusCode): string
     {
@@ -85,13 +85,15 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
             if (strpbrk($name, ":\r\n") !== false) {
                 continue;
             }
+            // Belt-and-braces: ResponseConverter already strips these, but keep
+            // the guards so a future caller cannot reintroduce them.
             if (strcasecmp($name, 'Content-Length') === 0) {
                 continue;
             }
             if (strcasecmp($name, 'Transfer-Encoding') === 0) {
                 continue;
             }
-            foreach ($values as $value) {
+            foreach ((array) $values as $value) {
                 if ($value !== null && strpbrk($value, "\r\n") !== false) {
                     continue;
                 }

--- a/tests/ContentLengthDesyncTest.php
+++ b/tests/ContentLengthDesyncTest.php
@@ -10,9 +10,11 @@ use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
 use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http;
 
 /**
  * Regression tests for issue #579: duplicate Content-Length on every file
@@ -77,74 +79,18 @@ final class ContentLengthDesyncTest extends TestCase
     }
 
     /**
-     * Path 1: BinaryFileResponse download — must emit exactly one
-     * Content-Length and one Accept-Ranges.
+     * Path 1: BinaryFileResponse download — see
+     * testFileDownloadThroughEncodeEmitsSingleFramingHeaders for the
+     * end-to-end wire test using Http::encode() that asserts exactly one
+     * Content-Length and one Accept-Ranges on the wire plus the full body.
      */
-    public function testBinaryFileDownloadEmitsSingleContentLengthAndAcceptRanges(): void
-    {
-        $file = $this->createFixtureFile('download.txt', str_repeat('x', 5000));
-
-        $converter = $this->createConverter();
-        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
-            'Content-Type' => 'text/plain',
-        ]);
-        $binaryResponse->prepare($this->createSymfonyRequest());
-
-        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
-
-        // For file responses, Workerman's Http::encode() adds Content-Length
-        // and Accept-Ranges via withHeaders(). We simulate that here to prove
-        // no duplication occurs when the app headers were stripped centrally.
-        $workermanResponse->withHeaders([
-            'Content-Length' => 5000,
-            'Accept-Ranges' => 'bytes',
-        ]);
-
-        $head = (string) $workermanResponse;
-
-        $this->assertSame(
-            1,
-            substr_count($head, 'Content-Length:'),
-            'File download must emit exactly one Content-Length header',
-        );
-        $this->assertSame(
-            1,
-            substr_count($head, 'Accept-Ranges:'),
-            'File download must emit exactly one Accept-Ranges header',
-        );
-    }
 
     /**
-     * Path 2: ranged BinaryFileResponse — must yield 206 with exactly one
-     * Content-Length and one Content-Range.
+     * Path 2: ranged BinaryFileResponse — see
+     * testRangedFileDownloadThroughEncodeEmitsCorrectBodyRange for the
+     * end-to-end wire test that asserts status 206, single Content-Length,
+     * correct Content-Range value, and the requested byte range as body.
      */
-    public function testRangedBinaryFileResponseEmitsSingleContentLengthAndContentRange(): void
-    {
-        $file = $this->createFixtureFile('ranged.txt', str_repeat('x', 5000));
-
-        $converter = $this->createConverter();
-        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
-            'Content-Type' => 'text/plain',
-        ]);
-        $binaryResponse->prepare($this->createSymfonyRequest(range: 'bytes=0-99'));
-
-        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
-
-        // Simulate Http::encode() adding Content-Length, Accept-Ranges, and
-        // setting Content-Range + status via header() (which overwrites).
-        $workermanResponse->withHeaders([
-            'Content-Length' => 100,
-            'Accept-Ranges' => 'bytes',
-        ]);
-        $workermanResponse->header('Content-Range', 'bytes 0-99/5000');
-        $workermanResponse->withStatus(206);
-
-        $head = (string) $workermanResponse;
-
-        $this->assertSame(1, substr_count($head, 'Content-Length:'));
-        $this->assertSame(1, substr_count($head, 'Content-Range:'));
-        $this->assertStringContainsString('206', $head);
-    }
 
     /**
      * Path 3: small body where the app sets a Content-Length that DISAGREES
@@ -198,7 +144,8 @@ final class ContentLengthDesyncTest extends TestCase
 
     /**
      * Path 5: StreamedResponse — uses Transfer-Encoding: chunked, must not
-     * emit Content-Length at all.
+     * emit Content-Length at all, even when the application sets its own
+     * Content-Length (which must be stripped so it cannot leak onto the wire).
      */
     public function testStreamedResponseEmitsNoContentLength(): void
     {
@@ -206,12 +153,15 @@ final class ContentLengthDesyncTest extends TestCase
 
         $streamedResponse = new StreamedResponse(function (): void {
             echo 'streamed content';
-        });
+        }, Response::HTTP_OK, [
+            'Content-Length' => '999',
+        ]);
 
         $converter->convert($streamedResponse, $this->connection);
 
         $sent = implode('', $this->getSent());
-        $this->assertSame(0, substr_count($sent, 'Content-Length:'));
+        $this->assertSame(0, substr_count($sent, 'Content-Length:'), 'Streamed path must not emit Content-Length even if the app set one');
+        $this->assertSame(0, substr_count($sent, 'Content-Length: 999'), 'App-supplied Content-Length must not leak onto the wire');
         $this->assertSame(1, substr_count($sent, 'Transfer-Encoding: chunked'));
     }
 
@@ -294,6 +244,106 @@ final class ContentLengthDesyncTest extends TestCase
         $this->assertSame(1, substr_count($head, 'Content-Length:'));
         $this->assertSame(0, substr_count($head, 'Content-Length: 12345'));
         $this->assertStringContainsString('ETag: "abc"', $head);
+    }
+
+    /**
+     * A HEAD request must emit no body and a consistent Content-Length.
+     * Symfony's prepare() empties the body for HEAD; the transport then
+     * computes Content-Length: 0 from the empty body.
+     */
+    public function testHeadRequestEmitsNoBodyAndSingleContentLength(): void
+    {
+        $converter = $this->createConverter();
+
+        $response = new Response('hello world', Response::HTTP_OK, [
+            'Content-Length' => '999',
+        ]);
+        $response->prepare(Request::create('/', \Symfony\Component\HttpFoundation\Request::METHOD_HEAD));
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $output = (string) $workermanResponse;
+
+        $this->assertSame(1, substr_count($output, 'Content-Length:'), 'HEAD must emit exactly one Content-Length');
+        $this->assertStringContainsString('Content-Length: 0', $output);
+        $this->assertStringNotContainsString('Content-Length: 999', $output);
+
+        // No body after the head terminator.
+        $parts = explode("\r\n\r\n", $output, 2);
+        $this->assertSame('', $parts[1] ?? '', 'HEAD must not emit a body');
+    }
+
+    /**
+     * End-to-end wire test for ranged file download using Workerman's actual
+     * Http::encode(). Asserts on the bytes written to the connection: status
+     * 206, exactly one Content-Length: 100, Content-Range: bytes 0-99/5000,
+     * and the body is the requested 100-byte range from the fixture.
+     */
+    public function testRangedFileDownloadThroughEncodeEmitsCorrectBodyRange(): void
+    {
+        $fixtureContent = str_repeat('y', 5000);
+        $file = $this->createFixtureFile('ranged_encode.txt', $fixtureContent);
+
+        $converter = $this->createConverter();
+        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+        $binaryResponse->prepare($this->createSymfonyRequest(range: 'bytes=0-99'));
+
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+
+        // Drive the real Workerman serializer. For files < 2MB, encode() sends
+        // head + body in one send() call and returns ''.
+        $return = Http::encode($workermanResponse, $this->connection);
+        $this->assertSame('', $return, 'encode() should send inline for small files');
+
+        $wire = implode('', $this->getSent());
+
+        $this->assertStringContainsString('HTTP/1.1 206', $wire, 'Ranged response must be 206');
+        $this->assertSame(1, substr_count($wire, 'Content-Length:'), 'Exactly one Content-Length on the wire');
+        $this->assertStringContainsString('Content-Length: 100', $wire);
+        $this->assertSame(1, substr_count($wire, 'Content-Range:'), 'Exactly one Content-Range on the wire');
+        $this->assertStringContainsString('Content-Range: bytes 0-99/5000', $wire, 'Content-Range value must match the requested range');
+
+        // Body after the head terminator must be the requested 100-byte range.
+        $parts = explode("\r\n\r\n", $wire, 2);
+        $this->assertSame(
+            substr($fixtureContent, 0, 100),
+            $parts[1] ?? '',
+            'Body must be the requested byte range from the fixture',
+        );
+    }
+
+    /**
+     * End-to-end wire test for plain file download using Workerman's actual
+     * Http::encode(). Asserts exactly one Content-Length and one Accept-Ranges
+     * on the wire, and the body is the full fixture content.
+     */
+    public function testFileDownloadThroughEncodeEmitsSingleFramingHeaders(): void
+    {
+        $fixtureContent = str_repeat('z', 5000);
+        $file = $this->createFixtureFile('download_encode.txt', $fixtureContent);
+
+        $converter = $this->createConverter();
+        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+        $binaryResponse->prepare($this->createSymfonyRequest());
+
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+
+        $return = Http::encode($workermanResponse, $this->connection);
+        $this->assertSame('', $return);
+
+        $wire = implode('', $this->getSent());
+
+        $this->assertSame(1, substr_count($wire, 'Content-Length:'), 'Exactly one Content-Length on the wire');
+        $this->assertStringContainsString('Content-Length: 5000', $wire);
+        $this->assertSame(1, substr_count($wire, 'Accept-Ranges:'), 'Exactly one Accept-Ranges on the wire');
+        $this->assertStringContainsString('Accept-Ranges: bytes', $wire);
+
+        $parts = explode("\r\n\r\n", $wire, 2);
+        $this->assertSame($fixtureContent, $parts[1] ?? '', 'Body must be the full fixture content');
     }
 
     private function createConverter(): ResponseConverter

--- a/tests/ContentLengthDesyncTest.php
+++ b/tests/ContentLengthDesyncTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use CrazyGoat\WorkermanBundle\Http\Response\ResponseConverter;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\BinaryFileResponseStrategy;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\DefaultResponseStrategy;
+use CrazyGoat\WorkermanBundle\Http\Response\Strategy\StreamedResponseStrategy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Workerman\Connection\TcpConnection;
+
+/**
+ * Regression tests for issue #579: duplicate Content-Length on every file
+ * download and on app-set Content-Length — response desync when values
+ * conflict.
+ *
+ * Each test asserts on the actual bytes that would be written to the wire,
+ * not on the Response object's header array, because the duplicate arises in
+ * Workerman's encode()/__toString() at serialization time.
+ */
+final class ContentLengthDesyncTest extends TestCase
+{
+    private string $fixtureDir;
+    private TcpConnection $connection;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = sys_get_temp_dir() . '/cld_' . uniqid();
+        mkdir($this->fixtureDir, 0777, true);
+
+        // Anonymous TcpConnection subclass that captures every raw send()
+        // without touching a real socket. Mirrors the pattern used in
+        // BinaryFileResponseStrategyTest. Captured bytes are exposed via the
+        // public $captured property.
+        $this->connection = new class extends TcpConnection {
+            /** @var list<string> */
+            public array $captured = [];
+
+            public function __construct()
+            {
+                // Bypass parent constructor — no socket needed.
+            }
+
+            public function send(mixed $sendBuffer, bool $raw = false): bool
+            {
+                if (is_string($sendBuffer)) {
+                    $this->captured[] = $sendBuffer;
+                }
+
+                return true;
+            }
+        };
+        $this->connection->context = new \stdClass();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->fixtureDir)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->fixtureDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            foreach ($files as $fileinfo) {
+                if ($fileinfo->isDir()) {
+                    rmdir($fileinfo->getRealPath());
+                } else {
+                    unlink($fileinfo->getRealPath());
+                }
+            }
+            rmdir($this->fixtureDir);
+        }
+    }
+
+    /**
+     * Path 1: BinaryFileResponse download — must emit exactly one
+     * Content-Length and one Accept-Ranges.
+     */
+    public function testBinaryFileDownloadEmitsSingleContentLengthAndAcceptRanges(): void
+    {
+        $file = $this->createFixtureFile('download.txt', str_repeat('x', 5000));
+
+        $converter = $this->createConverter();
+        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+        $binaryResponse->prepare($this->createSymfonyRequest());
+
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+
+        // For file responses, Workerman's Http::encode() adds Content-Length
+        // and Accept-Ranges via withHeaders(). We simulate that here to prove
+        // no duplication occurs when the app headers were stripped centrally.
+        $workermanResponse->withHeaders([
+            'Content-Length' => 5000,
+            'Accept-Ranges' => 'bytes',
+        ]);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(
+            1,
+            substr_count($head, 'Content-Length:'),
+            'File download must emit exactly one Content-Length header',
+        );
+        $this->assertSame(
+            1,
+            substr_count($head, 'Accept-Ranges:'),
+            'File download must emit exactly one Accept-Ranges header',
+        );
+    }
+
+    /**
+     * Path 2: ranged BinaryFileResponse — must yield 206 with exactly one
+     * Content-Length and one Content-Range.
+     */
+    public function testRangedBinaryFileResponseEmitsSingleContentLengthAndContentRange(): void
+    {
+        $file = $this->createFixtureFile('ranged.txt', str_repeat('x', 5000));
+
+        $converter = $this->createConverter();
+        $binaryResponse = new BinaryFileResponse($file, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain',
+        ]);
+        $binaryResponse->prepare($this->createSymfonyRequest(range: 'bytes=0-99'));
+
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+
+        // Simulate Http::encode() adding Content-Length, Accept-Ranges, and
+        // setting Content-Range + status via header() (which overwrites).
+        $workermanResponse->withHeaders([
+            'Content-Length' => 100,
+            'Accept-Ranges' => 'bytes',
+        ]);
+        $workermanResponse->header('Content-Range', 'bytes 0-99/5000');
+        $workermanResponse->withStatus(206);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(1, substr_count($head, 'Content-Length:'));
+        $this->assertSame(1, substr_count($head, 'Content-Range:'));
+        $this->assertStringContainsString('206', $head);
+    }
+
+    /**
+     * Path 3: small body where the app sets a Content-Length that DISAGREES
+     * with the actual body — must emit exactly one Content-Length matching
+     * the bytes actually sent.
+     */
+    public function testSmallBodyWithDisagreeingAppContentLengthEmitsSingleCorrectValue(): void
+    {
+        $converter = $this->createConverter();
+
+        $response = new Response('hello world', Response::HTTP_OK, [
+            'Content-Length' => '5',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(
+            1,
+            substr_count($head, 'Content-Length:'),
+            'Small-body path must emit exactly one Content-Length',
+        );
+        // Workerman computes Content-Length from the actual body (11 bytes),
+        // not from the stripped app-supplied value (5).
+        $this->assertStringContainsString('Content-Length: 11', $head);
+        $this->assertStringNotContainsString('Content-Length: 5', $head);
+    }
+
+    /**
+     * Path 4: large body (> chunk size) — buildHeaderString writes its own
+     * Content-Length. The app-supplied Content-Length must already be gone.
+     */
+    public function testLargeBodyPathEmitsSingleContentLength(): void
+    {
+        $converter = new ResponseConverter([
+            new DefaultResponseStrategy(2048),
+        ]);
+
+        $body = str_repeat('a', 4096);
+        $response = new Response($body, Response::HTTP_OK, [
+            'Content-Length' => (string) strlen($body),
+        ]);
+
+        $converter->convert($response, $this->connection);
+
+        $sent = implode('', $this->getSent());
+        $this->assertSame(1, substr_count($sent, 'Content-Length:'));
+        $this->assertStringContainsString('Content-Length: 4096', $sent);
+    }
+
+    /**
+     * Path 5: StreamedResponse — uses Transfer-Encoding: chunked, must not
+     * emit Content-Length at all.
+     */
+    public function testStreamedResponseEmitsNoContentLength(): void
+    {
+        $converter = $this->createConverter();
+
+        $streamedResponse = new StreamedResponse(function (): void {
+            echo 'streamed content';
+        });
+
+        $converter->convert($streamedResponse, $this->connection);
+
+        $sent = implode('', $this->getSent());
+        $this->assertSame(0, substr_count($sent, 'Content-Length:'));
+        $this->assertSame(1, substr_count($sent, 'Transfer-Encoding: chunked'));
+    }
+
+    /**
+     * Set-Cookie with multiple values must still emit one line per cookie
+     * even after the single-value flattening transformation.
+     */
+    public function testMultipleSetCookiesEmitOneLinePerCookie(): void
+    {
+        $converter = $this->createConverter();
+
+        $response = new Response('ok');
+        $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('a', '1'));
+        $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('b', '2'));
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(2, substr_count($head, 'Set-Cookie:'));
+        $this->assertStringContainsString('a=1', $head);
+        $this->assertStringContainsString('b=2', $head);
+    }
+
+    /**
+     * The transport-header strip must be explicit and catch any future header
+     * that encode() also sets. This guards the TRANSPORT_HEADERS list.
+     */
+    public function testTransportHeadersListedExplicitly(): void
+    {
+        $reflection = new \ReflectionClass(ResponseConverter::class);
+        $constant = $reflection->getConstant('TRANSPORT_HEADERS');
+
+        $this->assertSame(
+            ['content-length', 'accept-ranges', 'transfer-encoding'],
+            $constant,
+            'TRANSPORT_HEADERS must explicitly list Content-Length, Accept-Ranges, Transfer-Encoding',
+        );
+    }
+
+    /**
+     * A response with no body must still emit exactly one Content-Length,
+     * computed from the actual empty body. Covers the empty-body path that
+     * HEAD/204/304 responses share (Workerman emits Content-Length: 0).
+     */
+    public function testEmptyBodyEmitsSingleZeroContentLength(): void
+    {
+        $converter = $this->createConverter();
+
+        $response = new Response('', Response::HTTP_OK, [
+            'Content-Length' => '999',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(1, substr_count($head, 'Content-Length:'));
+        $this->assertStringContainsString('Content-Length: 0', $head);
+        $this->assertStringNotContainsString('Content-Length: 999', $head);
+    }
+
+    /**
+     * A 304 Not Modified must not carry a body and must emit a consistent
+     * Content-Length.
+     */
+    public function testNotModifiedEmitsSingleContentLength(): void
+    {
+        $converter = $this->createConverter();
+
+        $response = new Response('', Response::HTTP_NOT_MODIFIED, [
+            'Content-Length' => '12345',
+            'ETag' => '"abc"',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $head = (string) $workermanResponse;
+
+        $this->assertSame(1, substr_count($head, 'Content-Length:'));
+        $this->assertSame(0, substr_count($head, 'Content-Length: 12345'));
+        $this->assertStringContainsString('ETag: "abc"', $head);
+    }
+
+    private function createConverter(): ResponseConverter
+    {
+        return new ResponseConverter([
+            new StreamedResponseStrategy(),
+            new BinaryFileResponseStrategy(),
+            new DefaultResponseStrategy(),
+        ]);
+    }
+
+    private function createFixtureFile(string $name, string $content): string
+    {
+        $path = $this->fixtureDir . '/' . $name;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    private function createSymfonyRequest(?string $range = null): \Symfony\Component\HttpFoundation\Request
+    {
+        $request = new \Symfony\Component\HttpFoundation\Request(
+            server: ['REQUEST_METHOD' => 'GET', 'HTTP_HOST' => 'localhost'],
+        );
+
+        if ($range !== null) {
+            $request->headers->set('Range', $range);
+        }
+
+        return $request;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getSent(): array
+    {
+        // The anonymous TcpConnection subclass exposes a public $captured
+        // property that is not declared on TcpConnection itself, so we read it
+        // via reflection to satisfy PHPStan.
+        $reflection = (new \ReflectionObject($this->connection))->getProperty('captured');
+
+        /** @var list<string> $value */
+        $value = $reflection->getValue($this->connection);
+
+        return $value;
+    }
+}

--- a/tests/ResponseConverterTest.php
+++ b/tests/ResponseConverterTest.php
@@ -76,8 +76,8 @@ final class ResponseConverterTest extends TestCase
         $workermanResponse = $converter->convert($response, $this->connection);
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
-        $this->assertSame(['text/html'], $workermanResponse->getHeader('Content-Type'));
-        $this->assertSame(['attachment'], $workermanResponse->getHeader('Content-Disposition'));
+        $this->assertSame('text/html', $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame('attachment', $workermanResponse->getHeader('Content-Disposition'));
     }
 
     public function testConvertHandlesIterableStrategies(): void
@@ -128,10 +128,10 @@ final class ResponseConverterTest extends TestCase
 
         $workermanResponse = $converter->convert($response, $this->connection);
 
-        $this->assertSame(['"abc123"'], $workermanResponse->getHeader('ETag'));
-        $this->assertSame(['deadbeef'], $workermanResponse->getHeader('Content-MD5'));
-        $this->assertSame(['Bearer'], $workermanResponse->getHeader('WWW-Authenticate'));
-        $this->assertSame(['1'], $workermanResponse->getHeader('DNT'));
+        $this->assertSame('"abc123"', $workermanResponse->getHeader('ETag'));
+        $this->assertSame('deadbeef', $workermanResponse->getHeader('Content-MD5'));
+        $this->assertSame('Bearer', $workermanResponse->getHeader('WWW-Authenticate'));
+        $this->assertSame('1', $workermanResponse->getHeader('DNT'));
     }
 
     public function testConvertNormalizesIrregularHeadersConsistentlyOnRepeatedCalls(): void
@@ -150,8 +150,8 @@ final class ResponseConverterTest extends TestCase
         $r2 = $converter->convert($response2, $this->connection);
 
         // Both calls hit the static cache on the second invocation
-        $this->assertSame(['"v1"'], $r1->getHeader('ETag'));
-        $this->assertSame(['"v2"'], $r2->getHeader('ETag'));
+        $this->assertSame('"v1"', $r1->getHeader('ETag'));
+        $this->assertSame('"v2"', $r2->getHeader('ETag'));
     }
 
     public function testConvertPreservesRegularHeaderCasingAfterCaching(): void
@@ -173,8 +173,8 @@ final class ResponseConverterTest extends TestCase
         ]);
         $workermanResponse = $converter->convert($response2, $this->connection);
 
-        $this->assertSame(['application/json'], $workermanResponse->getHeader('Content-Type'));
-        $this->assertSame(['second'], $workermanResponse->getHeader('X-Custom-Two'));
+        $this->assertSame('application/json', $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame('second', $workermanResponse->getHeader('X-Custom-Two'));
     }
 
     public function testConvertNormalizesMixedRegularAndIrregularHeaders(): void
@@ -191,9 +191,117 @@ final class ResponseConverterTest extends TestCase
 
         $workermanResponse = $converter->convert($response, $this->connection);
 
-        $this->assertSame(['text/plain'], $workermanResponse->getHeader('Content-Type'));
-        $this->assertSame(['"abc"'], $workermanResponse->getHeader('ETag'));
-        $this->assertSame(['value'], $workermanResponse->getHeader('X-Custom'));
-        $this->assertSame(['0'], $workermanResponse->getHeader('DNT'));
+        $this->assertSame('text/plain', $workermanResponse->getHeader('Content-Type'));
+        $this->assertSame('"abc"', $workermanResponse->getHeader('ETag'));
+        $this->assertSame('value', $workermanResponse->getHeader('X-Custom'));
+        $this->assertSame('0', $workermanResponse->getHeader('DNT'));
+    }
+
+    /**
+     * Transport-owned headers must be stripped centrally so the transport
+     * (Workerman's Http::encode() / Response::__toString()) is the sole
+     * authority on message framing. Otherwise array_merge_recursive in
+     * Response::withHeaders() emits duplicates — see issue #579.
+     *
+     * @dataProvider transportHeadersProvider
+     */
+    public function testConvertStripsTransportOwnedHeaders(string $headerName): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            $headerName => 'should-be-stripped',
+            'X-Custom' => 'kept',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $this->assertNull(
+            $workermanResponse->getHeader($this->normalizeForAssertion($headerName)),
+            "{$headerName} must be stripped by the converter so the transport owns it",
+        );
+        $this->assertSame('kept', $workermanResponse->getHeader('X-Custom'));
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function transportHeadersProvider(): array
+    {
+        return [
+            ['Content-Length'],
+            ['content-length'],
+            ['Accept-Ranges'],
+            ['accept-ranges'],
+            ['Transfer-Encoding'],
+            ['transfer-encoding'],
+        ];
+    }
+
+    /**
+     * Set-Cookie legitimately needs multiple values (one Set-Cookie header per
+     * cookie), so flattening must not collapse it to a single string.
+     */
+    public function testConvertPreservesMultipleSetCookieValues(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_OK);
+        $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('a', '1'));
+        $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('b', '2'));
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $setCookie = $workermanResponse->getHeader('Set-Cookie');
+        $this->assertIsArray($setCookie, 'Set-Cookie must keep its array shape to emit one line per cookie');
+        $this->assertCount(2, $setCookie);
+        $this->assertStringContainsString('a=1', (string) $setCookie[0]);
+        $this->assertStringContainsString('b=2', (string) $setCookie[1]);
+    }
+
+    /**
+     * Content-Range must NOT be stripped — Workerman sets it via header()
+     * (which overwrites), and Symfony's value is correct for ranged responses.
+     */
+    public function testConvertPreservesContentRangeHeader(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_PARTIAL_CONTENT, [
+            'Content-Range' => 'bytes 0-99/5000',
+        ]);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $this->assertSame('bytes 0-99/5000', $workermanResponse->getHeader('Content-Range'));
+    }
+
+    /**
+     * A header whose values are all null (Symfony can produce these) must be
+     * dropped, not emitted as an empty line on the wire.
+     */
+    public function testConvertDropsAllNullHeaderValues(): void
+    {
+        $strategies = [new DefaultResponseStrategy()];
+        $converter = new ResponseConverter($strategies);
+
+        $response = new Response('content', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
+            'X-Custom' => 'kept',
+        ]);
+        // Force a header with only null values, as Symfony can produce.
+        $response->headers->set('X-Empty', null);
+
+        $workermanResponse = $converter->convert($response, $this->connection);
+
+        $this->assertNull($workermanResponse->getHeader('X-Empty'));
+        $this->assertSame('kept', $workermanResponse->getHeader('X-Custom'));
+    }
+
+    private function normalizeForAssertion(string $name): string
+    {
+        return implode('-', array_map(ucfirst(...), explode('-', strtolower($name))));
     }
 }

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -912,8 +912,8 @@ final class SymfonyControllerTest extends TestCase
 
         $this->assertInstanceOf(\Workerman\Protocols\Http\Response::class, $response);
         // All headers are normalized to proper case (e.g., Content-Type, X-Custom-Header)
-        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
-        $this->assertSame(['custom-value'], $response->getHeader('X-Custom-Header'));
+        $this->assertSame('application/json', $response->getHeader('Content-Type'));
+        $this->assertSame('custom-value', $response->getHeader('X-Custom-Header'));
     }
 
     public function testResponseStatusCodeIsPreserved(): void
@@ -1146,9 +1146,11 @@ final class SymfonyControllerTest extends TestCase
 
         $this->assertSame($initialObLevel, ob_get_level(), 'OB level should remain unchanged after test');
         // Content-Type may have charset added by Symfony
-        $this->assertStringContainsString('text/event-stream', $response->getHeader('Content-Type')[0] ?? '');
+        $contentType = $response->getHeader('Content-Type');
+        $this->assertIsString($contentType);
+        $this->assertStringContainsString('text/event-stream', $contentType);
         // Headers are normalized to proper case
-        $this->assertSame(['true'], $response->getHeader('X-Stream'));
+        $this->assertSame('true', $response->getHeader('X-Stream'));
         $this->assertSame('', $response->rawBody());
     }
 


### PR DESCRIPTION
## Description

Closes #579

## Changes

- `ResponseConverter::extractHeaders()` now strips transport-owned headers (`Content-Length`, `Accept-Ranges`, `Transfer-Encoding`) centrally so Workerman's transport layer (`Http::encode()` / `Response::__toString()`) is the sole authority on message framing
- Single-valued headers are flattened from `list<string|null>` to `string` (except `Set-Cookie`, which legitimately needs multiple values) to prevent `array_merge_recursive` in `Response::withHeaders()` from ever producing arrays of conflicting values
- Headers whose values are all null/empty are dropped so they are not emitted as empty lines on the wire
- `Content-Range` and the `206` status on ranged responses are preserved (Workerman sets them via `header()` which overwrites)
- Existing `strcasecmp` guards in `DefaultResponseStrategy::buildHeaderString()` and `StreamedResponseStrategy::buildHeaderString()` kept as belt-and-braces with explanatory comments
- Type annotations in `ResponseConverterStrategyInterface` and both strategies updated to `array<string, string|list<string|null>>`
- Existing tests updated to the new flattened header shape (`getHeader()` now returns `string` for single-valued headers)
- New `ContentLengthDesyncTest` with 9 tests covering all four body paths (file, small body, large body, streamed), ranged 206, multiple Set-Cookie, Content-Range preservation, empty body, 304, and the `TRANSPORT_HEADERS` constant
- New `testConvertDropsAllNullHeaderValues` in `ResponseConverterTest`

## Root cause

Workerman's `Response::withHeaders()` uses `array_merge_recursive`, which on a string key present in both arrays produces an array of both values rather than a replacement. `Http::encode()` adds its own `Content-Length`/`Accept-Ranges` via `withHeaders()` for file responses, and `Response::__toString()` appends its own `Content-Length` unconditionally for the small-body path — so an application-supplied `Content-Length` was emitted twice. When the two values disagreed, the conflict is a response-desync primitive (RFC 9110 §8.6) that can poison caches and leak responses across keep-alive connections.

## Changelog

Security fix entry added under `[Unreleased]` → `### Security`.

## Code Review

- [x] Passed subagent code review (two passes, no blockers)
- [x] All review comments addressed (HEAD/304 test coverage, null-values test, docblock accuracy, CHANGELOG corrections)
- [x] `composer lint` passes (PHPStan level 8, php-cs-fixer, rector)
- [x] `composer test` passes (1566 tests)