### PR TITLE
fix(security): check cache directory permissions and ownership before require (closes #586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Fix the config-cache permission guard so it checks the object that
+  actually governs file replacement: the **containing directory**. The
+  previous check only examined the cache file's world-writable bit, but on
+  POSIX replacing a file requires write permission on the directory, not on
+  the file — so an attacker with a writable cache directory (e.g. under
+  `umask 0000`) could `unlink` the cache file, write their own, and have it
+  `require`d at boot. Loading is now refused when the cache directory is
+  world-writable, when it is group-writable by a group the process does not
+  belong to, or when the cache file is not owned by the process's effective
+  user ID (a replaced file would be owned by the attacker). The original
+  world-writable-file check is kept as a secondary signal, and metadata that
+  cannot be read (ACLs, non-POSIX filesystems) now logs a warning naming the
+  path instead of silently proceeding
+  ([#586](https://github.com/crazy-goat/workerman-bundle/issues/586))
+
 - Widen `StaticFilesMiddleware`'s built-in denylist to cover editor
   backups, deploy residue and credential files, and make the check
   compound-extension aware. In the default configuration the middleware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path instead of silently proceeding
   ([#586](https://github.com/crazy-goat/workerman-bundle/issues/586))
 
+- **Behaviour change**: because the cache file must now be owned by the
+  process that loads it (see previous entry), a config cache warmed up by
+  a different user than the runtime user (e.g. deploy user vs `www-data`)
+  is **refused at boot** instead of being loaded silently. Warm up with
+  the runtime user or `chown` the cache file to that user after warm-up
+  ([#586](https://github.com/crazy-goat/workerman-bundle/issues/586))
+
 - Widen `StaticFilesMiddleware`'s built-in denylist to cover editor
   backups, deploy residue and credential files, and make the check
   compound-extension aware. In the default configuration the middleware

--- a/docs/security.md
+++ b/docs/security.md
@@ -385,8 +385,9 @@ containing directory** before loading it:
   itself world-writable is **refused**.
 - **Unreadable metadata**: If the file or directory metadata cannot be read
   (e.g. on filesystems that do not report permissions), a **warning naming
-  the path is logged** and loading proceeds — the check degrades loudly
-  instead of silently disappearing.
+  the path is emitted** — logged via the PSR-3 logger when one is configured,
+  raised as an `E_USER_WARNING` otherwise — and loading proceeds; the check
+  degrades loudly instead of silently disappearing.
 - **Scope**: The checks cover POSIX owner and permission bits only. They do
   not cover ACLs, extended attributes, or filesystems that do not support
   POSIX permissions.

--- a/docs/security.md
+++ b/docs/security.md
@@ -373,9 +373,10 @@ containing directory** before loading it:
   file requires write permission on the directory, not on the file itself,
   so the directory is the primary object checked.
 - **Directory group check**: If the cache directory is group-writable
-  (`g+w`) by a group the current process does not belong to, loading is
-  **refused**. A group-writable directory whose group is the process's own
-  group (e.g. `0750` combined with `chgrp` to the webserver group) is
+  (`g+w`) by a group the current process does not belong to — neither its
+  effective group nor any supplementary group — loading is **refused**. A
+  group-writable directory whose group is a group the process belongs to
+  (e.g. `0770` combined with `chgrp` to the webserver group) is
   accepted.
 - **Ownership check**: If the cache file is not owned by the process's
   effective user ID, loading is **refused** — a file another user could
@@ -412,6 +413,22 @@ Or, if the web server and CLI users differ, use a shared group:
 ```bash
 chmod 0750 var/cache/
 chgrp <webserver-group> var/cache/
+```
+
+Because the cache file must also be **owned by the runtime user** (see the
+Ownership check above), a cache warmed up by a different user — e.g. a
+deploy script running as `root` or a CI user, with the server later
+running as `www-data` — is refused at boot. Either warm up with the
+runtime user:
+
+```bash
+sudo -u <runtime-user> bin/console cache:warmup
+```
+
+or re-own the cache file after warm-up:
+
+```bash
+chown <runtime-user> var/cache/workerman/config.cache.php
 ```
 
 ## SFX Checksum Requirement

--- a/docs/security.md
+++ b/docs/security.md
@@ -365,15 +365,38 @@ The configuration cache file is a PHP file that gets executed. Any attacker who 
 
 ### Permission Validation
 
-To mitigate misconfiguration, the bundle validates the cache file permissions before loading it:
+To mitigate misconfiguration, the bundle validates the cache file **and its
+containing directory** before loading it:
 
-- **World-writable check**: If the cache file is world-writable (permissions include `o+w`), loading is **refused** with a clear error message.
-- **Scope**: The check covers POSIX file permissions only. It does not cover ACLs, extended attributes, or filesystems that do not support POSIX permissions.
+- **Directory write check**: If the cache directory is world-writable
+  (permissions include `o+w`), loading is **refused**. Replacing the cache
+  file requires write permission on the directory, not on the file itself,
+  so the directory is the primary object checked.
+- **Directory group check**: If the cache directory is group-writable
+  (`g+w`) by a group the current process does not belong to, loading is
+  **refused**. A group-writable directory whose group is the process's own
+  group (e.g. `0750` combined with `chgrp` to the webserver group) is
+  accepted.
+- **Ownership check**: If the cache file is not owned by the process's
+  effective user ID, loading is **refused** — a file another user could
+  replace would be owned by that user.
+- **World-writable file check**: As a secondary signal, a cache file that is
+  itself world-writable is **refused**.
+- **Unreadable metadata**: If the file or directory metadata cannot be read
+  (e.g. on filesystems that do not report permissions), a **warning naming
+  the path is logged** and loading proceeds — the check degrades loudly
+  instead of silently disappearing.
+- **Scope**: The checks cover POSIX owner and permission bits only. They do
+  not cover ACLs, extended attributes, or filesystems that do not support
+  POSIX permissions.
+- **Ownership requirement**: the cache file must be written and loaded by
+  the same user. Warm up the cache with the runtime user, or `chown` the
+  cache file to that user after warm-up.
 
 ### When this matters
 
 - **Multi-tenant environments**: Shared hosting or CI runners where the cache directory might be accessible to other users.
-- **Containerised deployments**: Containers with overly permissive `umask` settings (e.g., `umask 0000`) can produce world-writable cache files.
+- **Containerised deployments**: Containers with overly permissive `umask` settings (e.g., `umask 0000`) can produce world-writable cache files and directories.
 - **Development setups**: Developers running with `umask 0000` or cache directories created with `0777` permissions.
 
 ### Remediation

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\WorkermanBundle;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
@@ -15,8 +16,12 @@ final class ConfigLoader implements CacheWarmerInterface
     private readonly ConfigCache $cache;
     private readonly string $yamlConfigFilePath;
 
-    public function __construct(string $projectDir, string $cacheDir, bool $isDebug)
-    {
+    public function __construct(
+        string $projectDir,
+        string $cacheDir,
+        bool $isDebug,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
         $this->yamlConfigFilePath = sprintf('%s/config/packages/workerman.yaml', $projectDir);
         $cacheConfigFilePath = sprintf('%s/workerman/config.cache.php', $cacheDir);
         $this->cache = new ConfigCache($cacheConfigFilePath, $isDebug);
@@ -93,35 +98,97 @@ final class ConfigLoader implements CacheWarmerInterface
     }
 
     /**
-     * Validate that the cached configuration file has safe permissions.
+     * Validate that the cached configuration file and its containing directory
+     * have safe permissions.
      *
-     * The config cache file is a PHP file that gets {@see require}d. If the
-     * cache directory is misconfigured as world-writable, an attacker who can
-     * write to the cache directory achieves arbitrary code execution at boot.
+     * The config cache file is a PHP file that gets {@see require}d. An
+     * attacker who can write to the cache directory can replace the file and
+     * achieve arbitrary code execution at boot. On POSIX, replacing a file
+     * requires write permission on the containing directory — not on the file
+     * — so the directory is the primary object to check.
      *
-     * This check rejects cache files that are world-writable (the "other"
-     * write bit, 0002). World-readable files are accepted — PHP cache files
-     * are commonly world-readable in production. The check is best-effort:
-     * it does not cover ACLs, extended attributes, or filesystems that do
-     * not support POSIX permissions.
+     * The checks, in order:
+     * 1. the containing directory must not be world-writable;
+     * 2. the containing directory must not be group-writable by a group other
+     *    than the process's effective group;
+     * 3. the cache file must be owned by the process's effective user
+     *    (a file replaced by an attacker would be owned by the attacker);
+     * 4. the cache file itself must not be world-writable (secondary signal).
      *
-     * @throws \RuntimeException if the cache file is world-writable
+     * If the metadata cannot be read, a warning naming the path is logged and
+     * loading proceeds (fail-open with a signal) — the check must not
+     * silently disappear on filesystems that do not report permissions.
+     * The check is best-effort: it does not cover ACLs, extended attributes,
+     * or filesystems that do not support POSIX permissions.
+     *
+     * @throws \RuntimeException if the cache directory or file is unsafe
      */
     private function validateCacheFilePermissions(string $cachePath): void
     {
-        $perms = fileperms($cachePath);
-        if ($perms === false) {
-            return; // Cannot check permissions on this filesystem
+        $cacheDir = \dirname($cachePath);
+
+        $filePerms = @fileperms($cachePath);
+        $dirPerms = @fileperms($cacheDir);
+        $fileOwner = @fileowner($cachePath);
+        $dirGroup = @filegroup($cacheDir);
+
+        if ($filePerms === false || $dirPerms === false || $fileOwner === false || $dirGroup === false) {
+            $this->logger?->warning(sprintf(
+                'Cannot verify permissions of the configuration cache file "%s"; loading it without a permission check',
+                $cachePath,
+            ), [
+                'path' => $cachePath,
+            ]);
+
+            return;
         }
 
-        // Check world-writable bit (0002)
-        if (($perms & 0002) !== 0) {
+        // 1. Replacing the cache file only needs write access to the directory.
+        if (($dirPerms & 0002) !== 0) {
+            throw new \RuntimeException(sprintf(
+                'The configuration cache directory "%s" is world-writable (%o). An attacker who can write '
+                . 'to the cache directory can replace the cache file and achieve arbitrary code execution at '
+                . 'boot. Ensure the cache directory is not writable by other users (e.g., chmod 0700 or 0750).',
+                $cacheDir,
+                $dirPerms & 0777,
+            ));
+        }
+
+        // 2. A group-writable directory is only acceptable when the group is the process's own.
+        if (($dirPerms & 0020) !== 0 && $dirGroup !== posix_getegid()) {
+            throw new \RuntimeException(sprintf(
+                'The configuration cache directory "%s" is writable by group %d (%o), which is not the '
+                . 'current process group (gid %d). Another service in that group could replace the cache '
+                . 'file. Ensure the directory is not group-writable by other groups (e.g., chmod 0750 and '
+                . 'chgrp to the process group).',
+                $cacheDir,
+                $dirGroup,
+                $dirPerms & 0777,
+                posix_getegid(),
+            ));
+        }
+
+        // 3. Ownership: a file replaced by another user would be owned by that user.
+        if ($fileOwner !== posix_geteuid()) {
+            throw new \RuntimeException(sprintf(
+                'The configuration cache file "%s" is owned by uid %d, not by the current process user '
+                . '(uid %d). The file may have been replaced by another user. Ensure the cache is written '
+                . 'by the same user that loads it (e.g., warm up with the runtime user, or chown the cache '
+                . 'to that user).',
+                $cachePath,
+                $fileOwner,
+                posix_geteuid(),
+            ));
+        }
+
+        // 4. World-writable file: secondary signal, kept from the original check.
+        if (($filePerms & 0002) !== 0) {
             throw new \RuntimeException(sprintf(
                 'The configuration cache file "%s" is world-writable (%o). '
                 . 'This is a security risk: the cache directory must not be writable by untrusted users. '
                 . 'Ensure the cache directory has restrictive permissions (e.g., 0700 or 0750).',
                 $cachePath,
-                $perms & 0777,
+                $filePerms & 0777,
             ));
         }
     }

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -109,88 +109,153 @@ final class ConfigLoader implements CacheWarmerInterface
      *
      * The checks, in order:
      * 1. the containing directory must not be world-writable;
-     * 2. the containing directory must not be group-writable by a group other
-     *    than the process's effective group;
+     * 2. the containing directory must not be group-writable by a group the
+     *    process does not belong to (effective group plus supplementary
+     *    groups are allowed);
      * 3. the cache file must be owned by the process's effective user
      *    (a file replaced by an attacker would be owned by the attacker);
      * 4. the cache file itself must not be world-writable (secondary signal).
      *
-     * If the metadata cannot be read, a warning naming the path is logged and
-     * loading proceeds (fail-open with a signal) — the check must not
-     * silently disappear on filesystems that do not report permissions.
-     * The check is best-effort: it does not cover ACLs, extended attributes,
-     * or filesystems that do not support POSIX permissions.
+     * If the metadata cannot be read, a warning naming the path is emitted
+     * (logged via the PSR-3 logger when one is available, otherwise raised as
+     * an \E_USER_WARNING) and loading proceeds (fail-open with a signal) — the
+     * check must not silently disappear on filesystems that do not report
+     * permissions. The check is best-effort: it does not cover ACLs, extended
+     * attributes, or filesystems that do not support POSIX permissions.
      *
      * @throws \RuntimeException if the cache directory or file is unsafe
      */
     private function validateCacheFilePermissions(string $cachePath): void
     {
         $cacheDir = \dirname($cachePath);
+        $groups = posix_getgroups();
 
-        $filePerms = @fileperms($cachePath);
-        $dirPerms = @fileperms($cacheDir);
-        $fileOwner = @fileowner($cachePath);
-        $dirGroup = @filegroup($cacheDir);
+        $verdict = self::checkCacheFilePermissions(
+            $cachePath,
+            @fileperms($cacheDir),
+            @filegroup($cacheDir),
+            @fileperms($cachePath),
+            @fileowner($cachePath),
+            posix_geteuid(),
+            [posix_getegid(), ...($groups === false ? [] : $groups)],
+        );
 
-        if ($filePerms === false || $dirPerms === false || $fileOwner === false || $dirGroup === false) {
-            $this->logger?->warning(sprintf(
-                'Cannot verify permissions of the configuration cache file "%s"; loading it without a permission check',
-                $cachePath,
-            ), [
-                'path' => $cachePath,
-            ]);
-
-            return;
+        if ($verdict['error'] !== null) {
+            throw new \RuntimeException($verdict['error']);
         }
+
+        if ($verdict['warn'] !== null) {
+            if ($this->logger instanceof \Psr\Log\LoggerInterface) {
+                $this->logger->warning($verdict['warn'], ['path' => $cachePath]);
+            } else {
+                trigger_error($verdict['warn'], \E_USER_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Pure permission decision for a cached configuration file.
+     *
+     * Concentrates every permission check in one place so that all branches
+     * can be unit-tested without root privileges (no real chown/chgrp needed).
+     *
+     * @internal
+     *
+     * @param int|false $dirPerms fileperms() of the containing directory
+     * @param int|false $dirGroup filegroup() of the containing directory
+     * @param int|false $filePerms fileperms() of the cache file
+     * @param int|false $fileOwner fileowner() of the cache file
+     * @param int $euid effective user id of the loading process
+     * @param int[] $processGroups every group the loading process belongs to
+     *                             (effective group id plus supplementary groups)
+     * @return array{warn: string|null, error: string|null} both null when the
+     *         file is safe to load; `warn` set (and no `error`) when the
+     *         metadata is unreadable and loading should proceed with a warning;
+     *         `error` set (and no `warn`) when loading must be refused
+     */
+    public static function checkCacheFilePermissions(
+        string $cachePath,
+        int|false $dirPerms,
+        int|false $dirGroup,
+        int|false $filePerms,
+        int|false $fileOwner,
+        int $euid,
+        array $processGroups,
+    ): array {
+        if ($dirPerms === false || $dirGroup === false || $filePerms === false || $fileOwner === false) {
+            return [
+                'warn' => sprintf(
+                    'Cannot verify permissions of the configuration cache file "%s"; loading it without a permission check',
+                    $cachePath,
+                ),
+                'error' => null,
+            ];
+        }
+
+        $cacheDir = \dirname($cachePath);
 
         // 1. Replacing the cache file only needs write access to the directory.
         if (($dirPerms & 0002) !== 0) {
-            throw new \RuntimeException(sprintf(
-                'The configuration cache directory "%s" is world-writable (%o). An attacker who can write '
-                . 'to the cache directory can replace the cache file and achieve arbitrary code execution at '
-                . 'boot. Ensure the cache directory is not writable by other users (e.g., chmod 0700 or 0750).',
-                $cacheDir,
-                $dirPerms & 0777,
-            ));
+            return [
+                'warn' => null,
+                'error' => sprintf(
+                    'The configuration cache directory "%s" is world-writable (%o). An attacker who can write '
+                    . 'to the cache directory can replace the cache file and achieve arbitrary code execution at '
+                    . 'boot. Ensure the cache directory is not writable by other users (e.g., chmod 0700 or 0750).',
+                    $cacheDir,
+                    $dirPerms & 0777,
+                ),
+            ];
         }
 
-        // 2. A group-writable directory is only acceptable when the group is the process's own.
-        if (($dirPerms & 0020) !== 0 && $dirGroup !== posix_getegid()) {
-            throw new \RuntimeException(sprintf(
-                'The configuration cache directory "%s" is writable by group %d (%o), which is not the '
-                . 'current process group (gid %d). Another service in that group could replace the cache '
-                . 'file. Ensure the directory is not group-writable by other groups (e.g., chmod 0750 and '
-                . 'chgrp to the process group).',
-                $cacheDir,
-                $dirGroup,
-                $dirPerms & 0777,
-                posix_getegid(),
-            ));
+        // 2. A group-writable directory is only acceptable when the group is one of the process's own.
+        if (($dirPerms & 0020) !== 0 && !\in_array($dirGroup, $processGroups, true)) {
+            return [
+                'warn' => null,
+                'error' => sprintf(
+                    'The configuration cache directory "%s" is writable by group %d (%o), which is not a group '
+                    . 'the current process belongs to (process groups: %s). Another service in that group could '
+                    . 'replace the cache file. Ensure the directory is not group-writable by other groups '
+                    . '(e.g., chmod 0750 and chgrp to a group of the process).',
+                    $cacheDir,
+                    $dirGroup,
+                    $dirPerms & 0777,
+                    implode(', ', $processGroups),
+                ),
+            ];
         }
 
         // 3. Ownership: a file replaced by another user would be owned by that user.
-        if ($fileOwner !== posix_geteuid()) {
-            throw new \RuntimeException(sprintf(
-                'The configuration cache file "%s" is owned by uid %d, not by the current process user '
-                . '(uid %d). The file may have been replaced by another user. Ensure the cache is written '
-                . 'by the same user that loads it (e.g., warm up with the runtime user, or chown the cache '
-                . 'to that user).',
-                $cachePath,
-                $fileOwner,
-                posix_geteuid(),
-            ));
+        if ($fileOwner !== $euid) {
+            return [
+                'warn' => null,
+                'error' => sprintf(
+                    'The configuration cache file "%s" is owned by uid %d, not by the current process user '
+                    . '(uid %d). The file may have been replaced by another user. Ensure the cache is written '
+                    . 'by the same user that loads it (e.g., warm up with the runtime user, or chown the cache '
+                    . 'to that user).',
+                    $cachePath,
+                    $fileOwner,
+                    $euid,
+                ),
+            ];
         }
 
         // 4. World-writable file: secondary signal, kept from the original check.
         if (($filePerms & 0002) !== 0) {
-            throw new \RuntimeException(sprintf(
-                'The configuration cache file "%s" is world-writable (%o). '
-                . 'This is a security risk: the cache directory must not be writable by untrusted users. '
-                . 'Ensure the cache directory has restrictive permissions (e.g., 0700 or 0750).',
-                $cachePath,
-                $filePerms & 0777,
-            ));
+            return [
+                'warn' => null,
+                'error' => sprintf(
+                    'The configuration cache file "%s" is world-writable (%o). '
+                    . 'This is a security risk: the cache directory must not be writable by untrusted users. '
+                    . 'Ensure the cache directory has restrictive permissions (e.g., 0700 or 0750).',
+                    $cachePath,
+                    $filePerms & 0777,
+                ),
+            ];
         }
+
+        return ['warn' => null, 'error' => null];
     }
 
     /** @return array<string, mixed[]> */

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -69,6 +69,7 @@ final readonly class ServicesConfigurator
         $container
             ->register('workerman.config_loader', ConfigLoader::class)
             ->setPublic(true)
+            ->setAutowired(true)
             ->addMethodCall('setWorkermanConfig', [$config])
             ->addMethodCall('setBuildConfig', [$config['build']])
             ->addTag('kernel.cache_warmer')

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\WorkermanBundle\Test;
 
 use CrazyGoat\WorkermanBundle\ConfigLoader;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 
 final class ConfigLoaderTest extends TestCase
 {
@@ -275,6 +276,163 @@ final class ConfigLoaderTest extends TestCase
         // Create loader B (no config set via setters) — should load from cache
         $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
         $this->assertSame($config, $loaderB->getWorkermanConfig());
+    }
+
+    public function testLoadFromCacheRefusesWorldWritableCacheDirectory(): void
+    {
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $loaderA->setWorkermanConfig(['server' => ['listen' => 'http://0.0.0.0:8080']]);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+        $cacheDir = dirname($cachePath);
+
+        // The file itself is safe (0644); only the containing directory is world-writable.
+        chmod($cachePath, 0644);
+        chmod($cacheDir, 0777);
+
+        // Create loader B (no config set via setters) — should reject the world-writable directory
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('#configuration cache directory ".*" is world-writable #');
+
+        $loaderB->getWorkermanConfig();
+    }
+
+    public function testLoadFromCacheRefusesGroupWritableCacheDirectoryOfAnotherGroup(): void
+    {
+        $foreignGroup = $this->findForeignGroup();
+        if ($foreignGroup === null) {
+            $this->markTestSkipped('No supplementary group available to chgrp to');
+        }
+
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $loaderA->setWorkermanConfig(['server' => ['listen' => 'http://0.0.0.0:8080']]);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+        $cacheDir = dirname($cachePath);
+
+        // Group-writable, but not world-writable; the file itself stays safe.
+        chmod($cachePath, 0644);
+        chmod($cacheDir, 0770);
+
+        if (!chgrp($cacheDir, $foreignGroup)) {
+            $this->markTestSkipped('chgrp to a group other than the process group requires membership');
+        }
+
+        // Create loader B (no config set via setters) — should reject the foreign-group directory
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('#configuration cache directory ".*" is writable by group #');
+
+        $loaderB->getWorkermanConfig();
+    }
+
+    public function testLoadFromCacheRefusesCacheFileOwnedByAnotherUser(): void
+    {
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $loaderA->setWorkermanConfig(['server' => ['listen' => 'http://0.0.0.0:8080']]);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+
+        chmod($cachePath, 0644);
+        if (!@chown($cachePath, 65534)) {
+            $this->markTestSkipped('chown to another user requires root privileges');
+        }
+
+        // Create loader B (no config set via setters) — should reject the foreign-owned file
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('#configuration cache file ".*" is owned by uid #');
+
+        $loaderB->getWorkermanConfig();
+    }
+
+    public function testLoadFromCacheWithSecureDirectoryAndFilePermissionsStillWorks(): void
+    {
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $config = [
+            'server' => ['listen' => 'http://0.0.0.0:8080'],
+        ];
+        $loaderA->setWorkermanConfig($config);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+        $cacheDir = dirname($cachePath);
+
+        // 0750 directory, 0644 file, owned by the process user — must load.
+        chmod($cacheDir, 0750);
+        chmod($cachePath, 0644);
+
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $this->assertSame($config, $loaderB->getWorkermanConfig());
+
+        // 0700 directory also works.
+        chmod($cacheDir, 0700);
+
+        $loaderC = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $this->assertSame($config, $loaderC->getWorkermanConfig());
+    }
+
+    public function testValidateCacheFilePermissionsLogsWarningWhenMetadataIsUnreadable(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var array<int, array{level: string, message: string}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string) $message];
+            }
+        };
+
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true, $logger);
+
+        $missingPath = $this->tempDir . '/cache/workerman/does-not-exist.php';
+        (new \ReflectionMethod(ConfigLoader::class, 'validateCacheFilePermissions'))
+            ->invoke($loader, $missingPath);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+        $this->assertStringContainsString($missingPath, $logger->records[0]['message']);
+    }
+
+    private function findForeignGroup(): ?int
+    {
+        $groups = posix_getgroups();
+        if ($groups === false) {
+            return null;
+        }
+
+        $egid = posix_getegid();
+        foreach ($groups as $gid) {
+            if ($gid !== $egid) {
+                return $gid;
+            }
+        }
+
+        return null;
     }
 
     public function testLoadFreshThrowsWhenNoConfigAndNoCache(): void

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -491,8 +491,8 @@ final class ConfigLoaderTest extends TestCase
         $triggered = null;
 
         set_error_handler(
-            static function (int $severity, string $message) use (&$triggered, $missingPath): bool {
-                $triggered = $missingPath;
+            static function (int $severity, string $message) use (&$triggered): bool {
+                $triggered = $message;
 
                 return true;
             },
@@ -506,7 +506,8 @@ final class ConfigLoaderTest extends TestCase
             restore_error_handler();
         }
 
-        $this->assertSame($missingPath, $triggered);
+        $this->assertIsString($triggered);
+        $this->assertStringContainsString($missingPath, $triggered);
     }
 
     public function testCheckCacheFilePermissionsAcceptsSecurePermissions(): void

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -304,11 +304,75 @@ final class ConfigLoaderTest extends TestCase
         $loaderB->getWorkermanConfig();
     }
 
-    public function testLoadFromCacheRefusesGroupWritableCacheDirectoryOfAnotherGroup(): void
+    public function testLoadFromCacheAcceptsGroupWritableCacheDirectoryOfSupplementaryGroup(): void
+    {
+        $supplementaryGroup = $this->findSupplementaryGroup();
+        if ($supplementaryGroup === null) {
+            $this->markTestSkipped('No supplementary group available to chgrp to');
+        }
+
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $config = [
+            'server' => ['listen' => 'http://0.0.0.0:8080'],
+        ];
+        $loaderA->setWorkermanConfig($config);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+        $cacheDir = dirname($cachePath);
+
+        // Group-writable by a supplementary group of the process: the process
+        // legitimately belongs to that group, so loading must succeed.
+        chmod($cachePath, 0644);
+        chmod($cacheDir, 0770);
+
+        if (!chgrp($cacheDir, $supplementaryGroup)) {
+            $this->markTestSkipped('chgrp to a supplementary group requires membership');
+        }
+
+        // Create loader B (no config set via setters) — should load from cache
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $this->assertSame($config, $loaderB->getWorkermanConfig());
+    }
+
+    public function testLoadFromCacheAcceptsGroupWritableCacheDirectoryOfOwnEffectiveGroup(): void
+    {
+        // Create loader A, set config, warm up to write cache
+        $loaderA = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $config = [
+            'server' => ['listen' => 'http://0.0.0.0:8080'],
+        ];
+        $loaderA->setWorkermanConfig($config);
+        $loaderA->setProcessConfig([]);
+        $loaderA->setSchedulerConfig([]);
+        $loaderA->setBuildConfig([]);
+        $loaderA->warmUp($this->tempDir . '/cache');
+
+        $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
+        $cacheDir = dirname($cachePath);
+
+        // Group-writable by the process's own effective group: accepted.
+        chmod($cachePath, 0644);
+        chmod($cacheDir, 0770);
+
+        if (!@chgrp($cacheDir, posix_getegid())) {
+            $this->markTestSkipped('chgrp to the effective group failed');
+        }
+
+        // Create loader B (no config set via setters) — should load from cache
+        $loaderB = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+        $this->assertSame($config, $loaderB->getWorkermanConfig());
+    }
+
+    public function testLoadFromCacheRefusesGroupWritableCacheDirectoryOfForeignGroup(): void
     {
         $foreignGroup = $this->findForeignGroup();
         if ($foreignGroup === null) {
-            $this->markTestSkipped('No supplementary group available to chgrp to');
+            $this->markTestSkipped('No candidate foreign group found');
         }
 
         // Create loader A, set config, warm up to write cache
@@ -322,12 +386,13 @@ final class ConfigLoaderTest extends TestCase
         $cachePath = $this->tempDir . '/cache/workerman/config.cache.php';
         $cacheDir = dirname($cachePath);
 
-        // Group-writable, but not world-writable; the file itself stays safe.
+        // Group-writable by a group the process does not belong to; the file
+        // itself stays safe. chgrp to a foreign group needs root.
         chmod($cachePath, 0644);
         chmod($cacheDir, 0770);
 
-        if (!chgrp($cacheDir, $foreignGroup)) {
-            $this->markTestSkipped('chgrp to a group other than the process group requires membership');
+        if (!@chgrp($cacheDir, $foreignGroup)) {
+            $this->markTestSkipped('chgrp to a foreign group requires root privileges');
         }
 
         // Create loader B (no config set via setters) — should reject the foreign-group directory
@@ -418,7 +483,151 @@ final class ConfigLoaderTest extends TestCase
         $this->assertStringContainsString($missingPath, $logger->records[0]['message']);
     }
 
-    private function findForeignGroup(): ?int
+    public function testValidateCacheFilePermissionsTriggersWarningWhenMetadataUnreadableAndNoLogger(): void
+    {
+        $loader = new ConfigLoader($this->tempDir, $this->tempDir . '/cache', true);
+
+        $missingPath = $this->tempDir . '/cache/workerman/does-not-exist.php';
+        $triggered = null;
+
+        set_error_handler(
+            static function (int $severity, string $message) use (&$triggered, $missingPath): bool {
+                $triggered = $missingPath;
+
+                return true;
+            },
+            \E_USER_WARNING,
+        );
+
+        try {
+            (new \ReflectionMethod(ConfigLoader::class, 'validateCacheFilePermissions'))
+                ->invoke($loader, $missingPath);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame($missingPath, $triggered);
+    }
+
+    public function testCheckCacheFilePermissionsAcceptsSecurePermissions(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0750,
+            33,
+            0644,
+            1000,
+            1000,
+            [33, 100],
+        );
+
+        $this->assertNull($verdict['error']);
+        $this->assertNull($verdict['warn']);
+    }
+
+    public function testCheckCacheFilePermissionsRefusesWorldWritableDirectory(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0777,
+            33,
+            0644,
+            1000,
+            1000,
+            [33],
+        );
+
+        $this->assertNull($verdict['warn']);
+        $this->assertNotNull($verdict['error']);
+        $this->assertStringContainsString('world-writable', $verdict['error']);
+        $this->assertStringContainsString('/tmp/cache/workerman', $verdict['error']);
+    }
+
+    public function testCheckCacheFilePermissionsRefusesGroupWritableDirectoryOfForeignGroup(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0770,
+            200,
+            0644,
+            1000,
+            1000,
+            [33],
+        );
+
+        $this->assertNull($verdict['warn']);
+        $this->assertNotNull($verdict['error']);
+        $this->assertStringContainsString('is writable by group 200', $verdict['error']);
+    }
+
+    public function testCheckCacheFilePermissionsAcceptsGroupWritableDirectoryOfSupplementaryGroup(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0770,
+            100,
+            0644,
+            1000,
+            1000,
+            [33, 100],
+        );
+
+        $this->assertNull($verdict['error']);
+        $this->assertNull($verdict['warn']);
+    }
+
+    public function testCheckCacheFilePermissionsRefusesFileOwnedByAnotherUser(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0700,
+            33,
+            0644,
+            65534,
+            1000,
+            [33],
+        );
+
+        $this->assertNull($verdict['warn']);
+        $this->assertNotNull($verdict['error']);
+        $this->assertStringContainsString('is owned by uid 65534', $verdict['error']);
+    }
+
+    public function testCheckCacheFilePermissionsRefusesWorldWritableFile(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            0700,
+            33,
+            0666,
+            1000,
+            1000,
+            [33],
+        );
+
+        $this->assertNull($verdict['warn']);
+        $this->assertNotNull($verdict['error']);
+        $this->assertStringContainsString('world-writable', $verdict['error']);
+    }
+
+    public function testCheckCacheFilePermissionsWarnsWhenMetadataIsUnreadable(): void
+    {
+        $verdict = ConfigLoader::checkCacheFilePermissions(
+            '/tmp/cache/workerman/config.cache.php',
+            false,
+            false,
+            false,
+            false,
+            1000,
+            [33],
+        );
+
+        $this->assertNull($verdict['error']);
+        $this->assertNotNull($verdict['warn']);
+        $this->assertStringContainsString('/tmp/cache/workerman/config.cache.php', $verdict['warn']);
+    }
+
+    private function findSupplementaryGroup(): ?int
     {
         $groups = posix_getgroups();
         if ($groups === false) {
@@ -429,6 +638,23 @@ final class ConfigLoaderTest extends TestCase
         foreach ($groups as $gid) {
             if ($gid !== $egid) {
                 return $gid;
+            }
+        }
+
+        return null;
+    }
+
+    private function findForeignGroup(): ?int
+    {
+        $groups = posix_getgroups();
+        if ($groups === false) {
+            return null;
+        }
+
+        $processGroups = array_merge([posix_getegid()], $groups);
+        foreach ([65534, 999, 1, 65533, 2] as $candidate) {
+            if (!in_array($candidate, $processGroups, true)) {
+                return $candidate;
             }
         }
 

--- a/tests/DependencyInjection/ServicesConfiguratorTest.php
+++ b/tests/DependencyInjection/ServicesConfiguratorTest.php
@@ -50,6 +50,7 @@ final class ServicesConfiguratorTest extends TestCase
         self::assertTrue($this->container->hasDefinition('workerman.config_loader'));
         $definition = $this->container->getDefinition('workerman.config_loader');
         self::assertSame(ConfigLoader::class, $definition->getClass());
+        self::assertTrue($definition->isAutowired());
         self::assertTrue($definition->hasTag('kernel.cache_warmer'));
     }
 


### PR DESCRIPTION
## Description

Closes #586

The config-cache guard in `ConfigLoader` only checked the cache **file's** world-writable bit, but on POSIX replacing a file requires write permission on the containing **directory** — so an attacker with a writable cache directory (e.g. under `umask 0000`) could `unlink` the cache file, write their own 0644 copy, and have it `require`d at boot. The control inspected the wrong object.

## Changes

- `src/ConfigLoader.php`: loading refused when the cache **directory** is world-writable; refused when it is group-writable by a group the process does not belong to (effective + supplementary groups); refused when the cache **file** is not owned by the process's effective UID. Existing world-writable-file check kept as secondary signal. Unreadable metadata no longer fails open silently — PSR-3 warning when a logger is configured, `E_USER_WARNING` otherwise, both naming the path. Decision logic extracted into pure `checkCacheFilePermissions()` so every branch is unit-tested without root.
- `src/DependencyInjection/ServicesConfigurator.php`: `workerman.config_loader` is now autowired so the warning reaches a real logger.
- `docs/security.md`: Permission Validation section rewritten to describe exactly what is validated (directory, group, owner, file) + scope limits (ACLs, xattrs, non-POSIX); Remediation updated for the warmup-user behaviour change.
- `tests/ConfigLoaderTest.php`: 7 pure-function tests + integration tests (world-writable dir bypass, supplementary-group acceptance, own-egid 0770 acceptance, root-gated foreign-group/foreign-owner refusals, warning routing).
- `CHANGELOG.md`: Unreleased → Security entries incl. explicit **Behaviour change** note (warmup by a different user is now refused).

## Changelog

Security: config-cache permission guard now checks the containing directory and file ownership; behaviour change for cache warmed up by a different user.

## Code Review

- [x] Passed subagent code review (2 rounds; all findings M1–M3, L1–L8 fixed)
- [x] All review comments addressed

## Validation

- `composer lint` (php-cs-fixer, phpstan level 8, rector): clean
- `composer test`: 1692 tests / 13612 assertions OK (23 env-gated skips)