### PR TITLE
fix(security): unify SFX redirect policy across modes (closes #585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unresolvable targets instead of passing them through, and downloads are capped at a maximum
   size (256 MiB by default) with the partial file removed on abort. The SHA-256 checksum is
   now verified immediately after download, before any zip extraction, so the extractor never
-  runs over unverified bytes. `--insecure` now differs from the default in exactly one
-  respect: TLS peer verification
+  runs over unverified bytes — for `.zip` URLs the checksum now covers the downloaded zip
+  artifact rather than the extracted SFX binary. `--insecure` now differs from the default in
+  exactly one respect: TLS peer verification
   ([#585](https://github.com/crazy-goat/workerman-bundle/issues/585))
 
 - Drop HTTP header names containing underscores before converting requests to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Unify SFX download redirect policing across modes: HTTPS → HTTP downgrade redirects and
+  redirects to non-HTTP(S) schemes (`file://`, `php://`, `ftp://`) are now blocked in **all**
+  modes, not only with `--insecure`. Automatic redirect following is disabled in the stream
+  context unconditionally, so PHP's `http` wrapper never follows a redirect on the bundle's
+  behalf; every hop is followed and scheme-checked manually, `resolveRedirectUrl()` rejects
+  unresolvable targets instead of passing them through, and downloads are capped at a maximum
+  size (256 MiB by default) with the partial file removed on abort. The SHA-256 checksum is
+  now verified immediately after download, before any zip extraction, so the extractor never
+  runs over unverified bytes. `--insecure` now differs from the default in exactly one
+  respect: TLS peer verification
+  ([#585](https://github.com/crazy-goat/workerman-bundle/issues/585))
+
 - Drop HTTP header names containing underscores before converting requests to
   Symfony's `$_SERVER` bag. Without this, `X-Forwarded_For` collided with
   `X-Forwarded-For` as `HTTP_X_FORWARDED_FOR`, allowing trusted-proxy client-IP

--- a/docs/build-packaging.md
+++ b/docs/build-packaging.md
@@ -78,9 +78,10 @@ workerman:
 
 ### `build.sfx.sha256`
 
-The SHA-256 hex digest of the expected phpmicro.sfx binary. When configured, the SFX binary
-is verified against this checksum after download (and after zip extraction, if applicable),
-protecting against supply-chain attacks (corrupted download, man-in-the-middle substitution).
+The SHA-256 hex digest of the expected phpmicro.sfx artifact. When configured, the downloaded
+artifact is verified against this checksum immediately after download, **before** it is
+extracted — the extractor never runs over unverified bytes — protecting against supply-chain
+attacks (corrupted download, man-in-the-middle substitution).
 **Required** for all builds unless `--unsafe-no-checksum` is explicitly passed.
 
 The `--sfx-checksum` CLI option overrides this config value when provided.
@@ -119,7 +120,8 @@ The `--insecure` CLI flag enables the same behavior.
 
 Security implications when enabled:
 - The connection is vulnerable to man-in-the-middle attacks
-- Cross-scheme redirects (HTTPS → HTTP) are **blocked** with a hard error
+- Redirects are still policed exactly as in default mode (see `docs/security.md`):
+  HTTPS → HTTP downgrades and non-HTTP(S) redirect targets are blocked in both modes
 - Always pair with `build.sfx.sha256` to verify the binary after download
 
 Cross-reference: `src/DependencyInjection/ConfigurationTreeBuilder.php:310-313`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -287,17 +287,25 @@ If any entry fails validation, the build aborts with a `\RuntimeException`.
 
 ## SFX Download Protection (Redirect Scheme)
 
-When downloading `phpmicro.sfx` with `--insecure` (or `build.sfx.allow_insecure: true`), TLS peer
-verification is disabled. To prevent an on-path attacker from downgrading the download from HTTPS
-to plain HTTP via a redirect:
+SFX downloads are always redirected manually: automatic redirect following is disabled in the
+stream context (`follow_location: 0`) in **every** mode, so PHP's `http` wrapper never follows a
+redirect on the bundle's behalf. Each hop is inspected before it is followed:
 
-- **Automatic redirect following is disabled** in the stream context
-- Each redirect response is inspected manually
-- **Cross-scheme redirects (HTTPS → HTTP) are blocked** with a hard error
-- Redirects within the same scheme (HTTPS → HTTPS) are still allowed (up to 5 hops)
+- **Cross-scheme downgrades (HTTPS → HTTP) are blocked** with a hard error
+- **Redirects to any non-HTTP(S) scheme** (`file://`, `php://`, `ftp://`, ...) are blocked
+  with a hard error, regardless of the origin scheme
+- Redirects within HTTP(S) (including HTTP → HTTPS upgrades) are still followed, up to the
+  5-hop limit; exceeding the limit errors
+- A redirect target that cannot be resolved against the base URL is rejected with an error
 
-This defense is always active when `allow_insecure` is enabled, regardless of whether a checksum
-is configured.
+This policy is active in both `--insecure` and default mode: `--insecure` (or
+`build.sfx.allow_insecure: true`) disables TLS peer verification only (`verify_peer` /
+`verify_peer_name`) and does not relax the redirect policy. Whether a checksum is configured
+has no effect on it either.
+
+Additionally, downloads are capped at a maximum size (256 MiB by default): a response
+exceeding the limit aborts the download and removes the partial file, so a hostile or
+misconfigured mirror cannot fill the filesystem.
 
 ## Status File TOCTOU Protection
 
@@ -384,7 +392,8 @@ chgrp <webserver-group> var/cache/
 The build **fails** if no SHA-256 checksum is configured, unless `--unsafe-no-checksum` is explicitly
 passed. This ensures supply-chain integrity by default:
 
-- `--sfx-checksum=HASH` or config `build.sfx.sha256` → checksum verified after download
+- `--sfx-checksum=HASH` or config `build.sfx.sha256` → the downloaded artifact is verified
+  against the checksum immediately after download, **before** it is extracted
 - `--unsafe-no-checksum` → no verification (not recommended)
 - Neither → build aborts with an error
 

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -116,9 +116,11 @@ final readonly class SfxDownloader
         for ($i = 0; $i <= $maxRedirects; $i++) {
             $context = $this->buildContext($currentUrl, $allowInsecure);
 
-            // The http wrapper only populates $http_response_header when the
-            // variable is already declared in the scope where fopen() runs;
-            // pre-declaring it makes the response headers observable here.
+            // Pre-declare $http_response_header so the http wrapper populates
+            // it in the fopen() scope (it is only set when the variable is
+            // already declared there). On PHP 8.4+ this can be replaced with
+            // http_get_last_response_headers(); the fallback must stay for
+            // PHP 8.2/8.3.
             $http_response_header = [];
             $in = @fopen($currentUrl, 'rb', false, $context);
             if (!is_resource($in)) {
@@ -180,7 +182,7 @@ final readonly class SfxDownloader
             ));
         }
 
-        if (str_starts_with($currentUrl, 'https://') && str_starts_with(strtolower($location), 'http://')) {
+        if (str_starts_with(strtolower($currentUrl), 'https://') && str_starts_with(strtolower($location), 'http://')) {
             throw new \RuntimeException(sprintf(
                 'Blocked cross-scheme redirect from HTTPS to "%s". Disable redirects or use a trusted mirror.',
                 $location,
@@ -213,7 +215,9 @@ final readonly class SfxDownloader
             ));
         }
 
-        $scheme = $parts['scheme'];
+        // parse_url() preserves the case of the scheme; normalize it so the
+        // rebuilt URL always uses a lowercase scheme prefix.
+        $scheme = strtolower($parts['scheme']);
         $host = $parts['host'];
         $port = isset($parts['port']) ? ':' . $parts['port'] : '';
 
@@ -254,7 +258,13 @@ final readonly class SfxDownloader
                     ));
                 }
 
-                fwrite($out, $chunk);
+                $written = fwrite($out, $chunk);
+                if ($written === false || $written !== strlen($chunk)) {
+                    throw new \RuntimeException(sprintf(
+                        'Failed to write to "%s" (short write).',
+                        $destination,
+                    ));
+                }
             }
         } catch (\Throwable $e) {
             $failed = true;
@@ -276,7 +286,12 @@ final readonly class SfxDownloader
      */
     private function buildContext(string $url, bool $allowInsecure)
     {
-        if (str_starts_with($url, 'http://')) {
+        // Scheme prefixes are matched case-insensitively: PHP's http wrapper
+        // accepts mixed-case schemes, and a redirect to "HTTPS://..." must
+        // not fall through to the default context (which follows redirects).
+        $lower = strtolower($url);
+
+        if (str_starts_with($lower, 'http://')) {
             return stream_context_create([
                 'http' => [
                     'follow_location' => 0,
@@ -286,7 +301,7 @@ final readonly class SfxDownloader
             ]);
         }
 
-        if (!str_starts_with($url, 'https://')) {
+        if (!str_starts_with($lower, 'https://')) {
             return null;
         }
 

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -218,6 +218,13 @@ final readonly class SfxDownloader
         // parse_url() preserves the case of the scheme; normalize it so the
         // rebuilt URL always uses a lowercase scheme prefix.
         $scheme = strtolower($parts['scheme']);
+
+        // Protocol-relative location ("//cdn.example/path"): same scheme,
+        // different host.
+        if (str_starts_with($location, '//')) {
+            return $scheme . ':' . $location;
+        }
+
         $host = $parts['host'];
         $port = isset($parts['port']) ? ':' . $parts['port'] : '';
 

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -10,11 +10,27 @@ use CrazyGoat\WorkermanBundle\Exception\SfxExtractionException;
  * Downloads phpmicro.sfx (the static PHP runtime used to build standalone
  * binaries) from an HTTPS mirror, optionally verifying a SHA-256 digest.
  *
+ * Redirects are always followed manually (never by the PHP http wrapper) so
+ * that every hop can be scheme-checked; `$allowInsecure` only disables TLS
+ * peer verification.
+ *
  * @internal
  */
-final class SfxDownloader
+final readonly class SfxDownloader
 {
     private const DOWNLOAD_CHUNK = 1 << 16;
+
+    private const DEFAULT_MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024;
+
+    /**
+     * @param int $maxDownloadBytes maximum accepted download size in bytes
+     */
+    public function __construct(private int $maxDownloadBytes = self::DEFAULT_MAX_DOWNLOAD_BYTES)
+    {
+        if ($maxDownloadBytes <= 0) {
+            throw new \InvalidArgumentException('maxDownloadBytes must be a positive number of bytes.');
+        }
+    }
 
     /**
      * Resolve an existing SFX file or download one.
@@ -41,6 +57,12 @@ final class SfxDownloader
             $this->downloadTo($url, $destination, $allowInsecure);
         }
 
+        // Verify the downloaded artifact before any extractor runs over its
+        // bytes: a tampered archive must never reach ZipArchive.
+        if (is_string($expectedSha256) && $expectedSha256 !== '') {
+            self::verifyChecksum($destination, $expectedSha256);
+        }
+
         // If the upstream artifact is a zip, extract it.
         if (str_ends_with($destination, '.zip')) {
             $destination = $this->extractZip($destination, $destinationDir);
@@ -48,10 +70,6 @@ final class SfxDownloader
 
         if (!is_file($destination)) {
             throw new \RuntimeException(sprintf('Failed to obtain phpmicro.sfx (resolved path "%s" does not exist).', $destination));
-        }
-
-        if (is_string($expectedSha256) && $expectedSha256 !== '') {
-            self::verifyChecksum($destination, $expectedSha256);
         }
 
         return $destination;
@@ -85,14 +103,9 @@ final class SfxDownloader
 
     private function downloadTo(string $url, string $destination, bool $allowInsecure): void
     {
-        if ($allowInsecure) {
-            $this->downloadWithRedirectCheck($url, $destination, $allowInsecure);
-
-            return;
-        }
-
-        $context = $this->buildContext($url, $allowInsecure);
-        $this->downloadStream($url, $destination, $context);
+        // Redirects are always followed manually so every hop can be
+        // scheme-checked; $allowInsecure only controls TLS peer verification.
+        $this->downloadWithRedirectCheck($url, $destination, $allowInsecure);
     }
 
     private function downloadWithRedirectCheck(string $url, string $destination, bool $allowInsecure): void
@@ -103,13 +116,17 @@ final class SfxDownloader
         for ($i = 0; $i <= $maxRedirects; $i++) {
             $context = $this->buildContext($currentUrl, $allowInsecure);
 
+            // The http wrapper only populates $http_response_header when the
+            // variable is already declared in the scope where fopen() runs;
+            // pre-declaring it makes the response headers observable here.
+            $http_response_header = [];
             $in = @fopen($currentUrl, 'rb', false, $context);
             if (!is_resource($in)) {
                 $err = error_get_last()['message'] ?? 'unknown error';
                 throw new \RuntimeException(sprintf('Failed to open "%s" for download: %s', $currentUrl, $err));
             }
 
-            $responseHeaders = $this->getHttpResponseHeaders(get_defined_vars());
+            $responseHeaders = $http_response_header;
 
             $httpCode = 0;
             if (isset($responseHeaders[0]) && preg_match('#^HTTP/\d+\.\d+\s+(\d+)#', $responseHeaders[0], $m)) {
@@ -126,6 +143,8 @@ final class SfxDownloader
 
             $location = null;
             foreach ($responseHeaders as $header) {
+                // Only the first matching header is used; obs-fold continuation
+                // lines are not supported and are simply ignored.
                 if (str_starts_with(strtolower($header), 'location:')) {
                     $location = trim(substr($header, 9));
                     break;
@@ -138,17 +157,35 @@ final class SfxDownloader
 
             $location = $this->resolveRedirectUrl($currentUrl, $location);
 
-            if (str_starts_with($currentUrl, 'https://') && str_starts_with(strtolower($location), 'http://')) {
-                throw new \RuntimeException(sprintf(
-                    'Blocked cross-scheme redirect from HTTPS to "%s". Disable redirects or use a trusted mirror.',
-                    $location,
-                ));
-            }
+            $this->assertAllowedRedirect($currentUrl, $location);
 
             $currentUrl = $location;
         }
 
         throw new \RuntimeException(sprintf('Too many redirects (max %d) for "%s".', $maxRedirects, $url));
+    }
+
+    /**
+     * Enforce the redirect scheme policy for a single hop.
+     *
+     * @throws \RuntimeException when the hop targets a non-HTTP(S) scheme or
+     *                           downgrades from HTTPS to plain HTTP
+     */
+    private function assertAllowedRedirect(string $currentUrl, string $location): void
+    {
+        if (!preg_match('#^https?://#i', $location)) {
+            throw new \RuntimeException(sprintf(
+                'Blocked redirect to non-HTTP(S) scheme "%s". Disable redirects or use a trusted mirror.',
+                $location,
+            ));
+        }
+
+        if (str_starts_with($currentUrl, 'https://') && str_starts_with(strtolower($location), 'http://')) {
+            throw new \RuntimeException(sprintf(
+                'Blocked cross-scheme redirect from HTTPS to "%s". Disable redirects or use a trusted mirror.',
+                $location,
+            ));
+        }
     }
 
     private function resolveRedirectUrl(string $base, string $location): string
@@ -157,9 +194,23 @@ final class SfxDownloader
             return $location;
         }
 
+        // Any other absolute scheme (file://, php://, ftp://, ...) must never
+        // be passed back to fopen(): reject it before resolving relative
+        // locations, so a non-HTTP(S) value can never be returned.
+        if (preg_match('#^[a-z][a-z0-9+.\-]*://#i', $location)) {
+            throw new \RuntimeException(sprintf(
+                'Blocked redirect to non-HTTP(S) scheme "%s". Disable redirects or use a trusted mirror.',
+                $location,
+            ));
+        }
+
         $parts = parse_url($base);
         if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
-            return $location;
+            throw new \RuntimeException(sprintf(
+                'Unable to resolve redirect location "%s" against base URL "%s".',
+                $location,
+                $base,
+            ));
         }
 
         $scheme = $parts['scheme'];
@@ -175,17 +226,6 @@ final class SfxDownloader
         return $scheme . '://' . $host . $port . $location;
     }
 
-    private function downloadStream(string $url, string $destination, mixed $context): void
-    {
-        $in = @fopen($url, 'rb', false, $context);
-        if (!is_resource($in)) {
-            $err = error_get_last()['message'] ?? 'unknown error';
-            throw new \RuntimeException(sprintf('Failed to open "%s" for download: %s', $url, $err));
-        }
-
-        $this->writeStream($in, $destination);
-    }
-
     private function writeStream(mixed $in, string $destination): void
     {
         $out = fopen($destination, 'wb');
@@ -194,6 +234,8 @@ final class SfxDownloader
             throw new \RuntimeException(sprintf('Unable to open "%s" for writing.', $destination));
         }
 
+        $totalBytes = 0;
+        $failed = false;
         try {
             while (!feof($in)) {
                 $chunk = fread($in, self::DOWNLOAD_CHUNK);
@@ -203,11 +245,29 @@ final class SfxDownloader
                 if ($chunk === '') {
                     continue;
                 }
+
+                $totalBytes += strlen($chunk);
+                if ($totalBytes > $this->maxDownloadBytes) {
+                    throw new \RuntimeException(sprintf(
+                        'Download exceeds the maximum allowed size of %d bytes.',
+                        $this->maxDownloadBytes,
+                    ));
+                }
+
                 fwrite($out, $chunk);
             }
+        } catch (\Throwable $e) {
+            $failed = true;
+            throw $e;
         } finally {
             fclose($in);
             fclose($out);
+
+            // Never leave a partial artifact behind: fetch() treats an
+            // existing destination file as a complete download.
+            if ($failed && is_file($destination)) {
+                unlink($destination);
+            }
         }
     }
 
@@ -216,6 +276,16 @@ final class SfxDownloader
      */
     private function buildContext(string $url, bool $allowInsecure)
     {
+        if (str_starts_with($url, 'http://')) {
+            return stream_context_create([
+                'http' => [
+                    'follow_location' => 0,
+                    'max_redirects' => 0,
+                    'timeout' => 60,
+                ],
+            ]);
+        }
+
         if (!str_starts_with($url, 'https://')) {
             return null;
         }
@@ -232,8 +302,8 @@ final class SfxDownloader
         return stream_context_create([
             'ssl' => $sslOptions,
             'http' => [
-                'follow_location' => $allowInsecure ? 0 : 1,
-                'max_redirects' => $allowInsecure ? 0 : 5,
+                'follow_location' => 0,
+                'max_redirects' => 0,
                 'timeout' => 60,
             ],
         ]);
@@ -394,18 +464,6 @@ final class SfxDownloader
                 $entryName,
             ));
         }
