### PR TITLE
fix(security): block static-file backup/credential extensions (closes #582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   left in `public/` (`index.php~`, `index.php.bak`, `config.php.save`,
   `config.inc`, `backup.sql`, …) disclosed full PHP source or credentials
   over HTTP. The denylist now also rejects names ending in `~` (vim/emacs
-  backups) and `#…#` (emacs autosaves), extends the blocked extension list
-  with `phps`, `inc`, `bak`, `orig`, `rej`, `save`, `swp`, `swo`, `tmp`,
-  `old`, `dist`, `sql`, `log`, `pem`, `key`, `crt`, `sqlite`, `sqlite3`,
-  `db`, and checks every dot-separated extension segment so a blocked
-  extension is caught wherever it appears (`x.phar.gz`, `x.php.txt`)
+  backups), extends the blocked extension list with `phps`, `inc`, `sql`,
+  `log`, `pem`, `key`, `crt`, `sqlite`, `sqlite3`, `db` — checked in every
+  dot-separated suffix segment so they are caught wherever they appear
+  (`x.phar.gz`, `x.php.txt`) — and with `bak`, `orig`, `rej`, `save`, `swp`,
+  `swo`, `tmp`, `old`, `dist` — blocked as the final extension of a file
+  only (`config.dist` is denied, an `assets.dist/` directory or an interior
+  `app.dist.js` segment is not)
   ([#582](https://github.com/crazy-goat/workerman-bundle/issues/582))
 
 - Harden master-process identification before sending signals. The legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Widen `StaticFilesMiddleware`'s built-in denylist to cover editor
+  backups, deploy residue and credential files, and make the check
+  compound-extension aware. In the default configuration the middleware
+  previously served any existing file whose final extension was not one of
+  `.php`, `.phar`, `.phtml`, so a single editor backup or interrupted save
+  left in `public/` (`index.php~`, `index.php.bak`, `config.php.save`,
+  `config.inc`, `backup.sql`, …) disclosed full PHP source or credentials
+  over HTTP. The denylist now also rejects names ending in `~` (vim/emacs
+  backups) and `#…#` (emacs autosaves), extends the blocked extension list
+  with `phps`, `inc`, `bak`, `orig`, `rej`, `save`, `swp`, `swo`, `tmp`,
+  `old`, `dist`, `sql`, `log`, `pem`, `key`, `crt`, `sqlite`, `sqlite3`,
+  `db`, and checks every dot-separated extension segment so a blocked
+  extension is caught wherever it appears (`x.phar.gz`, `x.php.txt`)
+  ([#582](https://github.com/crazy-goat/workerman-bundle/issues/582))
+
 - Harden master-process identification before sending signals. The legacy
   `/proc/$pid/cmdline` fallback accepted any process whose command line
   contained the substring `php` (and returned `true` unconditionally when

--- a/benchmarks/StaticFilesMiddlewareBench.php
+++ b/benchmarks/StaticFilesMiddlewareBench.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\WorkermanBundle\Benchmark;
+
+use CrazyGoat\WorkermanBundle\Http\Request;
+use CrazyGoat\WorkermanBundle\Middleware\StaticFilesMiddleware;
+use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Workerman\Protocols\Http\Response;
+
+/**
+ * Benchmarks StaticFilesMiddleware::__invoke — the static asset hot path.
+ *
+ * The per-path-component block check (denylist, backup-suffix rules,
+ * allowlist) runs on every request that resolves to an existing file, so
+ * regressions here translate directly into per-request latency for
+ * legitimate assets.
+ *
+ * @BeforeMethods("init")
+ * @AfterMethods("tearDown")
+ * @Revs(1000)
+ * @Iterations(5)
+ * @Warmup(1)
+ */
+final class StaticFilesMiddlewareBench
+{
+    private string $rootDirectory;
+    private StaticFilesMiddleware $middleware;
+    private StaticFilesMiddleware $allowlistMiddleware;
+    private Request $assetRequest;
+    private Request $nestedAssetRequest;
+    private Request $blockedBackupRequest;
+
+    public function init(): void
+    {
+        $this->rootDirectory = sys_get_temp_dir() . '/static-files-bench-' . bin2hex(random_bytes(6));
+        mkdir($this->rootDirectory, 0777, true);
+        mkdir($this->rootDirectory . '/assets', 0777, true);
+        file_put_contents($this->rootDirectory . '/style.css', 'body { color: red; }');
+        file_put_contents($this->rootDirectory . '/assets/logo.png', 'png');
+        file_put_contents($this->rootDirectory . '/index.php.bak', '<?php $DB_PASS = "s3cr3t";');
+
+        $this->middleware = new StaticFilesMiddleware($this->rootDirectory);
+        $this->allowlistMiddleware = new StaticFilesMiddleware(
+            $this->rootDirectory,
+            ['css', 'png'],
+        );
+
+        $this->assetRequest = new Request("GET /style.css HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        $this->nestedAssetRequest = new Request("GET /assets/logo.png HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        $this->blockedBackupRequest = new Request("GET /index.php.bak HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDirectory);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    public function benchServedAsset(): void
+    {
+        ($this->middleware)($this->assetRequest, $this->next(...));
+    }
+
+    public function benchServedNestedAsset(): void
+    {
+        ($this->middleware)($this->nestedAssetRequest, $this->next(...));
+    }
+
+    public function benchServedAssetWithAllowlist(): void
+    {
+        ($this->allowlistMiddleware)($this->assetRequest, $this->next(...));
+    }
+
+    public function benchBlockedBackupFile(): void
+    {
+        ($this->middleware)($this->blockedBackupRequest, $this->next(...));
+    }
+
+    private function next(): Response
+    {
+        return new Response(404);
+    }
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,10 +114,10 @@ Configure `trusted_hosts` when your application generates absolute URLs based on
 The following are **always blocked** (requests return 404):
 
 - **Dotfiles and dot-directories**: Any path component starting with `.` is rejected (e.g., `.env`, `.git/HEAD`, `.htaccess`, `.hidden/secret.txt`).
-- **Editor backup residue**: any name ending in `~` (vim/emacs backups, e.g. `index.php~`) and any name wrapped in `#...#` (emacs autosaves) is rejected.
-- **Source and executable extensions**: `.php`, `.phar`, `.phtml`, `.phps` and `.inc` files are never served. The check applies to every dot-separated extension segment, so a blocked extension is caught wherever it appears in a compound name (`x.php.bak`, `x.phar.gz`).
-- **Editor backup and deploy-residue extensions**: `.bak`, `.orig`, `.rej`, `.save`, `.swp`, `.swo`, `.tmp`, `.old`, `.dist`.
-- **Credentials, dumps and logs**: `.sql`, `.log`, `.pem`, `.key`, `.crt`, `.sqlite`, `.sqlite3`, `.db`.
+- **Editor backup residue**: any name ending in `~` (vim/emacs backups, e.g. `index.php~`) and any name wrapped in `#...#` (emacs autosaves) is rejected. The `#...#` rule is enforced defensively at the path-component level — normal HTTP path parsing already strips `#` fragments, so fragment-style names are in practice unreachable through URLs.
+- **Source and executable extensions**: `.php`, `.phar`, `.phtml`, `.phps` and `.inc` files are never served. The check applies to every dot-separated segment of the suffix, so a blocked extension is caught wherever it appears in a compound name (`x.php.bak`, `x.php.txt`, `x.phar.gz`).
+- **Credentials, dumps and logs**: `.sql`, `.log`, `.pem`, `.key`, `.crt`, `.sqlite`, `.sqlite3`, `.db` — also checked in every segment of a compound suffix.
+- **Editor backup and deploy-residue extensions**: `.bak`, `.orig`, `.rej`, `.save`, `.swp`, `.swo`, `.tmp`, `.old`, `.dist` — blocked as the final extension of a file only. An interior segment (`app.dist.js`) or a directory name (`assets.dist/`) is not a leak signal on its own; the contents are still covered by the rules above (and by the allowlist when configured).
 - **Well-known leak files**: `composer.json`, `composer.lock`, and `package.json` are blocked.
 - **Server configuration files**: `.htaccess` and `.htpasswd` are blocked.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,7 +114,10 @@ Configure `trusted_hosts` when your application generates absolute URLs based on
 The following are **always blocked** (requests return 404):
 
 - **Dotfiles and dot-directories**: Any path component starting with `.` is rejected (e.g., `.env`, `.git/HEAD`, `.htaccess`, `.hidden/secret.txt`).
-- **Executable file extensions**: `.php`, `.phar`, and `.phtml` files are never served.
+- **Editor backup residue**: any name ending in `~` (vim/emacs backups, e.g. `index.php~`) and any name wrapped in `#...#` (emacs autosaves) is rejected.
+- **Source and executable extensions**: `.php`, `.phar`, `.phtml`, `.phps` and `.inc` files are never served. The check applies to every dot-separated extension segment, so a blocked extension is caught wherever it appears in a compound name (`x.php.bak`, `x.phar.gz`).
+- **Editor backup and deploy-residue extensions**: `.bak`, `.orig`, `.rej`, `.save`, `.swp`, `.swo`, `.tmp`, `.old`, `.dist`.
+- **Credentials, dumps and logs**: `.sql`, `.log`, `.pem`, `.key`, `.crt`, `.sqlite`, `.sqlite3`, `.db`.
 - **Well-known leak files**: `composer.json`, `composer.lock`, and `package.json` are blocked.
 - **Server configuration files**: `.htaccess` and `.htpasswd` are blocked.
 
@@ -189,6 +192,7 @@ When `follow_symlinks` is `false` (default), any path component inside the root 
 ### Security Considerations
 
 - **Keep `$rootDirectory` isolated**: Point `$rootDirectory` to a dedicated public directory (e.g., `%kernel.project_dir%/public`). Never set it to the project root or a directory containing `.env`, source code, or VCS metadata.
+- **Prefer the allowlist over the denylist**: without `allowed_extensions`, the default posture is "serve everything except the denylist above" — safe for a directory that contains only public assets, but the denylist is a last line of defence, not a guarantee. Configure `allowed_extensions` to only permit the file types your application actually serves as static assets.
 - **Use the allowlist**: Configure `allowed_extensions` to only permit the file types your application actually serves as static assets.
 - **Disable symlinks**: Keep `$followSymlinks: false` (default) to prevent symlink-based file disclosure unless your application explicitly requires symlinks inside the public directory.
 - **404 for blocked files**: Denied files always return a 404 response (identical to non-existent files). This prevents attackers from probing whether a blocked file exists.

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -10,7 +10,37 @@ use Workerman\Protocols\Http\Response;
 
 final readonly class StaticFilesMiddleware implements MiddlewareInterface
 {
-    private const BLOCKED_EXTENSIONS = ['php', 'phar', 'phtml'];
+    private const BLOCKED_EXTENSIONS = [
+        // PHP source spellings — the middleware never executes PHP, so
+        // blocking these is about source disclosure, not execution.
+        'php',
+        'phar',
+        'phtml',
+        'phps',
+        'inc',
+        // Editor backup and deploy residue — vim/emacs backups, conflicted
+        // merges, interrupted saves. These appear in production directories
+        // without anyone intending them to, and often contain the source
+        // (and credentials) of the file they back up.
+        'bak',
+        'orig',
+        'rej',
+        'save',
+        'swp',
+        'swo',
+        'tmp',
+        'old',
+        'dist',
+        // Credentials, dumps and logs.
+        'sql',
+        'log',
+        'pem',
+        'key',
+        'crt',
+        'sqlite',
+        'sqlite3',
+        'db',
+    ];
 
     private const BLOCKED_FILENAMES = [
         '.htaccess',
@@ -139,9 +169,24 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
             return true;
         }
 
-        $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
-        if (in_array($ext, self::BLOCKED_EXTENSIONS, true)) {
+        // Editor backup residue: `index.php~` (vim/emacs) and
+        // `#index.php#` (emacs autosave) bypass the extension checks below.
+        if (str_ends_with($name, '~') || (str_starts_with($name, '#') && str_ends_with($name, '#'))) {
             return true;
+        }
+
+        $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        // Check every dot-separated extension segment of the full suffix
+        // (after the *first* dot), so a blocked extension is caught wherever
+        // it appears in a compound name (`x.php.bak`, `x.php.txt`,
+        // `x.phar.gz`), not only as the final extension (`pathinfo()`
+        // returns only the segment after the last dot).
+        $firstDot = strpos($name, '.');
+        $extensionChain = $firstDot === false ? '' : strtolower(substr($name, $firstDot + 1));
+        foreach ($extensionChain === '' ? [] : explode('.', $extensionChain) as $segment) {
+            if (in_array($segment, self::BLOCKED_EXTENSIONS, true)) {
+                return true;
+            }
         }
 
         if (in_array(strtolower($name), self::BLOCKED_FILENAMES, true)) {

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -10,18 +10,34 @@ use Workerman\Protocols\Http\Response;
 
 final readonly class StaticFilesMiddleware implements MiddlewareInterface
 {
-    private const BLOCKED_EXTENSIONS = [
+    private const LEAK_EXTENSIONS = [
         // PHP source spellings — the middleware never executes PHP, so
-        // blocking these is about source disclosure, not execution.
+        // blocking these is about source disclosure, not execution. A leak
+        // signal wherever it appears in a compound suffix (`x.php.bak`,
+        // `x.phar.gz`), for directories and files alike.
         'php',
         'phar',
         'phtml',
         'phps',
         'inc',
+        // Credentials, dumps and logs — also leak signals in any position.
+        'sql',
+        'log',
+        'pem',
+        'key',
+        'crt',
+        'sqlite',
+        'sqlite3',
+        'db',
+    ];
+
+    private const RESIDUE_EXTENSIONS = [
         // Editor backup and deploy residue — vim/emacs backups, conflicted
         // merges, interrupted saves. These appear in production directories
         // without anyone intending them to, and often contain the source
-        // (and credentials) of the file they back up.
+        // (and credentials) of the file they back up. A leak signal only as
+        // the *final* extension of a *file*: a directory named `assets.dist`
+        // or `backup.bak` is legitimate and must not deny its contents.
         'bak',
         'orig',
         'rej',
@@ -31,15 +47,6 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         'tmp',
         'old',
         'dist',
-        // Credentials, dumps and logs.
-        'sql',
-        'log',
-        'pem',
-        'key',
-        'crt',
-        'sqlite',
-        'sqlite3',
-        'db',
     ];
 
     private const BLOCKED_FILENAMES = [
@@ -154,8 +161,13 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         $relativePath = str_replace('\\', '/', $relativePath);
 
         $components = explode('/', ltrim($relativePath, '/'));
+        $componentPath = $this->rootRealPath;
         foreach ($components as $component) {
-            if ($component !== '' && $this->isComponentBlocked($component)) {
+            if ($component === '') {
+                continue;
+            }
+            $componentPath .= DIRECTORY_SEPARATOR . $component;
+            if ($this->isComponentBlocked($component, $componentPath)) {
                 return true;
             }
         }
@@ -163,7 +175,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         return false;
     }
 
-    private function isComponentBlocked(string $name): bool
+    private function isComponentBlocked(string $name, ?string $componentPath = null): bool
     {
         if (str_starts_with($name, '.')) {
             return true;
@@ -176,17 +188,32 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         }
 
         $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
-        // Check every dot-separated extension segment of the full suffix
-        // (after the *first* dot), so a blocked extension is caught wherever
-        // it appears in a compound name (`x.php.bak`, `x.php.txt`,
-        // `x.phar.gz`), not only as the final extension (`pathinfo()`
-        // returns only the segment after the last dot).
+
+        // Leak extensions are blocked wherever they appear in the suffix
+        // chain (after the *first* dot), so a blocked extension is caught
+        // in every position of a compound name (`x.php.bak`, `x.php.txt`,
+        // `x.phar.gz`) — `pathinfo()` alone only sees the segment after the
+        // last dot.
         $firstDot = strpos($name, '.');
-        $extensionChain = $firstDot === false ? '' : strtolower(substr($name, $firstDot + 1));
-        foreach ($extensionChain === '' ? [] : explode('.', $extensionChain) as $segment) {
-            if (in_array($segment, self::BLOCKED_EXTENSIONS, true)) {
-                return true;
+        if ($firstDot !== false) {
+            $chain = strtolower(substr($name, $firstDot + 1));
+            foreach (explode('.', $chain) as $segment) {
+                if (in_array($segment, self::LEAK_EXTENSIONS, true)) {
+                    return true;
+                }
             }
+        }
+
+        // Residue suffixes are a leak signal only as the final extension of
+        // a file. An interior or directory occurrence (`app.dist.js`,
+        // `assets.dist/`) is not — its contents are still protected by the
+        // checks above, and the allowlist below when configured. The
+        // directory stat is only paid when the final extension is a residue
+        // candidate, keeping the common asset path stat-free.
+        if (in_array($ext, self::RESIDUE_EXTENSIONS, true)
+            && ($componentPath === null || !is_dir($componentPath))
+        ) {
+            return true;
         }
 
         if (in_array(strtolower($name), self::BLOCKED_FILENAMES, true)) {

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -744,6 +744,25 @@ final class StaticFilesMiddlewareTest extends TestCase
             'PHP file' => ['test.php', 'php'],
             'PHAR file' => ['app.phar', 'phar'],
             'PHTML file' => ['index.phtml', 'phtml'],
+            'PHP source-highlight file' => ['index.phps', 'phps'],
+            'Legacy include file' => ['config.inc', 'inc'],
+            'Backup file' => ['index.php.bak', 'bak'],
+            'Patch original file' => ['index.php.orig', 'orig'],
+            'Rejected patch hunk' => ['index.php.rej', 'rej'],
+            'Interrupted save' => ['config.php.save', 'save'],
+            'Vim swap file' => ['index.php.swp', 'swp'],
+            'Vim swap file (newer)' => ['index.php.swo', 'swo'],
+            'Temp file' => ['config.php.tmp', 'tmp'],
+            'Old version' => ['config.php.old', 'old'],
+            'Distribution template' => ['config.inc.dist', 'dist'],
+            'SQL dump' => ['backup.sql', 'sql'],
+            'Log file' => ['app.log', 'log'],
+            'PEM private key' => ['id_rsa.pem', 'pem'],
+            'SSH key' => ['id_rsa.key', 'key'],
+            'Certificate' => ['server.crt', 'crt'],
+            'SQLite database' => ['app.sqlite', 'sqlite'],
+            'SQLite3 database' => ['app.sqlite3', 'sqlite3'],
+            'Database file' => ['app.db', 'db'],
         ];
     }
 
@@ -770,6 +789,139 @@ final class StaticFilesMiddlewareTest extends TestCase
             $this->assertEquals(404, $response->getStatusCode(), "Should return 404 for .$extension");
         } finally {
             unlink($file);
+        }
+    }
+
+    /**
+     * @dataProvider backupSuffixFileProvider
+     */
+    public function testBackupSuffixFilesBlockedReturn404(string $fileName): void
+    {
+        $file = $this->rootDirectory . '/' . $fileName;
+        file_put_contents($file, '<?php $DB_PASS = "s3cr3t";');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+            $request = $this->createRequest('/' . $fileName);
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, "Next should NOT be called for backup-suffix file: $fileName");
+            $this->assertEquals(404, $response->getStatusCode(), "Should return 404 for backup-suffix file: $fileName");
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function backupSuffixFileProvider(): array
+    {
+        return [
+            'vim backup of PHP file' => ['index.php~'],
+            'vim backup of stylesheet' => ['style.css~'],
+        ];
+    }
+
+    public function testEmacsAutosaveSuffixBlocked(): void
+    {
+        $middleware = new StaticFilesMiddleware($this->rootDirectory);
+        $reflection = new \ReflectionMethod($middleware, 'isComponentBlocked');
+
+        // Emacs autosaves are `#name#`. They cannot be addressed through the
+        // HTTP path (the underlying parser strips everything after `#`), but
+        // the rule is enforced defensively at the component level.
+        $this->assertTrue($reflection->invoke($middleware, '#index.php#'));
+        $this->assertTrue($reflection->invoke($middleware, '#style.css#'));
+    }
+
+    /**
+     * @dataProvider compoundExtensionProvider
+     */
+    public function testCompoundExtensionBlockedReturn404(string $fileName): void
+    {
+        $file = $this->rootDirectory . '/' . $fileName;
+        file_put_contents($file, '<?php $DB_PASS = "s3cr3t";');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+
+            $request = $this->createRequest('/' . $fileName);
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, "Next should NOT be called for compound-extension file: $fileName");
+            $this->assertEquals(404, $response->getStatusCode(), "Should return 404 for compound-extension file: $fileName");
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function compoundExtensionProvider(): array
+    {
+        return [
+            'PHP source with backup extension' => ['x.php.bak'],
+            'blocked segment before a safe extension' => ['x.php.txt'],
+            'compressed PHAR' => ['x.phar.gz'],
+            'PHP source with save suffix' => ['config.php.save'],
+            'PHTML with orig suffix' => ['index.phtml.orig'],
+            'compressed SQL dump' => ['secrets.sql.gz'],
+        ];
+    }
+
+    public function testLegitimateCompoundExtensionsStillServed(): void
+    {
+        $files = ['app.js.map', 'font.woff2', 'lib.tar.gz'];
+        foreach ($files as $fileName) {
+            file_put_contents($this->rootDirectory . '/' . $fileName, 'x');
+        }
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+            $next = fn(Request $req): Response => new Response(404);
+
+            foreach ($files as $fileName) {
+                $response = $middleware($this->createRequest('/' . $fileName), $next);
+                $this->assertSame(200, $response->getStatusCode(), "Legitimate asset should be served: $fileName");
+            }
+        } finally {
+            foreach ($files as $fileName) {
+                @unlink($this->rootDirectory . '/' . $fileName);
+            }
+        }
+    }
+
+    public function testBackupFileBlockedIsIndistinguishableFromMissingFile(): void
+    {
+        $blockedFile = $this->rootDirectory . '/index.php~';
+        file_put_contents($blockedFile, '<?php $DB_PASS = "s3cr3t";');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+            $next = fn(Request $req): Response => new Response(404);
+
+            $blockedResponse = $middleware($this->createRequest('/index.php~'), $next);
+            $missingResponse = $middleware($this->createRequest('/missing'), $next);
+
+            $this->assertSame($missingResponse->getStatusCode(), $blockedResponse->getStatusCode());
+            $this->assertSame($missingResponse->rawBody(), $blockedResponse->rawBody());
+        } finally {
+            unlink($blockedFile);
         }
     }
 

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -755,6 +755,8 @@ final class StaticFilesMiddlewareTest extends TestCase
             'Temp file' => ['config.php.tmp', 'tmp'],
             'Old version' => ['config.php.old', 'old'],
             'Distribution template' => ['config.inc.dist', 'dist'],
+            'Plain distribution template' => ['config.dist', 'dist'],
+            'Exported backup' => ['export.bak', 'bak'],
             'SQL dump' => ['backup.sql', 'sql'],
             'Log file' => ['app.log', 'log'],
             'PEM private key' => ['id_rsa.pem', 'pem'],
@@ -886,7 +888,7 @@ final class StaticFilesMiddlewareTest extends TestCase
 
     public function testLegitimateCompoundExtensionsStillServed(): void
     {
-        $files = ['app.js.map', 'font.woff2', 'lib.tar.gz'];
+        $files = ['app.js.map', 'font.woff2', 'lib.tar.gz', 'app.dist.js'];
         foreach ($files as $fileName) {
             file_put_contents($this->rootDirectory . '/' . $fileName, 'x');
         }
@@ -903,6 +905,35 @@ final class StaticFilesMiddlewareTest extends TestCase
             foreach ($files as $fileName) {
                 @unlink($this->rootDirectory . '/' . $fileName);
             }
+        }
+    }
+
+    public function testResidueSuffixDirectoriesAreNotBlocked(): void
+    {
+        $dir = $this->rootDirectory . '/assets.dist';
+        $backupDir = $this->rootDirectory . '/backup.bak';
+        mkdir($dir);
+        mkdir($backupDir);
+        file_put_contents($dir . '/logo.png', 'png');
+        file_put_contents($backupDir . '/style.css', 'css');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory);
+            $next = fn(Request $req): Response => new Response(404);
+
+            foreach (['/assets.dist/logo.png', '/backup.bak/style.css'] as $path) {
+                $response = $middleware($this->createRequest($path), $next);
+                $this->assertSame(
+                    200,
+                    $response->getStatusCode(),
+                    "Asset under a residue-suffix directory should be served: $path",
+                );
+            }
+        } finally {
+            @unlink($dir . '/logo.png');
+            @unlink($backupDir . '/style.css');
+            @rmdir($dir);
+            @rmdir($backupDir);
         }
     }
 


### PR DESCRIPTION
## Description

Closes #582

`StaticFilesMiddleware` served PHP source via backup/alternate extensions in the default configuration: the denylist was only `php`/`phar`/`phtml`, so `index.php~`, `index.php.bak`, `config.php.save`, `config.inc`, `backup.sql` etc. were served in full. Since the middleware never executes PHP, the purpose of the denylist is **source disclosure prevention** — judged against that, three entries were too narrow.

The sibling issue #580 (allowlist fails open for extensionless files) is already closed (#603), so this PR completes the pair.

## Changes

- **Widened denylist, split into two classes** (src/Middleware/StaticFilesMiddleware.php):
  - `LEAK_EXTENSIONS` — `php phar phtml phps inc sql log pem key crt sqlite sqlite3 db`: blocked in **any** dot-separated suffix segment, files and directories alike, so `x.php.bak`, `x.php.txt`, `x.phar.gz`, `secrets.sql.gz` are caught regardless of position.
  - `RESIDUE_EXTENSIONS` — `bak orig rej save swp swo tmp old dist`: blocked only as the **final extension of a file**, so `config.dist` is denied but `app.dist.js` (interior segment) and `assets.dist/` (directory) stay servable. The directory stat is lazy — only paid when the final extension is a residue candidate, keeping the common asset path stat-free.
- **Backup-suffix rule**: names ending in `~` (vim/emacs) and wrapped in `#…#` (emacs autosaves) are rejected. The `#…#` rule is defensive — the HTTP parser strips `#` fragments anyway (tested at component level).
- **docs/security.md**: Built-in Denylist section now lists the full rule set; Security Considerations note the default posture and recommend the allowlist.
- **Tests** (tests/StaticFilesMiddlewareTest.php, +5 tests / 22 new provider rows): backup suffixes, compound leaks, residue files vs residue directories, legitimate compound assets (`app.js.map`, `font.woff2`, `lib.tar.gz`, `app.dist.js`), 404 indistinguishability, denylist-over-allowlist precedence.
- **New benchmarks/StaticFilesMiddlewareBench.php** — static asset hot path.

## Changelog

Security entry added under [Unreleased] (Keep a Changelog), flagged as a security fix.

## Code Review

- [x] Passed subagent code review (2 rounds; round 1 major finding — over-blocking of `app.dist.js`/dotted directories — fixed via the leak/residue split; round 2: "Code looks good, no issues to fix")
- [x] All review comments addressed

## Bench numbers (StaticFilesMiddlewareBench, mode, 1000 revs × 5 its)

| subject | before | after |
|---|---|---|
| benchServedAsset | 1.397μs | 1.572μs (+12.5%) |
| benchServedNestedAsset | 1.394μs | 1.648μs (+18%) |
| benchServedAssetWithAllowlist | 1.502μs | 1.541μs (+2.6%) |
| benchBlockedBackupFile | 1.339μs (served) | 0.713μs (blocked, early return) |

Acceptable cost for closing the disclosure hole; hot path stays stat-free for non-residue assets.