### PR TITLE
test: silence expected failure diagnostics

### DIFF
--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -14,6 +14,7 @@ use CrazyGoat\WorkermanBundle\Reboot\Strategy\RebootStrategyInterface;
 use CrazyGoat\WorkermanBundle\Test\App\TestMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
@@ -294,7 +295,7 @@ final class HttpRequestHandlerTest extends TestCase
         $this->responseConverter = new ResponseConverter([new DefaultResponseStrategy()]);
 
         $controller = new SymfonyController($this->kernel, $this->responseConverter);
-        $this->handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+        $this->handler = new HttpRequestHandler($controller, $this->rebootStrategy, new NullLogger());
 
         // Initialize Timer with a test event so Timer::add() doesn't throw in unit tests
         $this->timerEvent = new TestTimerEvent();
@@ -1288,7 +1289,7 @@ final class HttpRequestHandlerTest extends TestCase
 
         $kernel = new HttpHandlerTestKernel($weirdResponse);
         $controller = new SymfonyController($kernel, $emptyConverter);
-        $handler = new HttpRequestHandler($controller, $this->rebootStrategy);
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, new NullLogger());
 
         $connection = new MockTcpConnection();
         $request = new Request("GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n");
@@ -1312,7 +1313,7 @@ final class HttpRequestHandlerTest extends TestCase
         $strategy->method('needsPeakMemory')->willReturn(false);
 
         $controller = new SymfonyController($this->kernel, $this->responseConverter);
-        $handler = new HttpRequestHandler($controller, $strategy);
+        $handler = new HttpRequestHandler($controller, $strategy, new NullLogger());
         $handler->withMiddlewares(
             $this->throwingMiddleware(new \RuntimeException('boom')),
         );
@@ -1336,7 +1337,7 @@ final class HttpRequestHandlerTest extends TestCase
         $strategy->method('needsPeakMemory')->willReturn(false);
 
         $controller = new SymfonyController($this->kernel, $this->responseConverter);
-        $handler = new HttpRequestHandler($controller, $strategy);
+        $handler = new HttpRequestHandler($controller, $strategy, new NullLogger());
         $handler->withMiddlewares(
             $this->throwingMiddleware(new \RuntimeException('boom')),
         );

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -357,7 +357,16 @@ final class RunnerTest extends TestCase
 
             $this->expectException(\RuntimeException::class);
             $this->expectExceptionMessage('Unable to create directory');
-            $this->invokeRunnerMethod($runner, 'applyWorkermanConfig', $config);
+
+            // The failed mkdir is intentional here: the test places a file at
+            // the directory path. Suppress only PHP's expected warning; the
+            // RuntimeException is the behavior this test verifies.
+            set_error_handler(static fn(int $severity, string $message): bool => $severity === \E_WARNING && \str_contains($message, 'mkdir(): Not a directory'));
+            try {
+                $this->invokeRunnerMethod($runner, 'applyWorkermanConfig', $config);
+            } finally {
+                restore_error_handler();
+            }
         } finally {
             $this->restoreWorkerState($saved);
             $this->removeDir($tmpDir);

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -793,11 +793,21 @@ final class ServerWorkerTest extends TestCase
         $handler = $connection->errorHandler;
         $this->assertNotNull($handler);
 
-        $threw = false;
+        // The backstop logs by design. Capture that expected log output so
+        // this behavioral test does not make the test suite look failed.
+        $logFile = tempnam(sys_get_temp_dir(), 'test_backstop_');
+        $this->assertNotFalse($logFile);
+        ini_set('error_log', $logFile);
         try {
-            $handler(new \RuntimeException('simulated escape from handler'));
-        } catch (\Throwable) {
-            $threw = true;
+            $threw = false;
+            try {
+                $handler(new \RuntimeException('simulated escape from handler'));
+            } catch (\Throwable) {
+                $threw = true;
+            }
+        } finally {
+            ini_restore('error_log');
+            @unlink($logFile);
         }
 
         $this->assertFalse($threw, 'errorHandler backstop must not rethrow (would bypass Worker::stopAll guard)');


### PR DESCRIPTION
## Description

Keep expected exception and warning diagnostics out of the PHPUnit progress output without changing production logging or error handling.

## Changes

- Capture the expected `ServerWorker` backstop log in a temporary file.
- Use `NullLogger` for `HttpRequestHandler` tests that verify 500/error-path behavior rather than logging.
- Suppress only the expected `mkdir(): Not a directory` warning in the directory-failure test.
- Keep dedicated tests that verify `error_log()` fallback behavior unchanged.

## Validation

- `composer lint`
- `composer test`

## Changelog

No changelog entry: this is test-only and does not change library behavior.

## Code Review

- [x] Local diff review completed
- [x] All local lint and test checks pass