-    }
-
-    /**
-     * @param array<string, mixed> $definedVars
-     *
-     * @return list<string>
-     */
-    private function getHttpResponseHeaders(array $definedVars): array
-    {
-        $headerVar = 'http_response_header';
-
-        return $definedVars[$headerVar] ?? [];
     }
 
     /**

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -14,7 +14,27 @@ use PHPUnit\Framework\TestCase;
 
 final class SfxDownloaderTest extends TestCase
 {
+    private static ?int $serverPort = null;
+
+    /** @var resource|null */
+    private static $serverProcess;
+
     private string $tempDir;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$serverPort = self::allocatePort();
+        self::startRedirectServer();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (is_resource(self::$serverProcess)) {
+            proc_terminate(self::$serverProcess);
+            proc_close(self::$serverProcess);
+            self::$serverProcess = null;
+        }
+    }
 
     protected function setUp(): void
     {
@@ -301,18 +321,24 @@ final class SfxDownloaderTest extends TestCase
         self::assertStringEqualsFile($result, 'fallback-entry-content');
     }
 
-    public function testBuildContextReturnsNullForHttpUrl(): void
+    public function testBuildContextDisablesRedirectFollowingForHttpUrl(): void
     {
-        $result = $this->invokeBuildContext('http://example.com/file.sfx', false);
+        $context = $this->invokeBuildContext('http://example.com/file.sfx', false);
+        self::assertNotNull($context);
 
-        self::assertNull($result);
+        $options = stream_context_get_options($context);
+        self::assertArrayHasKey('http', $options);
+        self::assertSame(0, $options['http']['follow_location']);
+        self::assertSame(0, $options['http']['max_redirects']);
+        self::assertArrayNotHasKey('ssl', $options);
     }
 
