### PR TITLE
fix: close static file allowlist bypass (closes #580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Fix `StaticFilesMiddleware` extension allowlists failing open for extensionless
+  files: `Dockerfile`, `id_rsa`, `dump`, and names ending in a dot now return 404
+  when an allowlist is configured. Blocked path components are also checked
+  correctly when filesystem paths use backslashes. This is a behavior change for
+  deployments that intentionally served extensionless files with an allowlist
+  ([#580](https://github.com/crazy-goat/workerman-bundle/issues/580))
+
 - Fix duplicate `Content-Length` on every file download and on responses where
   the application sets its own `Content-Length`. Workerman's
   `Response::withHeaders()` merges recursively (`array_merge_recursive`), so

--- a/docs/security.md
+++ b/docs/security.md
@@ -148,7 +148,7 @@ workerman:
               - workerman.middleware.static_files
 ```
 
-When `allowed_extensions` is set, only files with one of the listed extensions are served — all others return 404. The denylist (dotfiles, `.php`, etc.) takes precedence and is always enforced regardless of the allowlist setting.
+When `allowed_extensions` is set, only files with one of the listed extensions are served — all others return 404. Files without an extension, including names ending in a dot, are not served. The denylist (dotfiles, `.php`, etc.) takes precedence and is always enforced regardless of the allowlist setting.
 
 ### Symlink Protection
 

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -121,6 +121,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
     private function isFilePathBlocked(string $filePath): bool
     {
         $relativePath = substr($filePath, strlen($this->rootRealPath));
+        $relativePath = str_replace('\\', '/', $relativePath);
 
         $components = explode('/', ltrim($relativePath, '/'));
         foreach ($components as $component) {
@@ -147,7 +148,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
             return true;
         }
 
-        return $this->allowedExtensions !== [] && $ext !== '' && !in_array($ext, $this->allowedExtensions, true);
+        return $this->allowedExtensions !== [] && !in_array($ext, $this->allowedExtensions, true);
     }
 
     private function getPublicPathFile(Request $request): string|false

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -381,6 +381,37 @@ final class StaticFilesMiddlewareTest extends TestCase
         }
     }
 
+    public function testNestedHtaccessBlockedReturns404(): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory);
+        $nestedDir = $this->rootDirectory . '/nested';
+        mkdir($nestedDir);
+        file_put_contents($nestedDir . '/.htaccess', 'deny all');
+
+        try {
+            $request = $this->createRequest('/nested/.htaccess');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should NOT be called for nested .htaccess');
+            $this->assertEquals(404, $response->getStatusCode(), 'Should return 404 for nested .htaccess');
+
+            $rootPathReflection = new \ReflectionProperty($middleware, 'rootRealPath');
+            $rootPath = $rootPathReflection->getValue($middleware);
+            $this->assertIsString($rootPath);
+            $pathReflection = new \ReflectionMethod($middleware, 'isFilePathBlocked');
+            $this->assertTrue($pathReflection->invoke($middleware, $rootPath . '\\nested\\.htaccess'));
+        } finally {
+            unlink($nestedDir . '/.htaccess');
+            rmdir($nestedDir);
+        }
+    }
+
     public function testDotfileBlockedReturns404(): void
     {
         $dotfile = $this->rootDirectory . '/.secret';
@@ -592,6 +623,32 @@ final class StaticFilesMiddlewareTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider blockedExtensionProvider
+     */
+    public function testBlockedExtensionsTakePrecedenceOverAllowlist(string $fileName, string $extension): void
+    {
+        $file = $this->rootDirectory . '/' . $fileName;
+        file_put_contents($file, 'x');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, [$extension]);
+            $request = $this->createRequest('/' . $fileName);
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, "Next should NOT be called for .$extension file");
+            $this->assertEquals(404, $response->getStatusCode(), "Should return 404 for .$extension");
+        } finally {
+            unlink($file);
+        }
+    }
+
     public function testAllowedExtensionsWhitelistServing(): void
     {
         $cssFile = $this->rootDirectory . '/style.css';
@@ -636,6 +693,94 @@ final class StaticFilesMiddlewareTest extends TestCase
             $this->assertEquals(404, $response->getStatusCode(), 'Should return 404 for disallowed extension');
         } finally {
             unlink($jsonFile);
+        }
+    }
+
+    /**
+     * @dataProvider extensionlessFileProvider
+     */
+    public function testExtensionlessFilesAreBlockedWithAllowlist(string $fileName): void
+    {
+        $file = $this->rootDirectory . '/' . $fileName;
+        file_put_contents($file, 'sensitive content');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+
+            $request = $this->createRequest('/' . $fileName);
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, "Next should NOT be called for extensionless file: $fileName");
+            $this->assertEquals(404, $response->getStatusCode(), "Should return 404 for extensionless file: $fileName");
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function extensionlessFileProvider(): array
+    {
+        return [
+            'Dockerfile' => ['Dockerfile'],
+            'SSH private key' => ['id_rsa'],
+            'Database dump' => ['dump'],
+        ];
+    }
+
+    public function testFileNameEndingWithDotIsBlockedByAllowlist(): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $reflection = new \ReflectionMethod($middleware, 'isComponentBlocked');
+            $this->assertTrue($reflection->invoke($middleware, 'index.php.'));
+
+            return;
+        }
+
+        $file = $this->rootDirectory . '/index.php.';
+        file_put_contents($file, 'sensitive content');
+
+        try {
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($this->createRequest('/index.php.'), $next);
+
+            $this->assertFalse($called, 'Next should NOT be called for a filename ending in a dot');
+            $this->assertEquals(404, $response->getStatusCode());
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testAllowlistBlockedFileIsIndistinguishableFromMissingFile(): void
+    {
+        $blockedFile = $this->rootDirectory . '/Dockerfile';
+        file_put_contents($blockedFile, 'sensitive content');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+            $next = fn(Request $req): Response => new Response(404);
+
+            $blockedResponse = $middleware($this->createRequest('/Dockerfile'), $next);
+            $missingResponse = $middleware($this->createRequest('/missing'), $next);
+
+            $this->assertSame($missingResponse->getStatusCode(), $blockedResponse->getStatusCode());
+            $this->assertSame($missingResponse->rawBody(), $blockedResponse->rawBody());
+        } finally {
+            unlink($blockedFile);
         }
     }
 

--- a/tests/build-phar-e2e-test.php
+++ b/tests/build-phar-e2e-test.php
@@ -85,7 +85,7 @@ try {
     echo "\n4) HTTP GET /health...\n";
     [$code, $body] = httpGet('http://127.0.0.1:8887/health');
     assertEq(200, $code, 'HTTP status');
-    $data = json_decode((string) $body, true);
+    $data = json_decode($body, true);
     assertEq('ok', $data['status'] ?? null, 'Response status');
     echo "   HTTP/{$code}: {$body}\n";
 


### PR DESCRIPTION
## Description

Closes #580

## Changes

- Block extensionless files when `StaticFilesMiddleware` uses `allowed_extensions`.
- Keep the denylist authoritative even when a blocked extension is listed.
- Check blocked path components correctly when filesystem paths use backslashes.
- Add regression coverage for extensionless files, trailing-dot names, nested `.htaccess`, Windows separators, and indistinguishable 404 responses.
- Update static-file security documentation and the unreleased changelog.

## Code Review

- [x] Local security/diff review completed
- [x] All review findings addressed
- [x] Full lint passed
- [x] Full test suite passed

## Test results

- `composer lint` — passed
- `composer test` — passed: 1576 tests, 13360 assertions, 18 skipped, 1 pre-existing warning
- Targeted `StaticFilesMiddlewareTest` — passed: 61 tests, 108 assertions
