### PR TITLE
fix(security): reject underscore HTTP headers (closes #578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Drop HTTP header names containing underscores before converting requests to
+  Symfony's `$_SERVER` bag. Without this, `X-Forwarded_For` collided with
+  `X-Forwarded-For` as `HTTP_X_FORWARDED_FOR`, allowing trusted-proxy client-IP
+  spoofing and bypassing proxy header stripping. Dropped names are logged once
+  per worker; dash-spelled headers and the CGI `CONTENT_TYPE`, `CONTENT_LENGTH`,
+  and `CONTENT_MD5` conventions are preserved
+  ([#578](https://github.com/crazy-goat/workerman-bundle/issues/578))
+
 - Fix `StaticFilesMiddleware` extension allowlists failing open for extensionless
   files: `Dockerfile`, `id_rsa`, `dump`, and names ending in a dot now return 404
   when an allowlist is configured. Blocked path components are also checked

--- a/benchmarks/RequestConverterBench.md
+++ b/benchmarks/RequestConverterBench.md
@@ -2,25 +2,25 @@
 
 Environment: PHP 8.5.8, PHPBench 1.7.0, xdebug disabled, opcache disabled, 1000 revisions, 5 iterations, 1 warmup.
 
-The `RequestConverterBench` benchmark includes request conversion plus a direct measurement of the added `Request::resetHeaders()` operation. The converter subjects remain request-path proxies; `benchResetHeaders` measures the fix's added operation directly.
+The `RequestConverterBench` benchmark includes request conversion plus a direct measurement of the existing `Request::resetHeaders()` operation. The converter subjects remain request-path proxies; the underscore-name rejection is exercised by the per-header check in every converter subject.
 
 ## Before
 
-Source commit: `0cef5f2` (parent of the fix commit)
+Source commit: `0e11540` (before the underscore-header fix)
 
 | Subject | Mode |
 | --- | ---: |
-| `benchSimpleRequest` | 2.921 μs |
-| `benchHeaderHeavyRequest` | 5.915 μs |
-| `benchMultipartRequest` | 6.310 μs |
+| `benchSimpleRequest` | 2.824 μs |
+| `benchHeaderHeavyRequest` | 5.675 μs |
+| `benchMultipartRequest` | 5.579 μs |
 
 ## After
 
-Working tree after the request-header cache fix and E2E coverage.
+Working tree after the underscore-header filter.
 
 | Subject | Mode |
 | --- | ---: |
-| `benchSimpleRequest` | 3.167 μs |
-| `benchHeaderHeavyRequest` | 5.943 μs |
-| `benchMultipartRequest` | 5.361 μs |
-| `benchResetHeaders` | 0.108 μs |
+| `benchSimpleRequest` | 2.795 μs |
+| `benchHeaderHeavyRequest` | 6.042 μs |
+| `benchMultipartRequest` | 5.737 μs |
+| `benchResetHeaders` | 0.113 μs |

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,6 +4,14 @@
 
 The `RequestConverter` applies security hardening when propagating HTTP headers from Workerman to Symfony:
 
+### Header Names Containing Underscores
+
+HTTP field names may legally contain underscores, but PHP's CGI-style server bag cannot preserve the distinction between a dash and an underscore. Both `X-Forwarded-For` and `X-Forwarded_For` would otherwise become `HTTP_X_FORWARDED_FOR`. If a trusted proxy supplies the dash-spelled header, an attacker could append the underscore-spelled variant and control which value Symfony receives. The same collision could bypass a proxy rule that strips an application header such as `X-Internal-Admin`.
+
+The bundle therefore discards every incoming header whose name contains `_` before constructing the Symfony server bag. A warning containing the dropped header name is written once per worker, so legitimate clients depending on underscore-containing names can be diagnosed without allowing an attacker to flood the logs on every request. This is the default and is intentionally not configurable: Workerman is the front server and must enforce the same boundary operators already expect from nginx (`underscores_in_headers off`) and Apache.
+
+This filtering does not affect ordinary dash-spelled headers or the CGI convention for `Content-Type`, `Content-Length`, and `Content-MD5`: for example, `Content-Type` still becomes `CONTENT_TYPE`, not `HTTP_CONTENT_TYPE`.
+
 ### Cookie Header (RFC 6265)
 
 When multiple `Cookie` header lines are present in the request, values are joined with `; ` as required by RFC 6265, rather than the standard HTTP `, ` separator. This prevents cookie smuggling where a `,` byte in a cookie value could be misinterpreted as a separator between cookies.

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -9,6 +9,7 @@ use CrazyGoat\WorkermanBundle\Exception\MalformedRequestException;
 use CrazyGoat\WorkermanBundle\Validator\FileUploadValidator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
+use Workerman\Worker;
 
 final class RequestConverter
 {
@@ -19,6 +20,9 @@ final class RequestConverter
      */
     private const METHOD_REGEX = '/^[A-Z]+$/';
     private const MAX_METHOD_LENGTH = 32;
+
+    /** @var array<string, true> Header names already logged in this worker. */
+    private static array $loggedUnderscoreHeaders = [];
 
     /**
      * Validates that a URI does not contain control characters.
@@ -162,6 +166,8 @@ final class RequestConverter
      * - Host, Content-Length, Authorization: only the first value is used (duplicates discarded)
      * - All other headers: joined with ', ' per RFC 7230
      * - Header values containing control characters are rejected
+     * - Header names containing underscores are discarded because PHP's server
+     *   variable convention maps both dashes and underscores to underscores
      *
      * @param array<string, float|int|string> $server
      *
@@ -173,8 +179,8 @@ final class RequestConverter
         $rawHeaders = self::parseRawHeaderLines($rawRequest->rawHead());
 
         foreach ($workermanHeaders as $name => $value) {
-            $nameLower = \strtolower((string) $name);
-            $key = 'HTTP_' . \strtoupper(\str_replace('-', '_', $name));
+            $name = (string) $name;
+            $nameLower = \strtolower($name);
 
             // Validate header value for control characters
             $stringValue = (string) $value;
@@ -183,6 +189,13 @@ final class RequestConverter
                     \sprintf('Header "%s" contains control characters: "%s"', $nameLower, \addcslashes($stringValue, "\x00..\x1F\x7F")),
                 );
             }
+
+            if (\str_contains($name, '_')) {
+                self::logDroppedUnderscoreHeader($name);
+                continue;
+            }
+
+            $key = 'HTTP_' . \strtoupper(\str_replace('-', '_', $name));
 
             // Check if this header had duplicate values in the raw request
             $originalValues = $rawHeaders[$nameLower] ?? null;
@@ -213,6 +226,39 @@ final class RequestConverter
         }
 
         return $server;
+    }
+
+    /**
+     * Log an underscore-containing header once per worker before dropping it.
+     */
+    private static function logDroppedUnderscoreHeader(string $name): void
+    {
+        $nameLower = \strtolower($name);
+        if (isset(self::$loggedUnderscoreHeaders[$nameLower])) {
+            return;
+        }
+
+        self::$loggedUnderscoreHeaders[$nameLower] = true;
+        $message = \sprintf(
+            '[warning] Dropped HTTP header "%s": header names containing underscores are not forwarded to Symfony',
+            \addcslashes($name, "\0..\37\177"),
+        );
+
+        // Workerman initialises the output stream before serving requests. Keep
+        // direct RequestConverter users safe when conversion happens outside a
+        // running Worker (for example, in a unit test or a CLI utility), or
+        // when Workerman has no log file configured.
+        if (Worker::$logFile === '') {
+            \error_log($message);
+
+            return;
+        }
+
+        try {
+            Worker::log($message);
+        } catch (\Throwable) {
+            \error_log($message);
+        }
     }
 
     /**

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -11,6 +11,7 @@ use CrazyGoat\WorkermanBundle\Exception\MalformedRequestException;
 use CrazyGoat\WorkermanBundle\Http\Request;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Workerman\Worker;
 
 /**
  * @covers \CrazyGoat\WorkermanBundle\DTO\RequestConverter
@@ -382,6 +383,7 @@ final class RequestConverterTest extends TestCase
         $buffer .= "Authorization: Basic " . base64_encode('user:pass') . "\r\n";
         $buffer .= "Content-Type: application/json\r\n";
         $buffer .= "Content-Length: 123\r\n";
+        $buffer .= "Content-MD5: digest\r\n";
         $buffer .= "\r\n";
 
         $rawRequest = new Request($buffer);
@@ -403,10 +405,12 @@ final class RequestConverterTest extends TestCase
         // Content-Type and Content-Length should NOT have HTTP_ prefix (CGI convention)
         $this->assertSame('application/json', $symfonyRequest->server->get('CONTENT_TYPE'));
         $this->assertSame('123', $symfonyRequest->server->get('CONTENT_LENGTH'));
+        $this->assertSame('digest', $symfonyRequest->server->get('CONTENT_MD5'));
 
         // HTTP_CONTENT_TYPE should NOT exist (moved to CONTENT_TYPE)
         $this->assertNull($symfonyRequest->server->get('HTTP_CONTENT_TYPE'));
         $this->assertNull($symfonyRequest->server->get('HTTP_CONTENT_LENGTH'));
+        $this->assertNull($symfonyRequest->server->get('HTTP_CONTENT_MD5'));
     }
 
     public function testServerProtocolHasHttpPrefix(): void
@@ -750,6 +754,110 @@ final class RequestConverterTest extends TestCase
         RequestConverter::toSymfonyRequest($rawRequest);
     }
 
+    /**
+     * @dataProvider underscoreHeaderProvider
+     */
+    public function testHeadersContainingUnderscoresAreDiscarded(string $headerName): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= $headerName . ": attacker-value\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+        $serverKey = 'HTTP_' . strtoupper(str_replace('-', '_', $headerName));
+
+        $this->assertArrayNotHasKey($serverKey, $symfonyRequest->server->all());
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function underscoreHeaderProvider(): iterable
+    {
+        yield 'forwarded for with underscore' => ['X-Forwarded_For'];
+        yield 'forwarded name with underscores' => ['X_Forwarded_For'];
+        yield 'custom name with underscore' => ['X_Custom'];
+    }
+
+    /**
+     * @dataProvider forwardedHeaderOrderProvider
+     */
+    public function testUnderscoreForwardedHeaderCannotOverrideDashHeader(string $forwardedHeaders): void
+    {
+        $trustedHeaders = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_FOR;
+        \Symfony\Component\HttpFoundation\Request::setTrustedProxies(['10.0.0.7'], $trustedHeaders);
+
+        try {
+            $buffer = "GET /admin HTTP/1.1\r\n";
+            $buffer .= "Host: localhost\r\n";
+            $buffer .= $forwardedHeaders;
+            $buffer .= "\r\n";
+
+            $rawRequest = new Request($buffer);
+            $rawRequest->connection = $this->createMockConnection(80, 'tcp', '10.0.0.7:12345');
+            $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+
+            $this->assertSame('10.0.0.7', $symfonyRequest->server->get('REMOTE_ADDR'));
+            $this->assertSame('203.0.113.9', $symfonyRequest->getClientIp());
+            $this->assertSame('203.0.113.9', $symfonyRequest->headers->get('x-forwarded-for'));
+        } finally {
+            \Symfony\Component\HttpFoundation\Request::setTrustedProxies([], 0);
+        }
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function forwardedHeaderOrderProvider(): iterable
+    {
+        yield 'dash header first' => [
+            "X-Forwarded-For: 203.0.113.9\r\nX-Forwarded_For: 127.0.0.1\r\n",
+        ];
+        yield 'underscore header first' => [
+            "X-Forwarded_For: 127.0.0.1\r\nX-Forwarded-For: 203.0.113.9\r\n",
+        ];
+    }
+
+    public function testUnderscoreVariantCannotInjectProxyStrippedApplicationHeader(): void
+    {
+        $buffer = "GET /admin HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "X-Internal_Admin: 1\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertNull($symfonyRequest->server->get('HTTP_X_INTERNAL_ADMIN'));
+        $this->assertNull($symfonyRequest->headers->get('x-internal-admin'));
+    }
+
+    public function testDroppedUnderscoreHeaderIsLoggedOnlyOncePerWorker(): void
+    {
+        $headerName = 'X-Logged_' . bin2hex(random_bytes(4));
+        $logFile = tempnam(sys_get_temp_dir(), 'request_converter_log_');
+        $this->assertNotFalse($logFile);
+
+        $previousDaemonize = Worker::$daemonize;
+        $previousLogFile = Worker::$logFile;
+
+        try {
+            Worker::$daemonize = true;
+            Worker::$logFile = $logFile;
+
+            $buffer = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
+            $buffer .= $headerName . ": value\r\n\r\n";
+
+            RequestConverter::toSymfonyRequest(new Request($buffer));
+            RequestConverter::toSymfonyRequest(new Request($buffer));
+
+            $log = file_get_contents($logFile);
+            $this->assertIsString($log);
+            $this->assertSame(1, substr_count($log, strtolower($headerName)));
+            $this->assertStringContainsString('[warning] Dropped HTTP header', $log);
+        } finally {
+            Worker::$daemonize = $previousDaemonize;
+            Worker::$logFile = $previousLogFile;
+            @unlink($logFile);
+        }
+    }
+
     public function testMultipleCookieHeadersJoinedWithSemicolon(): void
     {
         $buffer = "GET /test HTTP/1.1\r\n";
@@ -896,12 +1004,18 @@ final class RequestConverterTest extends TestCase
         RequestConverter::toSymfonyRequest($rawRequest);
     }
 
-    private function createMockConnection(int $localPort, string $transport = 'tcp'): \Workerman\Connection\TcpConnection
-    {
-        return new class ($localPort, $transport) extends \Workerman\Connection\TcpConnection {
-            public function __construct(private readonly int $port, string $transport)
-            {
-                $this->remoteAddress = '192.168.1.1:12345';
+    private function createMockConnection(
+        int $localPort,
+        string $transport = 'tcp',
+        string $remoteAddress = '192.168.1.1:12345',
+    ): \Workerman\Connection\TcpConnection {
+        return new class ($localPort, $transport, $remoteAddress) extends \Workerman\Connection\TcpConnection {
+            public function __construct(
+                private readonly int $port,
+                string $transport,
+                string $remoteAddress,
+            ) {
+                $this->remoteAddress = $remoteAddress;
                 $this->transport = $transport;
             }
 


### PR DESCRIPTION
## Description

Closes #578.

`RequestConverter` previously converted both dash and underscore header names to the same `HTTP_*` server key. An attacker could use `X-Forwarded_For` to override a trusted proxy's `X-Forwarded-For` value or bypass proxy header stripping.

## Changes

- Discard header names containing `_` before constructing Symfony's server bag.
- Log each dropped header name once per worker at warning level.
- Preserve dash-spelled headers and CGI `CONTENT_TYPE`, `CONTENT_LENGTH`, and `CONTENT_MD5` handling.
- Add trusted-proxy, header-stripping, logging, documentation, changelog, and benchmark coverage.

## Verification

- `composer lint` passed.
- `composer test` passed: 1583 tests, 13378 assertions, 18 skipped.
- `vendor/bin/phpbench run benchmarks/RequestConverterBench.php --report=aggregate` passed.
- `composer test:coverage` could not run the coverage gate because this environment has no PCOV/Xdebug driver.

## Code Review

- [x] Reviewed the final diff for security, edge cases, style, and test coverage.
- [x] Addressed local lint/static-analysis findings.