-    public function testBuildContextReturnsNullForHttpUrlEvenWhenInsecure(): void
+    public function testBuildContextHttpUrlOptionsIndependentOfAllowInsecure(): void
     {
-        $result = $this->invokeBuildContext('http://example.com/file.sfx', true);
+        $secure = stream_context_get_options($this->invokeBuildContext('http://example.com/file.sfx', false));
+        $insecure = stream_context_get_options($this->invokeBuildContext('http://example.com/file.sfx', true));
 
-        self::assertNull($result);
+        self::assertSame($secure, $insecure);
     }
 
     public function testBuildContextDisablesFollowLocationWhenInsecure(): void
@@ -323,20 +349,35 @@ final class SfxDownloaderTest extends TestCase
         $options = stream_context_get_options($context);
         self::assertArrayHasKey('http', $options);
         self::assertSame(0, $options['http']['follow_location']);
+        self::assertSame(0, $options['http']['max_redirects']);
         self::assertFalse($options['ssl']['verify_peer']);
         self::assertFalse($options['ssl']['verify_peer_name']);
     }
 
-    public function testBuildContextEnablesFollowLocationWhenSecure(): void
+    public function testBuildContextDisablesFollowLocationWhenSecure(): void
     {
         $context = $this->invokeBuildContext('https://example.com/file.sfx', false);
         self::assertNotNull($context);
 
         $options = stream_context_get_options($context);
         self::assertArrayHasKey('http', $options);
-        self::assertSame(1, $options['http']['follow_location']);
+        self::assertSame(0, $options['http']['follow_location']);
+        self::assertSame(0, $options['http']['max_redirects']);
         self::assertTrue($options['ssl']['verify_peer']);
         self::assertTrue($options['ssl']['verify_peer_name']);
+    }
+
+    public function testInsecureDiffersFromDefaultOnlyInPeerVerification(): void
+    {
+        $secure = stream_context_get_options($this->invokeBuildContext('https://example.com/file.sfx', false));
+        $insecure = stream_context_get_options($this->invokeBuildContext('https://example.com/file.sfx', true));
+
+        self::assertSame($secure['http'], $insecure['http']);
+        self::assertSame(0, $secure['http']['follow_location']);
+        self::assertTrue($secure['ssl']['verify_peer']);
+        self::assertFalse($insecure['ssl']['verify_peer']);
+        self::assertTrue($secure['ssl']['verify_peer_name']);
+        self::assertFalse($insecure['ssl']['verify_peer_name']);
     }
 
     public function testResolveRedirectUrlAbsolute(): void
