### PR TITLE
fix(security): harden master process identification (closes #584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Harden master-process identification before sending signals. The legacy
+  `/proc/$pid/cmdline` fallback accepted any process whose command line
+  contained the substring `php` (and returned `true` unconditionally when
+  the cmdline was unreadable or on non-Linux hosts), so a stale or
+  attacker-supplied pid file could make `stop()`/`reload()`/`status` signal
+  an unrelated PHP process. The fallback now matches the process title
+  Workerman assigns to its master process (`WorkerMan: master process ...`)
+  and fails closed — an unverifiable PID is refused with a warning instead
+  of being signalled. A new `MasterWorker` records the master fingerprint
+  from inside the real master process, closing the daemon-mode gap where
+  `start -d` deployments never had a fingerprint
+  ([#584](https://github.com/crazy-goat/workerman-bundle/issues/584))
+
 - Fix unbounded memory growth in `StaticFilesMiddleware`'s realpath cache.
   The symlink-rejection path inserted into the shared worker cache without
   enforcing `CACHE_MAX_SIZE`, and negative entries only expired on a repeat

--- a/docs/security.md
+++ b/docs/security.md
@@ -425,9 +425,9 @@ The start time check is the strongest defense against PID reuse: even if the ori
 
 ### Fallback Behaviour
 
-If the fingerprint file does not exist (e.g. after upgrading from a version that did not write fingerprints, or if the write failed), `ProcessInspector` falls back to a strict check against the process title Workerman assigns to its master process — `WorkerMan: master process ...`. The check requires that exact title; a process whose cmdline merely contains the word "php" (or "WorkerMan" elsewhere) is **rejected**.
+If the fingerprint file does not exist (e.g. after upgrading from a version that did not write fingerprints, or if the write failed), `ProcessInspector` falls back to a strict command-line check against the process title Workerman assigns to its master process — `WorkerMan: master process ...`. The check requires that exact title; a process whose cmdline merely contains the word "php" (or "WorkerMan" elsewhere) is **rejected**.
 
-The check reads both `/proc/$pid/cmdline` and `/proc/$pid/comm`: `cli_set_process_title()` always sets the comm via `prctl(PR_SET_NAME)`, but on PHP >= 8.5 it no longer rewrites the argv memory area, so the cmdline keeps the original command line there — the comm (truncated to 15 chars by the kernel: `WorkerMan: mast`) still matches.
+**Runtime dependence**: `cli_set_process_title()` rewrites the argv memory area, and the effect is visible in `/proc/$pid/cmdline` on most PHP builds — but on PHP >= 8.5 some builds keep the original argv. On those runtimes the strict fallback may also reject the *real* master when no fingerprint exists; the command then fails closed ("not running"). The fingerprint is written automatically on every start (including daemon mode), so a single restart after upgrading restores full control-plane operation. This is the documented trade-off: refusing to signal an unverifiable PID is preferred over signalling an unrelated process.
 
 Verification is **fail-closed**: when the cmdline cannot be read (a process owned by another user under `hidepid`, a non-Linux host without `/proc`), `isMasterRunning()` logs a warning and returns `false` — the caller refuses to signal. Earlier revisions returned `true` in this situation (fail-open in the direction of sending a signal); that behaviour is gone (issue #584).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -401,11 +401,13 @@ passed. This ensures supply-chain integrity by default:
 
 `ServerManager` identifies the Workerman master process before sending signals (SIGINT, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO). Without hardening, the identification relied on a loose `str_contains($cmdline, 'WorkerMan')` check against `/proc/$pid/cmdline` — a substring match that could misidentify any co-located process whose command line happens to contain the word "WorkerMan" (an unrelated binary, a script with that name in its path, a build tool). A misidentification could lead to `SIGKILL` being sent to an unrelated process, causing a denial-of-service on adjacent services.
 
+A later revision added `|| str_contains($cmdline, 'php')` to that fallback, which made the check **vacuous**: every PHP process on the host matched — `php-fpm` children, a `composer` run, a cron script, an unrelated Symfony command, even the process asking the question. This was removed again (issue #584); see [Fallback Behaviour](#fallback-behaviour) for what the check enforces today.
+
 ### Defence
 
-When the master is started in **non-daemon mode**, `ServerManager` writes a **fingerprint file** alongside the PID file (`<pid_file>.fingerprint`). The fingerprint records:
+`ServerManager` writes a **fingerprint file** alongside the PID file (`<pid_file>.fingerprint`). The fingerprint records:
 
-- **PID**: the process ID of the master (the CLI process that becomes the master in non-daemon mode)
+- **PID**: the process ID of the master
 - **Start time**: clock ticks since boot, read from `/proc/$pid/stat` field 22. **Linux only** — on POSIX without `/proc` the value is recorded as `0` and the start-time check is disabled.
 - **UID**: the Unix user ID of the master process
 
@@ -417,25 +419,30 @@ Before sending any signal, `ProcessInspector` reads the fingerprint and verifies
 
 The start time check is the strongest defense against PID reuse: even if the original master process died and its PID was reassigned to an unrelated process, the new process will have a different start time and will be rejected.
 
-### Daemon Mode
+**Non-daemon mode**: the fingerprint is written by `ServerManager` before the runner starts (the CLI process becomes the master).
 
-In daemon mode (`start -d`), `Worker::daemonize()` forks twice and the launcher process exits. The actual master is a grandchild process whose PID differs from the launcher's PID. Since the fingerprint cannot be captured before `Runner::run()` is invoked, the fingerprint is **intentionally not written in daemon mode** and the legacy cmdline-based check is used as a fallback. This is a known limitation: daemon-mode deployments rely on the cmdline substring check, which is weaker than the fingerprint check but still prevents the most obvious misidentification attacks.
+**Daemon mode**: `Worker::daemonize()` forks twice and the launcher process exits, so the launcher PID is not the master PID. The bundle runs Workerman through `MasterWorker` (a `Workerman\Worker` subclass), which records the fingerprint from **inside the real master process** immediately after the PID file is written (`saveMasterPid()`). The fingerprint therefore describes the actual master PID in every mode — the daemon-mode gap documented in earlier revisions of this file is closed (issue #584). Until the master has started, `ProcessInspector` fails closed rather than signalling an unverifiable PID.
 
 ### Fallback Behaviour
 
-If the fingerprint file does not exist (e.g., after upgrading from a version that did not write fingerprints, in daemon mode, or if the write failed), `ProcessInspector` falls back to the legacy cmdline-based check. This ensures backward compatibility with existing deployments.
+If the fingerprint file does not exist (e.g. after upgrading from a version that did not write fingerprints, or if the write failed), `ProcessInspector` falls back to a strict cmdline check against the process title Workerman assigns to its master process — `WorkerMan: master process ...`. The check requires that exact title; a process whose cmdline merely contains the word "php" (or "WorkerMan" elsewhere) is **rejected**.
+
+Verification is **fail-closed**: when the cmdline cannot be read (a process owned by another user under `hidepid`, a non-Linux host without `/proc`), `isMasterRunning()` logs a warning and returns `false` — the caller refuses to signal. Earlier revisions returned `true` in this situation (fail-open in the direction of sending a signal); that behaviour is gone (issue #584).
 
 ### When this matters
 
-- **Multi-user hosts**: Shared CI runners, containers with multiple service accounts, or any environment where an attacker could spawn a process whose command line contains "WorkerMan".
+- **Multi-user hosts**: Shared CI runners, containers with multiple service accounts, or any environment where an attacker could spawn a process whose command line contains "WorkerMan" (or any plain PHP process — earlier revisions accepted any cmdline containing "php").
 - **Shared runtime directories**: If the PID file directory is shared between multiple services or users, an attacker could write a fake PID file pointing to an unrelated process.
-- **PID reuse**: After a master process dies, its PID may be reassigned to an unrelated process. The start time check prevents the new process from being misidentified as the master.
+- **PID reuse**: After a master process dies without a clean `stop()` (OOM kill, `SIGKILL`, host reboot with a persisted pid file), its PID may be reassigned to an unrelated process. The start time check prevents the new process from being misidentified as the master; without a fingerprint, the strict cmdline check (master process title) rejects the reused PID.
 
 ### Verification
 
+- `testDaemonModeWritesMasterFingerprint` (in `tests/WorkermanCommandTest.php`) verifies end to end that a `start -d` deployment produces a fingerprint for the real master PID (issue #584).
+- `testStopWithStalePidFileDoesNotSignalForeignProcess` (in `tests/WorkermanCommandTest.php`) runs the console `stop` command with a stale pid file pointing at a plain PHP process and asserts no signal is sent (issue #584 end-to-end regression).
 - `testIsRunningUsesFingerprintWhenAvailable` (in `tests/ServerManagerTest.php`) verifies that `isRunning()` returns true when the fingerprint matches the PID file PID.
 - `testIsRunningRejectsUnrelatedProcessWithFingerprint` (in `tests/ServerManagerTest.php`) verifies that `isRunning()` returns false when the fingerprint PID does not match the PID file PID.
-- `testIsRunningFallsBackToLegacyCheckWithoutFingerprint` (in `tests/ServerManagerTest.php`) verifies backward compatibility.
+- `testIsRunningWithoutFingerprintRejectsPlainPhpProcess` and `testIsRunningWithoutFingerprintAcceptsMasterTitleProcess` (in `tests/ServerManagerTest.php`) verify the strict cmdline fallback: a plain PHP process is rejected, a process carrying the `WorkerMan: master process` title is accepted (issue #584).
+- `testStopRefusesToSignalPlainPhpProcessWithoutFingerprint`, `testReloadRefusesToSignalPlainPhpProcessWithoutFingerprint`, `testGetStatusRefusesToSignalPlainPhpProcessWithoutFingerprint` and `testGetConnectionsRefusesToSignalPlainPhpProcessWithoutFingerprint` (in `tests/ServerManagerTest.php`) verify that every signal path refuses to signal when verification fails (issue #584).
 - `testKillOrphanedIntermediateForkWithFingerprintDoesNotKillUnrelatedProcess` (in `tests/ProcessInspectorTest.php`) verifies that `killOrphanedIntermediateFork()` does not kill a process whose PID does not match the fingerprint.
 
 ## Composer Audit Advisory Suppression Policy

--- a/docs/security.md
+++ b/docs/security.md
@@ -425,7 +425,9 @@ The start time check is the strongest defense against PID reuse: even if the ori
 
 ### Fallback Behaviour
 
-If the fingerprint file does not exist (e.g. after upgrading from a version that did not write fingerprints, or if the write failed), `ProcessInspector` falls back to a strict cmdline check against the process title Workerman assigns to its master process — `WorkerMan: master process ...`. The check requires that exact title; a process whose cmdline merely contains the word "php" (or "WorkerMan" elsewhere) is **rejected**.
+If the fingerprint file does not exist (e.g. after upgrading from a version that did not write fingerprints, or if the write failed), `ProcessInspector` falls back to a strict check against the process title Workerman assigns to its master process — `WorkerMan: master process ...`. The check requires that exact title; a process whose cmdline merely contains the word "php" (or "WorkerMan" elsewhere) is **rejected**.
+
+The check reads both `/proc/$pid/cmdline` and `/proc/$pid/comm`: `cli_set_process_title()` always sets the comm via `prctl(PR_SET_NAME)`, but on PHP >= 8.5 it no longer rewrites the argv memory area, so the cmdline keeps the original command line there — the comm (truncated to 15 chars by the kernel: `WorkerMan: mast`) still matches.
 
 Verification is **fail-closed**: when the cmdline cannot be read (a process owned by another user under `hidepid`, a non-Linux host without `/proc`), `isMasterRunning()` logs a warning and returns `false` — the caller refuses to signal. Earlier revisions returned `true` in this situation (fail-open in the direction of sending a signal); that behaviour is gone (issue #584).
 

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -23,16 +23,6 @@ final readonly class ProcessInspector
      */
     private const TIMEOUT_BUFFER = 3;
 
-    /**
-     * The process comm (prctl PR_SET_NAME) of a Workerman master as
-     * visible in `/proc/$pid/comm` on Linux. `cli_set_process_title()`
-     * always sets the comm, but on PHP >= 8.5 it no longer rewrites the
-     * argv memory area, so `/proc/$pid/cmdline` keeps the original
-     * command line; the comm is truncated to 15 chars by the kernel
-     * ("WorkerMan: mast").
-     */
-    private const MASTER_COMM = 'WorkerMan: mast';
-
     public function __construct(
         private LoggerInterface $logger = new NullLogger(),
     ) {
@@ -225,18 +215,6 @@ final readonly class ProcessInspector
                     return true;
                 }
             }
-
-            // On PHP >= 8.5, cli_set_process_title() no longer rewrites
-            // the argv memory area, so /proc/$pid/cmdline keeps the
-            // original command line — but the comm is always set via
-            // prctl and is truncated to 15 chars by the kernel.
-            $comm = "/proc/{$masterPid}/comm";
-            if (is_readable($comm)) {
-                $content = file_get_contents($comm);
-                if (\is_string($content) && \trim($content) === self::MASTER_COMM) {
-                    return true;
-                }
-            }
         }
 
         // Fail closed: on a non-Linux host, or when /proc/$pid/cmdline
@@ -284,23 +262,13 @@ final readonly class ProcessInspector
         // containing "WorkerMan"; it is tightened to the actual master
         // title so an unrelated "WorkerMan" mention cannot match (issue #584).
         $cmdline = "/proc/{$parentPid}/cmdline";
-        if (is_readable($cmdline)) {
-            $content = file_get_contents($cmdline);
-            if (\is_string($content) && $content !== '' && str_contains($content, 'WorkerMan: master process')) {
-                posix_kill($parentPid, \SIGKILL);
-
-                return;
-            }
+        if (!is_readable($cmdline)) {
+            return;
         }
 
-        // PHP >= 8.5 keeps the original argv in /proc/$pid/cmdline;
-        // match the comm (always set via prctl, truncated to 15 chars).
-        $comm = "/proc/{$parentPid}/comm";
-        if (is_readable($comm)) {
-            $content = file_get_contents($comm);
-            if (\is_string($content) && \trim($content) === self::MASTER_COMM) {
-                posix_kill($parentPid, \SIGKILL);
-            }
+        $content = file_get_contents($cmdline);
+        if (\is_string($content) && str_contains($content, 'WorkerMan: master process')) {
+            posix_kill($parentPid, \SIGKILL);
         }
     }
 

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -179,6 +179,13 @@ final readonly class ProcessInspector
         return true;
     }
 
+    /**
+     * Determine whether the given PID is the Workerman master process.
+     *
+     * Returns false (and logs a warning) when the candidate cannot be
+     * verified — the method fails closed, never open, in the direction of
+     * sending a signal.
+     */
     public function isMasterRunning(int $masterPid, ?MasterFingerprint $fingerprint = null): bool
     {
         if ($masterPid <= 0 || !$this->isProcessAlive($masterPid)) {
@@ -187,28 +194,38 @@ final readonly class ProcessInspector
 
         // If a fingerprint is available, use it as the primary check.
         // The fingerprint-based check is strictly stronger than the
-        // cmdline substring check because it verifies PID + UID + start
-        // time, not just a loose substring match.
+        // cmdline check because it verifies PID + UID + start time,
+        // not a substring match.
         if ($fingerprint instanceof \CrazyGoat\WorkermanBundle\MasterFingerprint) {
             return $this->matchesFingerprint($masterPid, $fingerprint);
         }
 
-        // Legacy fallback: cmdline substring check. Kept for backward
-        // compatibility with deployments that have an existing PID file
-        // but no fingerprint file (e.g., after upgrading from a version
-        // that did not write fingerprints, or in daemon mode where the
-        // launcher PID does not match the master PID).
+        // Legacy fallback: match against the process title the Workerman
+        // master actually sets ("WorkerMan: master process ..."). Earlier
+        // versions also accepted any cmdline containing the substring
+        // "php", which made the check vacuous — every PHP process on the
+        // host matched (see issue #584). The title is set before the
+        // master forks, so it survives daemon mode and matches only
+        // genuine Workerman masters.
         if (self::isLinux()) {
             $cmdline = "/proc/{$masterPid}/cmdline";
             if (is_readable($cmdline)) {
                 $content = file_get_contents($cmdline);
                 if (\is_string($content) && $content !== '') {
-                    return str_contains($content, 'WorkerMan') || str_contains($content, 'php');
+                    return str_contains($content, 'WorkerMan: master process');
                 }
             }
         }
 
-        return true;
+        // Fail closed: on a non-Linux host, or when /proc/$pid/cmdline
+        // is unreadable (e.g. a process owned by another user under
+        // hidepid), we cannot verify the candidate — refuse to signal.
+        $this->logger->warning('Cannot verify master process identity; refusing to signal', [
+            'pid' => $masterPid,
+            'has_fingerprint' => false,
+        ]);
+
+        return false;
     }
 
     public function killOrphanedIntermediateFork(int $parentPid, ?MasterFingerprint $fingerprint = null): void
@@ -240,14 +257,17 @@ final readonly class ProcessInspector
             return;
         }
 
-        // Legacy fallback: cmdline substring check.
+        // Legacy fallback: cmdline check against the process title the
+        // Workerman master sets. The old check accepted any cmdline
+        // containing "WorkerMan"; it is tightened to the actual master
+        // title so an unrelated "WorkerMan" mention cannot match (issue #584).
         $cmdline = "/proc/{$parentPid}/cmdline";
         if (!is_readable($cmdline)) {
             return;
         }
 
         $content = file_get_contents($cmdline);
-        if (\is_string($content) && str_contains($content, 'WorkerMan')) {
+        if (\is_string($content) && str_contains($content, 'WorkerMan: master process')) {
             posix_kill($parentPid, \SIGKILL);
         }
     }

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -23,6 +23,16 @@ final readonly class ProcessInspector
      */
     private const TIMEOUT_BUFFER = 3;
 
+    /**
+     * The process comm (prctl PR_SET_NAME) of a Workerman master as
+     * visible in `/proc/$pid/comm` on Linux. `cli_set_process_title()`
+     * always sets the comm, but on PHP >= 8.5 it no longer rewrites the
+     * argv memory area, so `/proc/$pid/cmdline` keeps the original
+     * command line; the comm is truncated to 15 chars by the kernel
+     * ("WorkerMan: mast").
+     */
+    private const MASTER_COMM = 'WorkerMan: mast';
+
     public function __construct(
         private LoggerInterface $logger = new NullLogger(),
     ) {
@@ -211,8 +221,20 @@ final readonly class ProcessInspector
             $cmdline = "/proc/{$masterPid}/cmdline";
             if (is_readable($cmdline)) {
                 $content = file_get_contents($cmdline);
-                if (\is_string($content) && $content !== '') {
-                    return str_contains($content, 'WorkerMan: master process');
+                if (\is_string($content) && $content !== '' && str_contains($content, 'WorkerMan: master process')) {
+                    return true;
+                }
+            }
+
+            // On PHP >= 8.5, cli_set_process_title() no longer rewrites
+            // the argv memory area, so /proc/$pid/cmdline keeps the
+            // original command line — but the comm is always set via
+            // prctl and is truncated to 15 chars by the kernel.
+            $comm = "/proc/{$masterPid}/comm";
+            if (is_readable($comm)) {
+                $content = file_get_contents($comm);
+                if (\is_string($content) && \trim($content) === self::MASTER_COMM) {
+                    return true;
                 }
             }
         }
@@ -262,13 +284,23 @@ final readonly class ProcessInspector
         // containing "WorkerMan"; it is tightened to the actual master
         // title so an unrelated "WorkerMan" mention cannot match (issue #584).
         $cmdline = "/proc/{$parentPid}/cmdline";
-        if (!is_readable($cmdline)) {
-            return;
+        if (is_readable($cmdline)) {
+            $content = file_get_contents($cmdline);
+            if (\is_string($content) && $content !== '' && str_contains($content, 'WorkerMan: master process')) {
+                posix_kill($parentPid, \SIGKILL);
+
+                return;
+            }
         }
 
-        $content = file_get_contents($cmdline);
-        if (\is_string($content) && str_contains($content, 'WorkerMan: master process')) {
-            posix_kill($parentPid, \SIGKILL);
+        // PHP >= 8.5 keeps the original argv in /proc/$pid/cmdline;
+        // match the comm (always set via prctl, truncated to 15 chars).
+        $comm = "/proc/{$parentPid}/comm";
+        if (is_readable($comm)) {
+            $content = file_get_contents($comm);
+            if (\is_string($content) && \trim($content) === self::MASTER_COMM) {
+                posix_kill($parentPid, \SIGKILL);
+            }
         }
     }
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\WorkermanBundle;
 
 use CrazyGoat\WorkermanBundle\Worker\FileMonitorWorker;
+use CrazyGoat\WorkermanBundle\Worker\MasterWorker;
 use CrazyGoat\WorkermanBundle\Worker\SchedulerWorker;
 use CrazyGoat\WorkermanBundle\Worker\ServerWorker;
 use CrazyGoat\WorkermanBundle\Worker\SupervisorWorker;
@@ -40,7 +41,10 @@ readonly class Runner implements RunnerInterface
         $this->applyWorkermanConfig($config);
         $this->createWorkers($config, $schedulerConfig, $processConfig);
 
-        Worker::runAll();
+        // Run through MasterWorker so the real master PID (which is only
+        // known after daemonize) gets a fingerprint — closing the daemon-mode
+        // verification gap described in issue #584.
+        MasterWorker::runAll();
 
         return 0;
     }

--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -300,16 +300,18 @@ final readonly class ServerManager
      * before sending signals — preventing the `/proc/cmdline`
      * substring-match vulnerability described in issue #327.
      *
-     * Daemon mode: in daemon mode, `Worker::daemonize()` forks twice
-     * and the launcher process exits. The actual master is a grandchild
-     * process whose PID differs from the launcher's PID. Since we
-     * cannot capture the grandchild's PID before `Runner::run()` is
-     * invoked, the fingerprint is intentionally NOT written in daemon
-     * mode and the legacy cmdline-based check is used as a fallback.
+     * Daemon mode: `Worker::daemonize()` forks twice and the launcher
+     * process exits, so the launcher PID is not the master PID and no
+     * fingerprint is written here. The gap is closed by
+     * {@see \CrazyGoat\WorkermanBundle\Worker\MasterWorker::saveMasterPid()},
+     * which records the fingerprint from inside the real master process
+     * right after the PID file is written (issue #584). Until the master
+     * starts, `ProcessInspector` fails closed rather than signalling on
+     * an unverifiable PID.
      *
      * Failures are logged but do not abort the start sequence: if the
-     * fingerprint cannot be written, the legacy cmdline-based check
-     * is used as a fallback.
+     * fingerprint cannot be written, the strict cmdline-based check
+     * (master process title) is used as a fallback.
      */
     private function writeMasterFingerprint(bool $daemon): void
     {
@@ -321,7 +323,7 @@ final readonly class ServerManager
         }
 
         if ($daemon) {
-            $this->logger->info('Daemon mode: skipping master fingerprint (launcher PID does not match master PID after daemonize)');
+            $this->logger->info('Daemon mode: skipping launcher fingerprint (master fingerprint is written by the master process itself)');
 
             return;
         }

--- a/src/Worker/MasterWorker.php
+++ b/src/Worker/MasterWorker.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Worker;
+
+use CrazyGoat\WorkermanBundle\MasterFingerprint;
+use Workerman\Worker;
+
+/**
+ * Workerman Worker subclass that records the master fingerprint in daemon mode.
+ *
+ * In daemon mode (`start -d`), `Worker::daemonize()` forks twice and the
+ * launcher process exits, so `ServerManager` cannot capture the master PID
+ * before `Runner::run()` is invoked. The PID file, however, is written by the
+ * master process itself via `Worker::saveMasterPid()` — which is invoked
+ * through late static binding from `Worker::runAll()`. By subclassing
+ * `Worker` and running `MasterWorker::runAll()`, this bundle intercepts that
+ * call and records a fingerprint for the real master immediately after its
+ * PID is known.
+ *
+ * This removes the daemon-mode verification gap described in issue #584,
+ * where daemonised deployments relied on the weak `/proc/$pid/cmdline`
+ * substring fallback that accepted any process whose command line contained
+ * the substring "php".
+ */
+final class MasterWorker extends Worker
+{
+    /**
+     * Write the master PID, then record its fingerprint.
+     *
+     * `parent::saveMasterPid()` persists the real master PID (this is the
+     * process that survives daemonize). The fingerprint is captured from
+     * the current process, so PID, start time, and UID always describe the
+     * actual master — even after the double fork of daemon mode.
+     *
+     * A failure to write the fingerprint is logged but must not abort the
+     * start sequence: `ProcessInspector` then falls back to the strict
+     * cmdline check instead of the fingerprint check.
+     */
+    protected static function saveMasterPid(): void
+    {
+        parent::saveMasterPid();
+
+        $pid = self::$masterPid;
+        $pidFile = self::$pidFile;
+
+        if ($pid <= 0 || $pidFile === '') {
+            return;
+        }
+
+        try {
+            MasterFingerprint::capture()->writeTo($pidFile . '.fingerprint');
+        } catch (\Throwable $e) {
+            self::log(\sprintf('Unable to write master fingerprint: %s', $e->getMessage()));
+        }
+    }
+}

--- a/src/Worker/MasterWorker.php
+++ b/src/Worker/MasterWorker.php
@@ -52,7 +52,7 @@ final class MasterWorker extends Worker
         try {
             MasterFingerprint::capture()->writeTo($pidFile . '.fingerprint');
         } catch (\Throwable $e) {
-            self::log(\sprintf('Unable to write master fingerprint: %s', $e->getMessage()));
+            self::log('Unable to write master fingerprint: ' . $e->getMessage());
         }
     }
 }

--- a/tests/MasterWorkerTest.php
+++ b/tests/MasterWorkerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Test;
+
+use CrazyGoat\WorkermanBundle\MasterFingerprint;
+use CrazyGoat\WorkermanBundle\Worker\MasterWorker;
+use PHPUnit\Framework\TestCase;
+use Workerman\Worker;
+
+/**
+ * Tests for MasterWorker: the Workerman subclass that records the master
+ * fingerprint in daemon mode (issue #584).
+ */
+final class MasterWorkerTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/workerman_master_worker_' . uniqid();
+        mkdir($this->tmpDir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    /**
+     * Regression test for issue #584: `saveMasterPid()` must write the
+     * PID file AND a fingerprint describing the current (master) process.
+     *
+     * `parent::saveMasterPid()` persists the PID; the override must then
+     * record a fingerprint of the real master — this is what closes the
+     * daemon-mode gap where no fingerprint was ever written.
+     */
+    public function testSaveMasterPidWritesPidFileAndFingerprint(): void
+    {
+        $pidFile = $this->tmpDir . '/workerman.pid';
+
+        $masterPidProp = new \ReflectionProperty(MasterWorker::class, 'masterPid');
+        $previousPidFile = Worker::$pidFile;
+        $previousMasterPid = $masterPidProp->getValue();
+
+        try {
+            Worker::$pidFile = $pidFile;
+            $masterPidProp->setValue(null, (int) \getmypid());
+
+            $method = new \ReflectionMethod(MasterWorker::class, 'saveMasterPid');
+            $method->invoke(null);
+
+            self::assertFileExists($pidFile, 'PID file must be written by parent::saveMasterPid()');
+            self::assertSame((string) \getmypid(), (string) file_get_contents($pidFile));
+
+            $fingerprint = MasterFingerprint::readFrom($pidFile . '.fingerprint');
+            self::assertNotNull($fingerprint, 'Fingerprint must be written by MasterWorker::saveMasterPid()');
+            self::assertSame((int) \getmypid(), $fingerprint->pid, 'Fingerprint PID must be the master PID');
+            self::assertSame(\posix_getuid(), $fingerprint->uid, 'Fingerprint UID must be the master UID');
+        } finally {
+            Worker::$pidFile = $previousPidFile;
+            $masterPidProp->setValue(null, $previousMasterPid);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: a fingerprint write failure must
+     * not abort the master start sequence — the strict cmdline fallback
+     * in ProcessInspector covers the unverifiable case.
+     *
+     * The failure is provoked by pre-creating a DIRECTORY at the
+     * fingerprint path: `MasterFingerprint::writeTo()` writes its temp
+     * file, then fails the final rename onto the directory and throws.
+     * The PID file write itself succeeds, so only the fingerprint step
+     * fails.
+     */
+    public function testSaveMasterPidDoesNotThrowWhenFingerprintWriteFails(): void
+    {
+        $pidFile = $this->tmpDir . '/workerman.pid';
+        // Occupy the fingerprint path with a directory so the rename fails.
+        mkdir($pidFile . '.fingerprint', 0700);
+
+        $masterPidProp = new \ReflectionProperty(MasterWorker::class, 'masterPid');
+        $previousPidFile = Worker::$pidFile;
+        $previousLogFile = Worker::$logFile;
+        $previousMasterPid = $masterPidProp->getValue();
+        $previousOutputStream = Worker::$outputStream;
+        // Worker::log() -> safeEcho() requires a writable stream; in a unit
+        // test no stream has been initialised, so give it one.
+        $testStream = \fopen('php://temp', 'w+');
+        if ($testStream === false) {
+            self::fail('Unable to open temp stream for test');
+        }
+        Worker::$outputStream = $testStream;
+
+        try {
+            Worker::$pidFile = $pidFile;
+            Worker::$logFile = $this->tmpDir . '/workerman.log';
+            $masterPidProp->setValue(null, (int) \getmypid());
+
+            $method = new \ReflectionMethod(MasterWorker::class, 'saveMasterPid');
+            $method->invoke(null);
+
+            // No exception means the start sequence continues; the PID
+            // file must still have been written by the parent.
+            self::assertFileExists($pidFile, 'PID file must still be written');
+            self::assertSame((string) \getmypid(), (string) file_get_contents($pidFile));
+        } finally {
+            Worker::$outputStream = $previousOutputStream;
+            Worker::$pidFile = $previousPidFile;
+            Worker::$logFile = $previousLogFile;
+            $masterPidProp->setValue(null, $previousMasterPid);
+        }
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                @rmdir($file->getRealPath());
+            } else {
+                @unlink($file->getRealPath());
+            }
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/MasterWorkerTest.php
+++ b/tests/MasterWorkerTest.php
@@ -108,6 +108,7 @@ final class MasterWorkerTest extends TestCase
             self::assertSame((string) \getmypid(), (string) file_get_contents($pidFile));
         } finally {
             Worker::$outputStream = $previousOutputStream;
+            \fclose($testStream);
             Worker::$pidFile = $previousPidFile;
             Worker::$logFile = $previousLogFile;
             $masterPidProp->setValue(null, $previousMasterPid);

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -526,7 +526,7 @@ final class ProcessInspectorTest extends TestCase
         try {
             $this->inspector->killOrphanedIntermediateFork($pid);
 
-            usleep(100_000);
+            $this->waitForProcessDeath($pid);
 
             $this->assertFalse(
                 $this->inspector->isProcessAlive($pid),
@@ -537,6 +537,18 @@ final class ProcessInspectorTest extends TestCase
                 posix_kill($pid, SIGKILL);
             }
             pcntl_waitpid($pid, $status);
+        }
+    }
+
+    /**
+     * Poll until the process is dead, so signal delivery does not depend
+     * on a fixed sleep (flaky under heavy CI load).
+     */
+    private function waitForProcessDeath(int $pid): void
+    {
+        $deadline = \microtime(true) + 1.0;
+        while ($this->inspector->isProcessAlive($pid) && \microtime(true) < $deadline) {
+            \usleep(20_000);
         }
     }
 
@@ -574,8 +586,7 @@ final class ProcessInspectorTest extends TestCase
         try {
             $this->inspector->killOrphanedIntermediateFork($pid, $fingerprint);
 
-            // Give the kernel a moment to deliver SIGKILL.
-            usleep(100_000);
+            $this->waitForProcessDeath($pid);
 
             $this->assertFalse(
                 $this->inspector->isProcessAlive($pid),

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -426,17 +426,19 @@ final class ProcessInspectorTest extends TestCase
     }
 
     /**
-     * Regression test for issue #327: `isMasterRunning()` without a
-     * fingerprint must fall back to the legacy cmdline-based check.
+     * Regression test for issue #584: `isMasterRunning()` without a
+     * fingerprint must reject a live process whose cmdline contains
+     * "php" but is not a Workerman master.
      *
-     * On non-Linux platforms, the legacy check returns true for any
-     * alive PID. On Linux, it requires the cmdline to contain
-     * "WorkerMan" or "php".
+     * The old fallback accepted any cmdline containing the substring
+     * "php", which made the check vacuous — every PHP process matched,
+     * including the caller itself. On non-Linux hosts the old code
+     * returned true unconditionally; it now fails closed.
      *
      * @requires extension pcntl
      * @requires extension posix
      */
-    public function testIsMasterRunningWithoutFingerprintFallsBackToLegacyCheck(): void
+    public function testIsMasterRunningWithoutFingerprintRejectsPlainPhpProcess(): void
     {
         $pid = pcntl_fork();
         if ($pid === -1) {
@@ -450,16 +452,90 @@ final class ProcessInspectorTest extends TestCase
         }
 
         try {
-            // Without a fingerprint, the legacy check is used.
-            // On Linux, the forked child's cmdline contains "php",
-            // so the check returns true. On non-Linux, the check
-            // returns true for any alive PID.
-            $this->assertTrue(
+            // Without a fingerprint, the legacy cmdline check is used.
+            // The forked child is a plain PHP process: its cmdline
+            // contains "php" but not the Workerman master title, so
+            // the check must reject it on every platform.
+            $this->assertFalse(
                 $this->inspector->isMasterRunning($pid),
-                'isMasterRunning() without fingerprint must use legacy cmdline check',
+                'isMasterRunning() without fingerprint must reject a plain PHP process',
             );
         } finally {
             posix_kill($pid, SIGKILL);
+            pcntl_waitpid($pid, $status);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `isMasterRunning()` without a
+     * fingerprint accepts a live process whose cmdline carries the
+     * process title Workerman assigns to its master process.
+     *
+     * @requires OS Linux
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsMasterRunningWithoutFingerprintAcceptsWorkermanMasterTitle(): void
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            $this->assertTrue(
+                $this->inspector->isMasterRunning($pid),
+                'isMasterRunning() must accept a process carrying the Workerman master title',
+            );
+        } finally {
+            posix_kill($pid, SIGKILL);
+            pcntl_waitpid($pid, $status);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `killOrphanedIntermediateFork()`
+     * without a fingerprint must kill a process carrying the Workerman
+     * master title.
+     *
+     * @requires OS Linux
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testKillOrphanedIntermediateForkWithoutFingerprintKillsMasterTitleProcess(): void
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            $this->inspector->killOrphanedIntermediateFork($pid);
+
+            usleep(100_000);
+
+            $this->assertFalse(
+                $this->inspector->isProcessAlive($pid),
+                'killOrphanedIntermediateFork() must kill a process carrying the Workerman master title',
+            );
+        } finally {
+            if ($this->inspector->isProcessAlive($pid)) {
+                posix_kill($pid, SIGKILL);
+            }
             pcntl_waitpid($pid, $status);
         }
     }
@@ -565,12 +641,13 @@ final class ProcessInspectorTest extends TestCase
     }
 
     /**
-     * Regression test for issue #327: `killOrphanedIntermediateFork()`
+     * Regression test for issue #327/#584: `killOrphanedIntermediateFork()`
      * without a fingerprint must fall back to the legacy cmdline check.
      *
      * On Linux, the legacy check kills the process only if its cmdline
-     * contains "WorkerMan". A forked child's cmdline contains "php" but
-     * not "WorkerMan", so the legacy check does NOT kill it.
+     * carries the Workerman master title. A forked child's cmdline
+     * contains "php" but not that title, so the legacy check does NOT
+     * kill it.
      *
      * @requires OS Linux
      * @requires extension pcntl

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -490,9 +490,11 @@ final class ProcessInspectorTest extends TestCase
         }
 
         try {
+            $cmdline = \is_readable("/proc/{$pid}/cmdline") ? (string) @file_get_contents("/proc/{$pid}/cmdline") : 'unreadable';
+            $comm = \is_readable("/proc/{$pid}/comm") ? \trim((string) @file_get_contents("/proc/{$pid}/comm")) : 'unreadable';
             $this->assertTrue(
                 $this->inspector->isMasterRunning($pid),
-                'isMasterRunning() must accept a process carrying the Workerman master title',
+                'isMasterRunning() must accept a process carrying the Workerman master title (cmdline=' . var_export(\str_replace("\0", ' ', $cmdline), true) . ', comm=' . var_export($comm, true) . ')',
             );
         } finally {
             posix_kill($pid, SIGKILL);

--- a/tests/ProcessInspectorTest.php
+++ b/tests/ProcessInspectorTest.php
@@ -471,30 +471,23 @@ final class ProcessInspectorTest extends TestCase
      * fingerprint accepts a live process whose cmdline carries the
      * process title Workerman assigns to its master process.
      *
+     * The title is simulated with `execve()` (argv[0]) rather than
+     * `cli_set_process_title()`, whose effect on /proc/$pid/cmdline
+     * varies by PHP build (PHP >= 8.5 keeps the original argv on some
+     * builds) — execve is kernel behaviour, identical everywhere.
+     *
      * @requires OS Linux
      * @requires extension pcntl
      * @requires extension posix
      */
     public function testIsMasterRunningWithoutFingerprintAcceptsWorkermanMasterTitle(): void
     {
-        $pid = pcntl_fork();
-        if ($pid === -1) {
-            $this->markTestSkipped('pcntl_fork failed');
-        }
-
-        if ($pid === 0) {
-            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
-            for (;;) {
-                sleep(1);
-            }
-        }
+        $pid = $this->forkChildWithMasterTitle();
 
         try {
-            $cmdline = \is_readable("/proc/{$pid}/cmdline") ? (string) @file_get_contents("/proc/{$pid}/cmdline") : 'unreadable';
-            $comm = \is_readable("/proc/{$pid}/comm") ? \trim((string) @file_get_contents("/proc/{$pid}/comm")) : 'unreadable';
             $this->assertTrue(
                 $this->inspector->isMasterRunning($pid),
-                'isMasterRunning() must accept a process carrying the Workerman master title (cmdline=' . var_export(\str_replace("\0", ' ', $cmdline), true) . ', comm=' . var_export($comm, true) . ')',
+                'isMasterRunning() must accept a process carrying the Workerman master title',
             );
         } finally {
             posix_kill($pid, SIGKILL);
@@ -513,17 +506,7 @@ final class ProcessInspectorTest extends TestCase
      */
     public function testKillOrphanedIntermediateForkWithoutFingerprintKillsMasterTitleProcess(): void
     {
-        $pid = pcntl_fork();
-        if ($pid === -1) {
-            $this->markTestSkipped('pcntl_fork failed');
-        }
-
-        if ($pid === 0) {
-            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
-            for (;;) {
-                sleep(1);
-            }
-        }
+        $pid = $this->forkChildWithMasterTitle();
 
         try {
             $this->inspector->killOrphanedIntermediateFork($pid);
@@ -550,6 +533,79 @@ final class ProcessInspectorTest extends TestCase
     {
         $deadline = \microtime(true) + 1.0;
         while ($this->inspector->isProcessAlive($pid) && \microtime(true) < $deadline) {
+            \usleep(20_000);
+        }
+    }
+
+    /**
+     * Fork a child that replaces itself with a process carrying the
+     * Workerman master process title in its command line.
+     *
+     * The title is simulated with `bash -c 'exec -a ...'` (execve
+     * argv[0]) rather than `cli_set_process_title()`, whose effect on
+     * /proc/$pid/cmdline varies by PHP build (PHP >= 8.5 keeps the
+     * original argv on some builds). Execve is kernel behaviour,
+     * identical everywhere.
+     *
+     * A marker file (created by the child AFTER the exec) synchronises
+     * the fork, so the caller never reads /proc before the title is in
+     * place.
+     */
+    private function forkChildWithMasterTitle(): int
+    {
+        $marker = \sys_get_temp_dir() . '/workerman_master_title_' . \bin2hex(\random_bytes(4));
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            $this->execAsMasterTitle($marker);
+        }
+
+        $this->waitForFile($marker, 3);
+        @\unlink($marker);
+
+        return $pid;
+    }
+
+    /**
+     * Replace the current process with one that carries the Workerman
+     * master process title in its command line.
+     *
+     * The exec'd process redirects stdio to `/dev/null` so it cannot
+     * keep PHPUnit's output descriptors open, and it uses a tiny PHP
+     * loop (not `/bin/sh`) because the shell loop ignores SIGINT/SIGQUIT
+     * on macOS and makes stop() tests hang in `waitpid()`.
+     */
+    private function execAsMasterTitle(string $marker): never
+    {
+        $title = 'WorkerMan: master process  start_file=' . __FILE__;
+        $script = <<<'PHP'
+pcntl_async_signals(true);
+pcntl_signal(SIGINT, static function (): void { exit(0); });
+pcntl_signal(SIGQUIT, static function (): void { exit(0); });
+pcntl_signal(SIGTERM, static function (): void { exit(0); });
+touch(__MARKER__);
+while (true) {
+    sleep(1);
+}
+PHP;
+        $script = str_replace('__MARKER__', var_export($marker, true), $script);
+        $command = 'exec -a ' . escapeshellarg($title)
+            . ' ' . escapeshellarg(\PHP_BINARY)
+            . ' -r ' . escapeshellarg($script)
+            . ' < /dev/null > /dev/null 2>&1';
+
+        pcntl_exec('/bin/bash', ['-c', $command]);
+        \fwrite(\STDERR, 'Unable to exec master-title process' . \PHP_EOL);
+        exit(1);
+    }
+
+    private function waitForFile(string $path, int $timeout): void
+    {
+        $deadline = \microtime(true) + $timeout;
+        while (!\file_exists($path) && \microtime(true) < $deadline) {
             \usleep(20_000);
         }
     }

--- a/tests/ServerManagerTest.php
+++ b/tests/ServerManagerTest.php
@@ -1057,22 +1057,23 @@ final class ServerManagerTest extends TestCase
      * master process title and a matching fingerprint is written by the
      * parent. Used by signal-path tests so verification passes on every
      * platform (fingerprint) and the strict cmdline fallback also passes
-     * on Linux (title).
+     * on Linux (title, simulated via execve argv[0] — see
+     * {@see forkChildWithMasterTitle}).
      */
     private function forkMasterLikeChild(): int
     {
+        $marker = \sys_get_temp_dir() . '/workerman_master_title_' . \bin2hex(\random_bytes(4));
         $pid = pcntl_fork();
         if ($pid === -1) {
             $this->markTestSkipped('pcntl_fork failed');
         }
 
         if ($pid === 0) {
-            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
-            for (;;) {
-                sleep(1);
-            }
+            $this->execAsMasterTitle($marker);
         }
 
+        $this->waitForFile($marker, 3);
+        @\unlink($marker);
         $this->writeMatchingFingerprint($pid);
 
         return $pid;
@@ -1081,7 +1082,10 @@ final class ServerManagerTest extends TestCase
     /**
      * Fork a child that looks like a Workerman master AND installs an
      * async signal handler for the given signal (same behaviors as
-     * {@see forkChildWithAsyncSignalHandler}).
+     * {@see forkChildWithAsyncSignalHandler}). The master identity is
+     * established by the matching fingerprint only — the process title
+     * is irrelevant here and is intentionally not simulated (it cannot
+     * survive the exec that a signal handler requires).
      */
     private function forkMasterLikeChildWithSignalHandler(int $signal, string $signalFile, ?string $content = null): int
     {
@@ -1091,7 +1095,7 @@ final class ServerManagerTest extends TestCase
         }
 
         if ($pid === 0) {
-            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            // Enable async signal delivery so handlers fire immediately.
             pcntl_async_signals(true);
 
             pcntl_signal($signal, static function () use ($signalFile, $content): void {
@@ -1111,20 +1115,26 @@ final class ServerManagerTest extends TestCase
     /**
      * Fork a child that carries the Workerman master title but gets NO
      * fingerprint — used by strict fallback tests (Linux cmdline check).
+     *
+     * The title is simulated with `execve()` (argv[0]) rather than
+     * `cli_set_process_title()`, whose effect on /proc/$pid/cmdline
+     * varies by PHP build (PHP >= 8.5 keeps the original argv on some
+     * builds) — execve is kernel behaviour, identical everywhere.
      */
     private function forkChildWithMasterTitle(): int
     {
+        $marker = \sys_get_temp_dir() . '/workerman_master_title_' . \bin2hex(\random_bytes(4));
         $pid = pcntl_fork();
         if ($pid === -1) {
             $this->markTestSkipped('pcntl_fork failed');
         }
 
         if ($pid === 0) {
-            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
-            for (;;) {
-                sleep(1);
-            }
+            $this->execAsMasterTitle($marker);
         }
+
+        $this->waitForFile($marker, 3);
+        @\unlink($marker);
 
         return $pid;
     }
@@ -1141,6 +1151,45 @@ final class ServerManagerTest extends TestCase
             uid: \posix_getuid(),
         );
         $fingerprint->writeTo($this->pidFile . '.fingerprint');
+    }
+
+    /**
+     * Replace the current process with one that carries the Workerman
+     * master process title in its command line (used by the fork
+     * helpers). The title is simulated with `bash -c 'exec -a ...'`
+     * (execve argv[0]) rather than `cli_set_process_title()`, whose
+     * effect on /proc/$pid/cmdline varies by PHP build (PHP >= 8.5
+     * keeps the original argv on some builds). Execve is kernel
+     * behaviour, identical everywhere. The child touches $marker AFTER
+     * the exec so the parent can synchronise on it.
+     *
+     * The exec'd process redirects stdio to `/dev/null` so it cannot
+     * keep PHPUnit's output descriptors open, and it uses a tiny PHP
+     * loop (not `/bin/sh`) because the shell loop ignores SIGINT/SIGQUIT
+     * on macOS and makes stop() tests hang in `waitpid()`.
+     */
+    private function execAsMasterTitle(string $marker): never
+    {
+        $title = 'WorkerMan: master process  start_file=' . __FILE__;
+        $script = <<<'PHP'
+pcntl_async_signals(true);
+pcntl_signal(SIGINT, static function (): void { exit(0); });
+pcntl_signal(SIGQUIT, static function (): void { exit(0); });
+pcntl_signal(SIGTERM, static function (): void { exit(0); });
+touch(__MARKER__);
+while (true) {
+    sleep(1);
+}
+PHP;
+        $script = str_replace('__MARKER__', var_export($marker, true), $script);
+        $command = 'exec -a ' . escapeshellarg($title)
+            . ' ' . escapeshellarg(\PHP_BINARY)
+            . ' -r ' . escapeshellarg($script)
+            . ' < /dev/null > /dev/null 2>&1';
+
+        pcntl_exec('/bin/bash', ['-c', $command]);
+        \fwrite(\STDERR, 'Unable to exec master-title process' . \PHP_EOL);
+        exit(1);
     }
 
     /**

--- a/tests/ServerManagerTest.php
+++ b/tests/ServerManagerTest.php
@@ -130,7 +130,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testIsRunningReturnsTrueWhenMasterIsRunning(): void
     {
-        $pid = $this->forkSleepingChild();
+        $pid = $this->forkMasterLikeChild();
         file_put_contents($this->pidFile, (string) $pid);
 
         try {
@@ -174,7 +174,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testStopForcefulSendsSIGINT(): void
     {
-        $pid = $this->forkSleepingChild();
+        $pid = $this->forkMasterLikeChild();
         file_put_contents($this->pidFile, (string) $pid);
 
         try {
@@ -195,7 +195,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testStopGracefulSendsSIGQUIT(): void
     {
-        $pid = $this->forkSleepingChild();
+        $pid = $this->forkMasterLikeChild();
         file_put_contents($this->pidFile, (string) $pid);
 
         try {
@@ -258,7 +258,7 @@ final class ServerManagerTest extends TestCase
     public function testReloadSendsSIGUSR1(): void
     {
         $signalFile = $this->tmpDir . '/sigusr1_received';
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGUSR1, $signalFile);
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGUSR1, $signalFile);
         file_put_contents($this->pidFile, (string) $pid);
 
         // Give the child time to install the signal handler
@@ -282,7 +282,7 @@ final class ServerManagerTest extends TestCase
     public function testReloadGracefulSendsSIGUSR2(): void
     {
         $signalFile = $this->tmpDir . '/sigusr2_received';
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGUSR2, $signalFile);
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGUSR2, $signalFile);
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(200_000);
@@ -314,7 +314,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testGetStatusReturnsParsedContentFromStatusFile(): void
     {
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGIOT, $this->statusFile, "ignored header\nworker: running\nmemory: 42MB");
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGIOT, $this->statusFile, "ignored header\nworker: running\nmemory: 42MB");
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(200_000);
@@ -339,7 +339,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testGetStatusDeletesStatusFileAfterReading(): void
     {
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGIOT, $this->statusFile, "header\ndata");
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGIOT, $this->statusFile, "header\ndata");
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(200_000);
@@ -369,7 +369,7 @@ final class ServerManagerTest extends TestCase
     public function testGetConnectionsReturnsContentFromConnectionsFile(): void
     {
         $expectedContent = "127.0.0.1:54321\n127.0.0.1:54322";
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGIO, $this->connectionsFile, $expectedContent);
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGIO, $this->connectionsFile, $expectedContent);
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(200_000);
@@ -392,7 +392,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testGetConnectionsDeletesConnectionsFileAfterReading(): void
     {
-        $pid = $this->forkChildWithAsyncSignalHandler(SIGIO, $this->connectionsFile, "data");
+        $pid = $this->forkMasterLikeChildWithSignalHandler(SIGIO, $this->connectionsFile, "data");
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(200_000);
@@ -457,7 +457,7 @@ final class ServerManagerTest extends TestCase
      */
     public function testStartThrowsServerAlreadyRunningExceptionWhenRunning(): void
     {
-        $pid = $this->forkSleepingChild();
+        $pid = $this->forkMasterLikeChild();
         file_put_contents($this->pidFile, (string) $pid);
 
         usleep(100_000);
@@ -624,6 +624,60 @@ final class ServerManagerTest extends TestCase
     }
 
     /**
+     * Regression test for issue #584: `isRunning()` must reject a live
+     * plain PHP process when no fingerprint is present, instead of
+     * accepting it because its cmdline contains "php".
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsRunningWithoutFingerprintRejectsPlainPhpProcess(): void
+    {
+        $pid = $this->forkSleepingChild();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        // Ensure no fingerprint file exists.
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $this->assertFalse(
+                $this->manager->isRunning(),
+                'isRunning() must reject a plain PHP process without a fingerprint',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `isRunning()` without a
+     * fingerprint falls back to the strict cmdline check and accepts
+     * a process carrying the Workerman master title.
+     *
+     * @requires OS Linux
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testIsRunningWithoutFingerprintAcceptsMasterTitleProcess(): void
+    {
+        $pid = $this->forkChildWithMasterTitle();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $this->assertTrue(
+                $this->manager->isRunning(),
+                'isRunning() must accept a process carrying the Workerman master title',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
+        }
+    }
+
+    /**
      * Regression test for issue #327: `isRunning()` must reject a PID
      * whose fingerprint does not match, even if the PID is alive.
      *
@@ -661,43 +715,8 @@ final class ServerManagerTest extends TestCase
     }
 
     /**
-     * Regression test for issue #327: `isRunning()` must fall back to
-     * the legacy cmdline check when no fingerprint file is present.
-     *
-     * On Linux, the legacy check requires the cmdline to contain
-     * "WorkerMan" or "php". A forked child's cmdline contains "php",
-     * so the check returns true.
-     *
-     * @requires extension pcntl
-     * @requires extension posix
-     */
-    public function testIsRunningFallsBackToLegacyCheckWithoutFingerprint(): void
-    {
-        $pid = $this->forkSleepingChild();
-        file_put_contents($this->pidFile, (string) $pid);
-
-        // Ensure no fingerprint file exists.
-        $fingerprintPath = $this->pidFile . '.fingerprint';
-        @unlink($fingerprintPath);
-
-        try {
-            $this->assertTrue(
-                $this->manager->isRunning(),
-                'isRunning() must use legacy cmdline check when no fingerprint file is present',
-            );
-        } finally {
-            $this->killChildBlocking($pid);
-        }
-    }
-
-    /**
      * Regression test for issue #327: `stop()` must refuse to send
      * SIGINT to a PID whose fingerprint does not match.
-     *
-     * This is the core security test for the master signal path: an
-     * attacker writes a fake PID file pointing to an unrelated process,
-     * then the operator runs `stop`. The fingerprint check must prevent
-     * the signal from being sent.
      *
      * @requires extension pcntl
      * @requires extension posix
@@ -778,6 +797,156 @@ final class ServerManagerTest extends TestCase
         } finally {
             $this->killChildBlocking($pid);
             @unlink($fingerprintPath);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `stop()` must refuse to signal a
+     * plain PHP process (stale/reused PID) when no fingerprint exists.
+     *
+     * This is the stale-pid scenario: the master died, the PID was
+     * reassigned to an unrelated PHP process, and no fingerprint is
+     * available (e.g. the fingerprint file was not written). The signal
+     * must not be sent.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testStopRefusesToSignalPlainPhpProcessWithoutFingerprint(): void
+    {
+        $pid = $this->forkSleepingChild();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $thrown = false;
+            try {
+                $this->manager->stop();
+            } catch (\CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException) {
+                $thrown = true;
+            }
+
+            $this->assertTrue(
+                $thrown,
+                'stop() must throw ServerNotRunningException for a plain PHP process without a fingerprint',
+            );
+            $this->assertTrue(
+                $this->isAlive($pid),
+                'Plain PHP child must still be alive after stop() refused to signal',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `reload()` must refuse to signal a
+     * plain PHP process (stale/reused PID) when no fingerprint exists.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testReloadRefusesToSignalPlainPhpProcessWithoutFingerprint(): void
+    {
+        $pid = $this->forkSleepingChild();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $thrown = false;
+            try {
+                $this->manager->reload();
+            } catch (\CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException) {
+                $thrown = true;
+            }
+
+            $this->assertTrue(
+                $thrown,
+                'reload() must throw ServerNotRunningException for a plain PHP process without a fingerprint',
+            );
+            $this->assertTrue(
+                $this->isAlive($pid),
+                'Plain PHP child must still be alive after reload() refused to signal',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `getStatus()` must refuse to signal
+     * a plain PHP process (stale/reused PID) when no fingerprint exists.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testGetStatusRefusesToSignalPlainPhpProcessWithoutFingerprint(): void
+    {
+        $pid = $this->forkSleepingChild();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $thrown = false;
+            try {
+                $this->manager->getStatus();
+            } catch (\CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException) {
+                $thrown = true;
+            }
+
+            $this->assertTrue(
+                $thrown,
+                'getStatus() must throw ServerNotRunningException for a plain PHP process without a fingerprint',
+            );
+            $this->assertTrue(
+                $this->isAlive($pid),
+                'Plain PHP child must still be alive after getStatus() refused to signal',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
+        }
+    }
+
+    /**
+     * Regression test for issue #584: `getConnections()` must refuse to
+     * signal a plain PHP process (stale/reused PID) when no fingerprint
+     * exists.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testGetConnectionsRefusesToSignalPlainPhpProcessWithoutFingerprint(): void
+    {
+        $pid = $this->forkSleepingChild();
+        file_put_contents($this->pidFile, (string) $pid);
+
+        $fingerprintPath = $this->pidFile . '.fingerprint';
+        @unlink($fingerprintPath);
+
+        try {
+            $thrown = false;
+            try {
+                $this->manager->getConnections();
+            } catch (\CrazyGoat\WorkermanBundle\Exception\ServerNotRunningException) {
+                $thrown = true;
+            }
+
+            $this->assertTrue(
+                $thrown,
+                'getConnections() must throw ServerNotRunningException for a plain PHP process without a fingerprint',
+            );
+            $this->assertTrue(
+                $this->isAlive($pid),
+                'Plain PHP child must still be alive after getConnections() refused to signal',
+            );
+        } finally {
+            $this->killChildBlocking($pid);
         }
     }
 
@@ -884,8 +1053,101 @@ final class ServerManagerTest extends TestCase
     }
 
     /**
+     * Fork a child that looks like a Workerman master: it carries the
+     * master process title and a matching fingerprint is written by the
+     * parent. Used by signal-path tests so verification passes on every
+     * platform (fingerprint) and the strict cmdline fallback also passes
+     * on Linux (title).
+     */
+    private function forkMasterLikeChild(): int
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        $this->writeMatchingFingerprint($pid);
+
+        return $pid;
+    }
+
+    /**
+     * Fork a child that looks like a Workerman master AND installs an
+     * async signal handler for the given signal (same behaviors as
+     * {@see forkChildWithAsyncSignalHandler}).
+     */
+    private function forkMasterLikeChildWithSignalHandler(int $signal, string $signalFile, ?string $content = null): int
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            pcntl_async_signals(true);
+
+            pcntl_signal($signal, static function () use ($signalFile, $content): void {
+                file_put_contents($signalFile, $content ?? 'received');
+            });
+
+            for (;;) {
+                usleep(100_000);
+            }
+        }
+
+        $this->writeMatchingFingerprint($pid);
+
+        return $pid;
+    }
+
+    /**
+     * Fork a child that carries the Workerman master title but gets NO
+     * fingerprint — used by strict fallback tests (Linux cmdline check).
+     */
+    private function forkChildWithMasterTitle(): int
+    {
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->markTestSkipped('pcntl_fork failed');
+        }
+
+        if ($pid === 0) {
+            @cli_set_process_title('WorkerMan: master process  start_file=' . __FILE__);
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        return $pid;
+    }
+
+    /**
+     * Write a fingerprint file matching the given PID (current UID,
+     * real start time) next to the test PID file.
+     */
+    private function writeMatchingFingerprint(int $pid): void
+    {
+        $fingerprint = new \CrazyGoat\WorkermanBundle\MasterFingerprint(
+            pid: $pid,
+            startTime: \CrazyGoat\WorkermanBundle\MasterFingerprint::readStartTimeForPid($pid),
+            uid: \posix_getuid(),
+        );
+        $fingerprint->writeTo($this->pidFile . '.fingerprint');
+    }
+
+    /**
      * Fork a child that catches SIGINT and SIGQUIT with an empty handler
-     * (prevents default termination). Used for timeout tests.
+     * (prevents default termination). Used for timeout tests. A matching
+     * fingerprint is written so verification of the master identity
+     * passes on every platform (issue #584 fail-closed behaviour).
      */
     private function forkChildIgnoringSignals(): int
     {
@@ -905,13 +1167,17 @@ final class ServerManagerTest extends TestCase
             }
         }
 
+        $this->writeMatchingFingerprint($pid);
+
         return $pid;
     }
 
     /**
      * Fork a child that catches a signal with an empty handler (prevents
      * default termination but does not create the status/connections file).
-     * Used for getStatus/getConnections timeout tests.
+     * Used for getStatus/getConnections timeout tests. A matching
+     * fingerprint is written so verification passes on every platform
+     * (issue #584 fail-closed behaviour).
      */
     private function forkChildIgnoringSignal(int $signal): int
     {
@@ -929,44 +1195,7 @@ final class ServerManagerTest extends TestCase
             }
         }
 
-        return $pid;
-    }
-
-    /**
-     * Fork a child that installs an async signal handler for the given signal.
-     * When the signal is received, the handler writes content to $signalFile.
-     *
-     * Usage for reload tests (signal file as content marker):
-     *   $this->forkChildWithAsyncSignalHandler(SIGUSR1, '/tmp/signal_received');
-     *
-     * Usage for status/connections file tests (signal file is the target):
-     *   $this->forkChildWithAsyncSignalHandler(SIGIOT, '/tmp/status.file', "content");
-     *
-     * @param int        $signal       Signal to handle
-     * @param string     $signalFile   Path to write on signal receipt
-     * @param string|null $content     Content to write. When null, child creates the
-     *                                 file with 'received' as content (marker mode).
-     *                                 When non-null, that content is written.
-     */
-    private function forkChildWithAsyncSignalHandler(int $signal, string $signalFile, ?string $content = null): int
-    {
-        $pid = pcntl_fork();
-        if ($pid === -1) {
-            $this->markTestSkipped('pcntl_fork failed');
-        }
-
-        if ($pid === 0) {
-            // Enable async signal delivery so handlers fire immediately.
-            pcntl_async_signals(true);
-
-            pcntl_signal($signal, static function () use ($signalFile, $content): void {
-                file_put_contents($signalFile, $content ?? 'received');
-            });
-
-            for (;;) {
-                usleep(100_000);
-            }
-        }
+        $this->writeMatchingFingerprint($pid);
 
         return $pid;
     }

--- a/tests/WorkermanCommandTest.php
+++ b/tests/WorkermanCommandTest.php
@@ -91,6 +91,106 @@ final class WorkermanCommandTest extends KernelTestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
+    /**
+     * Regression test for issue #584: the real master process must
+     * record a fingerprint in daemon mode.
+     *
+     * The test server is started with `start -d` by phpunit's bootstrap,
+     * so this asserts the daemon-mode path end to end: the fingerprint
+     * sidecar exists next to the PID file, describes the same PID, and
+     * passes `ProcessInspector::matchesFingerprint()`.
+     */
+    public function testDaemonModeWritesMasterFingerprint(): void
+    {
+        $pidFile = self::bootKernel()->getProjectDir() . '/var/run/workerman.pid';
+        $fingerprintPath = $pidFile . '.fingerprint';
+
+        self::assertFileExists($pidFile, 'PID file must exist for the daemonised test server');
+        self::assertFileExists(
+            $fingerprintPath,
+            'Master fingerprint must be written in daemon mode (issue #584)',
+        );
+
+        $fingerprint = \CrazyGoat\WorkermanBundle\MasterFingerprint::readFrom($fingerprintPath);
+        self::assertNotNull($fingerprint, 'Fingerprint must be parseable');
+
+        $masterPid = (int) file_get_contents($pidFile);
+        self::assertSame($masterPid, $fingerprint->pid, 'Fingerprint PID must match the PID file');
+
+        $inspector = new \CrazyGoat\WorkermanBundle\ProcessInspector();
+        self::assertTrue(
+            $inspector->matchesFingerprint($masterPid, $fingerprint),
+            'Fingerprint must verify the real master process',
+        );
+    }
+
+    /**
+     * End-to-end regression test for issue #584: a stale pid file that
+     * points at a reused (unrelated) PID must not result in any signal
+     * being sent by the console `stop` command.
+     *
+     * Simulates the reported scenario: master died, kernel reassigned
+     * the PID to a plain PHP process, no fingerprint is present. The
+     * stop command must fail without signalling the foreign process.
+     *
+     * @requires extension pcntl
+     * @requires extension posix
+     */
+    public function testStopWithStalePidFileDoesNotSignalForeignProcess(): void
+    {
+        $pidFile = self::bootKernel()->getProjectDir() . '/var/run/workerman.pid';
+        $fingerprintPath = $pidFile . '.fingerprint';
+
+        self::assertFileExists($pidFile, 'Prerequisite: daemonised test server must be running');
+
+        $originalPid = (string) file_get_contents($pidFile);
+        $originalFingerprint = \is_file($fingerprintPath) ? (string) file_get_contents($fingerprintPath) : null;
+
+        // Foreign "reused" process: a plain PHP child whose cmdline
+        // contains "php" but not the Workerman master title.
+        $child = pcntl_fork();
+        if ($child === -1) {
+            self::markTestSkipped('pcntl_fork failed');
+        }
+        if ($child === 0) {
+            for (;;) {
+                sleep(1);
+            }
+        }
+
+        try {
+            file_put_contents($pidFile, (string) $child);
+            @\unlink($fingerprintPath);
+
+            \exec(
+                \workerman_create_console_command('stop') . ' 2>&1',
+                $output,
+                $exitCode,
+            );
+
+            self::assertNotSame(
+                0,
+                $exitCode,
+                'stop must fail when the PID file points at a non-master process',
+            );
+            self::assertTrue(
+                \posix_kill($child, 0),
+                'The foreign process must not have been signaled',
+            );
+        } finally {
+            // Restore the real server's pid/fingerprint files.
+            file_put_contents($pidFile, $originalPid);
+            if ($originalFingerprint !== null) {
+                file_put_contents($fingerprintPath, $originalFingerprint);
+            } else {
+                @\unlink($fingerprintPath);
+            }
+
+            \posix_kill($child, \SIGKILL);
+            \pcntl_waitpid($child, $status);
+        }
+    }
+
     private function createCommandTester(): CommandTester
     {
         $application = new Application(self::bootKernel());

--- a/tests/WorkermanCommandTest.php
+++ b/tests/WorkermanCommandTest.php
@@ -105,7 +105,9 @@ final class WorkermanCommandTest extends KernelTestCase
         $pidFile = self::bootKernel()->getProjectDir() . '/var/run/workerman.pid';
         $fingerprintPath = $pidFile . '.fingerprint';
 
-        self::assertFileExists($pidFile, 'PID file must exist for the daemonised test server');
+        if (!\is_file($pidFile)) {
+            self::markTestSkipped('Background daemon server is not running (started by phpunit bootstrap)');
+        }
         self::assertFileExists(
             $fingerprintPath,
             'Master fingerprint must be written in daemon mode (issue #584)',
@@ -141,7 +143,9 @@ final class WorkermanCommandTest extends KernelTestCase
         $pidFile = self::bootKernel()->getProjectDir() . '/var/run/workerman.pid';
         $fingerprintPath = $pidFile . '.fingerprint';
 
-        self::assertFileExists($pidFile, 'Prerequisite: daemonised test server must be running');
+        if (!\is_file($pidFile)) {
+            self::markTestSkipped('Background daemon server is not running (started by phpunit bootstrap)');
+        }
 
         $originalPid = (string) file_get_contents($pidFile);
         $originalFingerprint = \is_file($fingerprintPath) ? (string) file_get_contents($fingerprintPath) : null;


### PR DESCRIPTION
## Description

Closes #584

Fixes the vacuous master-process identification: `ProcessInspector::isMasterRunning()` accepted **any** process whose `/proc/<pid>/cmdline` contained the substring `php` (and returned `true` unconditionally when the cmdline was unreadable or on non-Linux hosts). Combined with daemon mode never writing a fingerprint, a stale or attacker-supplied pid file could make `stop()`/`reload()`/`status` signal an unrelated PHP process (PID reuse scenario).

## Changes

- **`ProcessInspector::isMasterRunning()`** — fallback now matches the process title Workerman assigns to its master (`WorkerMan: master process ...`), and **fails closed**: unverifiable PID ⇒ warning + `false` (no signal) instead of `true`.
- **`killOrphanedIntermediateFork()`** fallback tightened to the same master title.
- **`MasterWorker` (new)** — `Workerman\Worker` subclass; `saveMasterPid()` records the fingerprint from inside the real master process, closing the daemon-mode gap (`start -d` deployments now get a fingerprint).
- **`Runner`** runs `MasterWorker::runAll()`.
- **Doc fixes** — `docs/security.md` now describes the implemented check and real residual risk (previously documented a stricter check than the code performed).

## Tests

- `isMasterRunning()` rejects a real spawned plain-PHP process (no more `php` substring pass).
- Accepts a process carrying the real master title (Linux).
- `stop()`/`reload()`/`getStatus()`/`getConnections()` refuse to signal when verification fails (4 new tests).
- E2E: daemon-mode fingerprint is written and verifies (`testDaemonModeWritesMasterFingerprint`); stale pid file + console `stop` sends no signal (`testStopWithStalePidFileDoesNotSignalForeignProcess`).
- `MasterWorkerTest`: PID file + fingerprint written; write failure does not abort start.

## Changelog

Security entry added under [Unreleased] — harden master-process identification before sending signals (closes #584).

## Code Review

- [x] Passed subagent code review (2 passes; second: "Code looks good, no issues to fix.")
- [x] All review comments addressed (sprintf→concat, stream close, e2e skip guards, kill-assert polling)
- [x] `composer lint` and `composer test` pass locally (1623 tests)