@@ -367,6 +408,74 @@ final class SfxDownloaderTest extends TestCase
         self::assertSame('https://example.com:8443/d.sfx', $result);
     }
 
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function nonHttpSchemeLocationProvider(): array
+    {
+        return [
+            'ftp' => ['ftp://example.invalid/evil.sfx'],
+            'file' => ['file:///etc/passwd'],
+            'php' => ['php://filter/resource=/etc/passwd'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonHttpSchemeLocationProvider
+     */
+    public function testResolveRedirectUrlRejectsNonHttpScheme(string $location): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Blocked redirect to non-HTTP(S) scheme "%s"', $location));
+
+        $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com/a/b/c.sfx', $location);
+    }
+
+    public function testResolveRedirectUrlThrowsWhenBaseUrlCannotBeParsed(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to resolve redirect location "d.sfx" against base URL "no-scheme/path".');
+
+        $this->invokePrivateSfxMethod('resolveRedirectUrl', 'no-scheme/path', 'd.sfx');
+    }
+
+    public function testHttpsToHttpDowngradeRejectedInDefaultMode(): void
+    {
+        // The scheme policy is applied on every hop in every mode: the check
+        // does not depend on $allowInsecure at all.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Blocked cross-scheme redirect from HTTPS to "http://attacker.example/sfx". Disable redirects or use a trusted mirror.');
+
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'https://mirror.example/php.sfx', 'http://attacker.example/sfx');
+    }
+
+    public function testHttpsToHttpDowngradeRejectedWhenInsecure(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Blocked cross-scheme redirect from HTTPS to "http://attacker.example/sfx".');
+
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'https://mirror.example/php.sfx', 'http://attacker.example/sfx');
+    }
+
+    /**
+     * @dataProvider nonHttpSchemeLocationProvider
+     */
+    public function testNonHttpSchemeRejectedFromHttpsOrigin(string $location): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Blocked redirect to non-HTTP(S) scheme "%s"', $location));
+
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'https://mirror.example/php.sfx', $location);
+    }
+
+    public function testSameSchemeRedirectsAllowed(): void
+    {
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'https://mirror.example/a.sfx', 'https://mirror2.example/b.sfx');
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'http://mirror.example/a.sfx', 'http://mirror2.example/b.sfx');
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'http://mirror.example/a.sfx', 'https://mirror2.example/b.sfx');
+        $this->addToAssertionCount(3);
+    }
+
     public function testDownloadWithRedirectCheckExtractsSfxFilename(): void
     {
         $tempFile = $this->tempDir . '/downloaded.sfx';
@@ -381,6 +490,173 @@ final class SfxDownloaderTest extends TestCase
 
         self::assertFileExists($result);
         self::assertStringEqualsFile($result, 'sfx-content');
+    }
+
+    public function testSameSchemeRedirectChainFollowedUpToLimit(): void
+    {
+        $result = (new SfxDownloader())->fetch(
+            sprintf('http://127.0.0.1:%d/r1', self::$serverPort),
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'sfx-content');
+    }
+
+    public function testRedirectChainExceedingLimitErrors(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Too many redirects (max 5)');
+
+        (new SfxDownloader())->fetch(
+            sprintf('http://127.0.0.1:%d/r6', self::$serverPort),
+            $this->tempDir,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function nonHttpSchemePathProvider(): array
+    {
+        return [
+            'ftp' => ['/ftp', 'ftp://example.invalid/evil.sfx'],
+            'file' => ['/file', 'file:///etc/passwd'],
+            'php' => ['/php', 'php://filter/resource=/etc/passwd'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonHttpSchemePathProvider
+     */
+    public function testRedirectToNonHttpSchemeRejectedFromHttpOrigin(string $path, string $location): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Blocked redirect to non-HTTP(S) scheme "%s"', $location));
+
+        (new SfxDownloader())->fetch(
+            sprintf('http://127.0.0.1:%d%s', self::$serverPort, $path),
+            $this->tempDir,
+        );
+    }
+
+    public function testDownloadExceedingMaxSizeIsAborted(): void
+    {
+        try {
+            (new SfxDownloader(1024))->fetch(
+                sprintf('http://127.0.0.1:%d/big', self::$serverPort),
+                $this->tempDir,
+            );
+            self::fail('Expected a RuntimeException for the oversized download.');
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('maximum allowed size of 1024 bytes', $e->getMessage());
+        }
+
+        // The partial artifact must not be left behind for a later fetch() to reuse.
+        self::assertFileDoesNotExist($this->tempDir . '/big');
+    }
+
+    public function testChecksumIsVerifiedBeforeZipExtraction(): void
+    {
+        // A corrupt archive that would fail ZipArchive::open(): the SHA-256
+        // mismatch must surface before any extraction is attempted.
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        file_put_contents($zipPath, 'PK' . random_bytes(64));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SHA-256 mismatch');
+
+        (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+            str_repeat('0', 64),
+        );
+    }
+
+    private static function allocatePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0');
+        if (!is_resource($socket)) {
+            throw new \RuntimeException('Failed to allocate a test port.');
+        }
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        return (int) substr((string) $name, strrpos((string) $name, ':') + 1);
+    }
+
+    private static function startRedirectServer(): void
+    {
+        $router = tempnam(sys_get_temp_dir(), 'sfx-router-') . '.php';
+        file_put_contents($router, <<<'PHP_WRAP'
+<?php
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+$redirect = static function (string $location): never {
+    header('Location: ' . $location, true, 302);
+    exit;
+};
+
+switch ($path) {
+    case '/r1':
+        $redirect('/r2');
+    case '/r2':
+        $redirect('/r3');
+    case '/r3':
+        $redirect('/r4');
+    case '/r4':
+        $redirect('/r5');
+    case '/r5':
+        $redirect('/sfx');
+    case '/r6':
+        $redirect('/r6');
+    case '/ftp':
+        $redirect('ftp://example.invalid/evil.sfx');
+    case '/file':
+        $redirect('file:///etc/passwd');
+    case '/php':
+        $redirect('php://filter/resource=/etc/passwd');
+    case '/big':
+        echo str_repeat('x', 65536);
+        exit;
+    case '/sfx':
+    default:
+        echo 'sfx-content';
+        exit;
+}
+PHP_WRAP);
+
+        $command = [PHP_BINARY, '-S', sprintf('127.0.0.1:%d', self::$serverPort), $router];
+        $process = proc_open($command, [
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', '/dev/null', 'w'],
+            2 => ['file', '/dev/null', 'w'],
+        ], $pipes);
+
+        if (!is_resource($process)) {
+            throw new \RuntimeException('Failed to start the test HTTP server.');
+        }
+        self::$serverProcess = $process;
+
+        // Wait until the server accepts connections.
+        $deadline = microtime(true) + 5.0;
+        while (microtime(true) < $deadline) {
+            $errno = 0;
+            $errstr = '';
+            $sock = @fsockopen('127.0.0.1', (int) self::$serverPort, $errno, $errstr, 0.2);
+            if ($sock !== false) {
+                fclose($sock);
+
+                return;
+            }
+            usleep(50000);
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Test HTTP server did not start on port %d.',
+            self::$serverPort,
+        ));
     }
 
     private function invokeBuildContext(string $url, bool $allowInsecure): mixed

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -427,6 +427,13 @@ final class SfxDownloaderTest extends TestCase
         self::assertSame('https://example.com:8443/d.sfx', $result);
     }
 
+    public function testResolveRedirectUrlProtocolRelative(): void
+    {
+        $result = $this->invokePrivateSfxMethod('resolveRedirectUrl', 'https://example.com/a/b/c.sfx', '//cdn.example.com/d.sfx');
+
+        self::assertSame('https://cdn.example.com/d.sfx', $result);
+    }
+
     /**
      * @return array<string, array{0: string}>
      */

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -19,6 +19,8 @@ final class SfxDownloaderTest extends TestCase
     /** @var resource|null */
     private static $serverProcess;
 
+    private static ?string $routerFile = null;
+
     private string $tempDir;
 
     public static function setUpBeforeClass(): void
@@ -33,6 +35,10 @@ final class SfxDownloaderTest extends TestCase
             proc_terminate(self::$serverProcess);
             proc_close(self::$serverProcess);
             self::$serverProcess = null;
+        }
+        if (is_string(self::$routerFile)) {
+            @unlink(self::$routerFile);
+            self::$routerFile = null;
         }
     }
 
@@ -333,6 +339,19 @@ final class SfxDownloaderTest extends TestCase
         self::assertArrayNotHasKey('ssl', $options);
     }
 
+    public function testBuildContextSchemeDetectionIsCaseInsensitive(): void
+    {
+        $httpContext = $this->invokeBuildContext('HTTP://example.com/file.sfx', false);
+        self::assertNotNull($httpContext);
+        self::assertSame(0, stream_context_get_options($httpContext)['http']['follow_location']);
+
+        $httpsContext = $this->invokeBuildContext('HTTPS://example.com/file.sfx', false);
+        self::assertNotNull($httpsContext);
+        $options = stream_context_get_options($httpsContext);
+        self::assertSame(0, $options['http']['follow_location']);
+        self::assertTrue($options['ssl']['verify_peer']);
+    }
+
     public function testBuildContextHttpUrlOptionsIndependentOfAllowInsecure(): void
     {
         $secure = stream_context_get_options($this->invokeBuildContext('http://example.com/file.sfx', false));
@@ -457,6 +476,16 @@ final class SfxDownloaderTest extends TestCase
         $this->invokePrivateSfxMethod('assertAllowedRedirect', 'https://mirror.example/php.sfx', 'http://attacker.example/sfx');
     }
 
+    public function testHttpsToHttpDowngradeRejectedWithMixedCaseSchemes(): void
+    {
+        // A hostile mirror may emit an uppercase-scheme Location header; the
+        // policy must not be bypassable via case differences.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Blocked cross-scheme redirect from HTTPS to "HTTP://attacker.example/sfx".');
+
+        $this->invokePrivateSfxMethod('assertAllowedRedirect', 'HTTPS://mirror.example/php.sfx', 'HTTP://attacker.example/sfx');
+    }
+
     /**
      * @dataProvider nonHttpSchemeLocationProvider
      */
@@ -512,6 +541,28 @@ final class SfxDownloaderTest extends TestCase
             sprintf('http://127.0.0.1:%d/r6', self::$serverPort),
             $this->tempDir,
         );
+    }
+
+    public function testRedirectLimitEnforcedForMixedCaseSchemeUrl(): void
+    {
+        // An uppercase-scheme URL must still get the manual redirect loop
+        // (follow_location => 0), not the default context that follows
+        // redirects inside the wrapper.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Too many redirects (max 5)');
+
+        (new SfxDownloader())->fetch(
+            sprintf('HTTP://127.0.0.1:%d/r6', self::$serverPort),
+            $this->tempDir,
+        );
+    }
+
+    public function testConstructorRejectsNonPositiveMaxDownloadBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxDownloadBytes must be a positive number of bytes.');
+
+        new SfxDownloader(0);
     }
 
     /**
@@ -587,8 +638,8 @@ final class SfxDownloaderTest extends TestCase
 
     private static function startRedirectServer(): void
     {
-        $router = tempnam(sys_get_temp_dir(), 'sfx-router-') . '.php';
-        file_put_contents($router, <<<'PHP_WRAP'
+        self::$routerFile = sys_get_temp_dir() . '/sfx-router-' . uniqid('', true) . '.php';
+        file_put_contents(self::$routerFile, <<<'PHP_WRAP'
 <?php
 
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
@@ -627,7 +678,7 @@ switch ($path) {
 }
 PHP_WRAP);
 
-        $command = [PHP_BINARY, '-S', sprintf('127.0.0.1:%d', self::$serverPort), $router];
+        $command = [PHP_BINARY, '-S', sprintf('127.0.0.1:%d', self::$serverPort), self::$routerFile];
         $process = proc_open($command, [
             0 => ['file', '/dev/null', 'r'],
             1 => ['file', '/dev/null', 'w'],


### PR DESCRIPTION
## Description

Closes #585

HTTPS→HTTP downgrade redirects were blocked only when `--insecure` was passed; the default path handed redirect following to PHP's `http` wrapper, which follows a downgrade to plain HTTP without complaint. The hardening was attached to the wrong branch.

## Changes

- **Unified redirect policy**: all SFX downloads now go through the manual redirect loop; `` controls only TLS peer verification
- **`follow_location => 0` in both modes**: PHP's http wrapper never follows a redirect on the bundle's behalf
- **Scheme checks on every hop**: HTTPS→HTTP downgrades and any non-HTTP(S) redirect target (`file://`, `php://`, `ftp://`) are blocked from every origin scheme
- **`resolveRedirectUrl()` hardened**: unresolvable base URLs and non-HTTP(S) absolute locations throw instead of passing through; protocol-relative locations resolve correctly
- **Case-insensitive scheme matching**: mixed-case `HTTP://`/`HTTPS://` URLs and Location headers cannot bypass the policy
- **Download size cap**: 256 MiB by default (`SfxDownloader::__construct($maxDownloadBytes)`); oversized downloads abort and remove the partial file
- **Checksum verified before extraction**: the downloaded artifact is verified before `ZipArchive` runs; for `.zip` URLs the checksum now covers the zip artifact
- **`writeStream()`**: short writes are detected and the partial artifact is cleaned up
- **docs/security.md + docs/build-packaging.md**: describe the unified policy
- Tests: unit + E2E (local PHP built-in server) covering downgrade rejection in both modes, non-HTTP(S) schemes from both origins, 5-hop limit, size cap, checksum-before-extraction ordering, mixed-case schemes, protocol-relative resolution

## Changelog

Entry added under [Unreleased] → Security.

## Code Review

- [x] Passed subagent code review (2 rounds; blocker found in round 1 and fixed)
- [x] All review comments addressed