### PR TITLE
fix(core): cancel per-connection timers on close (closes #571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))
+
 ### Security
 
 - Fix the config-cache permission guard so it checks the object that

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -62,16 +62,22 @@ final readonly class ServerWorker
 
         $bodySizeCap = $serverConfig['body_size_cap'] ?? null;
 
+        $worker->onClose = function (TcpConnection $connection): void {
+            $this->cancelConnectionTimers($connection);
+            $connection->context = null;
+        };
+
         $worker->onConnect = function (TcpConnection $connection) use ($connectionTimeout, $bodySizeCap): void {
             if ($bodySizeCap !== null) {
                 $connection->maxPackageSize = $bodySizeCap;
             }
 
             $connection->context ??= new \stdClass();
+            $connectionReference = \WeakReference::create($connection);
             $connection->context->connectionTimerId = Timer::add(
                 $connectionTimeout,
-                static function () use ($connection): void {
-                    $connection->close();
+                static function () use ($connectionReference): void {
+                    $connectionReference->get()?->close();
                 },
                 [],
                 false,
@@ -84,7 +90,7 @@ final readonly class ServerWorker
             // the connection cleanly instead of letting Workerman call
             // Worker::stopAll(250) which terminates the whole worker
             // process. See issue #577.
-            $connection->errorHandler = static function (\Throwable $e) use ($connection): void {
+            $connection->errorHandler = function (\Throwable $e) use ($connection): void {
                 // Log unconditionally — an escaped throwable should never
                 // happen and operators need visibility. Use error_log()
                 // because the PSR-3 logger is not easily reachable here.
@@ -97,14 +103,7 @@ final readonly class ServerWorker
 
                 // Clean up per-connection timers so they don't keep
                 // firing on a defunct connection after close().
-                if (isset($connection->context->keepaliveTimerId)) {
-                    Timer::del($connection->context->keepaliveTimerId);
-                    unset($connection->context->keepaliveTimerId);
-                }
-                if (isset($connection->context->connectionTimerId)) {
-                    Timer::del($connection->context->connectionTimerId);
-                    unset($connection->context->connectionTimerId);
-                }
+                $this->cancelConnectionTimers($connection);
 
                 $connection->close();
             };
@@ -123,15 +122,7 @@ final readonly class ServerWorker
             $handler = $this->configureHandler($kernel, $serverConfig, $rootDir);
 
             $worker->onMessage = function (TcpConnection $connection, Request $request) use ($handler, $keepaliveTimeout): void {
-                if (isset($connection->context->connectionTimerId)) {
-                    Timer::del($connection->context->connectionTimerId);
-                    unset($connection->context->connectionTimerId);
-                }
-
-                if (isset($connection->context->keepaliveTimerId)) {
-                    Timer::del($connection->context->keepaliveTimerId);
-                    unset($connection->context->keepaliveTimerId);
-                }
+                $this->cancelConnectionTimers($connection);
 
                 try {
                     $handler($connection, $request);
@@ -141,10 +132,11 @@ final readonly class ServerWorker
 
                 if ($keepaliveTimeout > 0) {
                     $connection->context ??= new \stdClass();
+                    $connectionReference = \WeakReference::create($connection);
                     $connection->context->keepaliveTimerId = Timer::add(
                         $keepaliveTimeout,
-                        static function () use ($connection): void {
-                            $connection->close();
+                        static function () use ($connectionReference): void {
+                            $connectionReference->get()?->close();
                         },
                         [],
                         false,
@@ -200,6 +192,23 @@ final readonly class ServerWorker
         }
 
         return $callable;
+    }
+
+    private function cancelConnectionTimers(TcpConnection $connection): void
+    {
+        if (!$connection->context instanceof \stdClass) {
+            return;
+        }
+
+        if (isset($connection->context->keepaliveTimerId)) {
+            Timer::del($connection->context->keepaliveTimerId);
+            unset($connection->context->keepaliveTimerId);
+        }
+
+        if (isset($connection->context->connectionTimerId)) {
+            Timer::del($connection->context->connectionTimerId);
+            unset($connection->context->connectionTimerId);
+        }
     }
 
     /**

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Workerman\Connection\TcpConnection;
+use Workerman\Events\Select;
+use Workerman\Timer;
 use Workerman\Worker;
 
 final class ServerWorkerTest extends TestCase
@@ -926,6 +928,173 @@ final class ServerWorkerTest extends TestCase
         $this->assertNotNull($worker->onMessage, 'onMessage should be set after onWorkerStart');
     }
 
+    public function testOnCloseCancelsPerConnectionTimersAndClearsContext(): void
+    {
+        $worker = $this->createStartedWorkerForTimerTests('ows-close-timers', 5, 5);
+        $eventLoop = new Select();
+        Timer::init($eventLoop);
+
+        [$idleConnection, $idlePeer] = $this->createRealConnection($eventLoop);
+        [$keepaliveConnection, $keepalivePeer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($idleConnection, $worker);
+        $this->bindConnectionToWorker($keepaliveConnection, $worker);
+
+        try {
+            $baseline = $eventLoop->getTimerCount();
+            $this->assertSame(0, $baseline);
+
+            $onConnect = $worker->onConnect;
+            $this->assertNotNull($onConnect);
+            $onConnect($idleConnection);
+            $this->assertSame($baseline + 1, $eventLoop->getTimerCount(), 'connection timeout timer should be armed on connect');
+
+            $idleConnection->close();
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing before a request must cancel the connection-timeout timer');
+            $this->assertNull($idleConnection->context, 'worker-level onClose should clear connection context');
+
+            $onConnect($keepaliveConnection);
+            $onMessage = $worker->onMessage;
+            $this->assertNotNull($onMessage);
+            $onMessage($keepaliveConnection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+            $this->assertSame($baseline + 1, $eventLoop->getTimerCount(), 'keepalive timer should be armed after a request');
+
+            $keepaliveConnection->close();
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing after a request must cancel the keepalive timer');
+            $this->assertNull($keepaliveConnection->context, 'worker-level onClose should clear connection context after keepalive close');
+        } finally {
+            Timer::delAll();
+            @fclose($idlePeer);
+            @fclose($keepalivePeer);
+        }
+    }
+
+    public function testClosedConnectionIsCollectableAfterDestroyAndEventLoopTick(): void
+    {
+        $worker = $this->createStartedWorkerForTimerTests('ows-weakref', 5, 5);
+        $eventLoop = new Select();
+        Timer::init($eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $this->assertNotNull($onConnect);
+            $onConnect($connection);
+
+            $weakReference = \WeakReference::create($connection);
+
+            $connection->destroy();
+            unset($connection);
+            gc_collect_cycles();
+
+            $this->runEventLoopFor($eventLoop, 0.01);
+            gc_collect_cycles();
+
+            $this->assertNull($weakReference->get(), 'closed connection should be collectable after destroy() and one event-loop tick');
+        } finally {
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testConnectionTimeoutStillClosesIdleConnections(): void
+    {
+        $worker = $this->createStartedWorkerForTimerTests('ows-connection-timeout', 1, 5);
+        $eventLoop = new Select();
+        Timer::init($eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $this->assertNotNull($onConnect);
+            $onConnect($connection);
+
+            $this->runEventLoopFor($eventLoop, 1.1);
+
+            $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
+            $this->assertNull($connection->context);
+            $this->assertSame(0, $eventLoop->getTimerCount());
+        } finally {
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testKeepaliveTimeoutStillClosesInactiveConnections(): void
+    {
+        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-timeout', 5, 1);
+        $eventLoop = new Select();
+        Timer::init($eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $onMessage = $worker->onMessage;
+            $this->assertNotNull($onConnect);
+            $this->assertNotNull($onMessage);
+
+            $onConnect($connection);
+            $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+
+            $this->runEventLoopFor($eventLoop, 1.1);
+
+            $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
+            $this->assertNull($connection->context);
+            $this->assertSame(0, $eventLoop->getTimerCount());
+        } finally {
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testKeepaliveTimeoutZeroDoesNotScheduleKeepaliveTimer(): void
+    {
+        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-zero', 5, 0);
+        $eventLoop = new Select();
+        Timer::init($eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $onMessage = $worker->onMessage;
+            $this->assertNotNull($onConnect);
+            $this->assertNotNull($onMessage);
+
+            $onConnect($connection);
+            $this->assertSame(1, $eventLoop->getTimerCount(), 'connection timeout timer should be armed before the first request');
+
+            $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+            $this->assertSame(0, $eventLoop->getTimerCount(), 'keepaliveTimeout=0 must leave no timer armed after a request');
+
+            $this->runEventLoopFor($eventLoop, 0.05);
+
+            $this->assertSame(TcpConnection::STATUS_ESTABLISHED, $connection->getStatus(), 'keepaliveTimeout=0 should not close active keep-alive connections');
+        } finally {
+            $connection->destroy();
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testTimerCancellationLogicIsCentralizedInOneHelper(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../src/Worker/ServerWorker.php');
+        $this->assertIsString($source);
+        $this->assertSame(1, substr_count($source, 'private function cancelConnectionTimers'));
+        $this->assertSame(2, substr_count($source, 'Timer::del('), 'Timer cancellation should live in the helper only');
+        $this->assertStringContainsString('$worker->onClose = function (TcpConnection $connection): void {', $source);
+        $this->assertStringContainsString('$this->cancelConnectionTimers($connection);' . "\n            " . '$connection->context = null;', $source);
+        $this->assertStringContainsString('$worker->onMessage = function (TcpConnection $connection, Request $request) use ($handler, $keepaliveTimeout): void {', $source);
+        $this->assertSame(3, substr_count($source, '$this->cancelConnectionTimers($connection);'));
+    }
+
     private function findWorkerByName(string $name): ?Worker
     {
         foreach (Worker::getAllWorkers() as $worker) {
@@ -935,6 +1104,83 @@ final class ServerWorkerTest extends TestCase
         }
 
         return null;
+    }
+
+    private function createStartedWorkerForTimerTests(string $name, int $connectionTimeout, int $keepaliveTimeout): Worker
+    {
+        $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['withStaticFileConfig', 'withRootDirectory'])
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $handler->method('withStaticFileConfig')->willReturnSelf();
+        $handler->method('withRootDirectory')->willReturnSelf();
+        $handler->method('__invoke')->willReturn(null);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('workerman.http_request_handler')->willReturn($handler);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('boot');
+        $kernel->method('getContainer')->willReturn($container);
+
+        new ServerWorker(
+            new KernelFactory(fn(): KernelInterface => $kernel, []),
+            null,
+            null,
+            [
+                'name' => $name,
+                'listen' => 'http://127.0.0.1:0',
+            ],
+            connectionTimeout: $connectionTimeout,
+            keepaliveTimeout: $keepaliveTimeout,
+        );
+
+        $worker = $this->findWorkerByName('[Server] ' . $name);
+        $this->assertNotNull($worker);
+
+        $onWorkerStart = $worker->onWorkerStart;
+        $this->assertNotNull($onWorkerStart);
+        $onWorkerStart($worker);
+
+        return $worker;
+    }
+
+    /**
+     * @return array{0: TcpConnection, 1: resource}
+     */
+    private function createRealConnection(Select $eventLoop): array
+    {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        if ($pair === false) {
+            $this->fail('Failed to create socket pair for TcpConnection test');
+        }
+
+        [$serverSocket, $peerSocket] = $pair;
+
+        return [
+            new TcpConnection($eventLoop, $serverSocket, '127.0.0.1:12345'),
+            $peerSocket,
+        ];
+    }
+
+    private function bindConnectionToWorker(TcpConnection $connection, Worker $worker): void
+    {
+        $connection->worker = $worker;
+        $worker->connections[$connection->id] = $connection;
+        $connection->onClose = $worker->onClose;
+        $connection->onMessage = $worker->onMessage;
+        $connection->onError = $worker->onError;
+        $connection->onBufferDrain = $worker->onBufferDrain;
+        $connection->onBufferFull = $worker->onBufferFull;
+    }
+
+    private function runEventLoopFor(Select $eventLoop, float $seconds): void
+    {
+        $eventLoop->delay($seconds, static function () use ($eventLoop): void {
+            $eventLoop->stop();
+        });
+        $eventLoop->run();
     }
 
     /**

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -1012,7 +1012,7 @@ final class ServerWorkerTest extends TestCase
             $this->assertNotNull($onConnect);
             $onConnect($connection);
 
-            $this->runEventLoopFor($eventLoop, 1.1);
+            $this->runEventLoopFor($eventLoop, 1.3);
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
@@ -1041,7 +1041,7 @@ final class ServerWorkerTest extends TestCase
             $onConnect($connection);
             $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
 
-            $this->runEventLoopFor($eventLoop, 1.1);
+            $this->runEventLoopFor($eventLoop, 1.3);
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
@@ -1081,18 +1081,6 @@ final class ServerWorkerTest extends TestCase
             Timer::delAll();
             @fclose($peer);
         }
-    }
-
-    public function testTimerCancellationLogicIsCentralizedInOneHelper(): void
-    {
-        $source = file_get_contents(__DIR__ . '/../src/Worker/ServerWorker.php');
-        $this->assertIsString($source);
-        $this->assertSame(1, substr_count($source, 'private function cancelConnectionTimers'));
-        $this->assertSame(2, substr_count($source, 'Timer::del('), 'Timer cancellation should live in the helper only');
-        $this->assertStringContainsString('$worker->onClose = function (TcpConnection $connection): void {', $source);
-        $this->assertStringContainsString('$this->cancelConnectionTimers($connection);' . "\n            " . '$connection->context = null;', $source);
-        $this->assertStringContainsString('$worker->onMessage = function (TcpConnection $connection, Request $request) use ($handler, $keepaliveTimeout): void {', $source);
-        $this->assertSame(3, substr_count($source, '$this->cancelConnectionTimers($connection);'));
     }
 
     private function findWorkerByName(string $name): ?Worker
@@ -1166,6 +1154,8 @@ final class ServerWorkerTest extends TestCase
 
     private function bindConnectionToWorker(TcpConnection $connection, Worker $worker): void
     {
+        // Mirrors Workerman\Worker::acceptTcpConnection(), which copies the worker-level
+        // callbacks onto each accepted connection. Keep in sync if Workerman changes this.
         $connection->worker = $worker;
         $worker->connections[$connection->id] = $connection;
         $connection->onClose = $worker->onClose;

--- a/tests/Strategy/BinaryFileResponseStrategyTest.php
+++ b/tests/Strategy/BinaryFileResponseStrategyTest.php
@@ -257,6 +257,43 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $this->assertFileDoesNotExist($tempFile);
     }
 
+    public function testBufferDrainRestoresWorkerLevelOnCloseChain(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/drain_worker_base_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Drain worker base!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $workerOnCloseCalled = false;
+        $this->connection->context = new \stdClass();
+        $this->connection->onClose = function (TcpConnection $conn) use (&$workerOnCloseCalled): void {
+            $workerOnCloseCalled = true;
+            $conn->context = null;
+        };
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onBufferDrain = $this->connection->onBufferDrain;
+        $this->assertNotNull($onBufferDrain);
+        assert(is_callable($onBufferDrain));
+        $onBufferDrain($this->connection);
+
+        $this->assertFileDoesNotExist($tempFile);
+        $this->assertNotNull($this->connection->onClose, 'worker-level onClose should be restored after buffer drain');
+
+        $restoredOnClose = $this->connection->onClose;
+        assert(is_callable($restoredOnClose));
+        $restoredOnClose($this->connection);
+
+        $this->assertTrue($workerOnCloseCalled, 'restored worker-level onClose callback must still run');
+        $this->assertNull($this->connection->context, 'restored worker-level onClose should still be able to clear context');
+    }
+
     public function testBufferDrainPreservesExistingOnBufferDrainCallback(): void
     {
         $strategy = new BinaryFileResponseStrategy();
@@ -388,6 +425,36 @@ final class BinaryFileResponseStrategyTest extends TestCase
             $this->connection->onBufferDrain,
             'onBufferDrain must be removed when onClose fires first',
         );
+        $this->assertFileDoesNotExist($tempFile);
+    }
+
+    public function testOnCloseFallbackChainsWorkerLevelOnClose(): void
+    {
+        $strategy = new BinaryFileResponseStrategy();
+
+        $tempFile = sys_get_temp_dir() . '/close_worker_base_' . uniqid() . '.txt';
+        file_put_contents($tempFile, 'Close worker base!');
+
+        $binaryResponse = new BinaryFileResponse($tempFile, Response::HTTP_OK);
+        $reflection = new \ReflectionClass($binaryResponse);
+        $property = $reflection->getProperty('deleteFileAfterSend');
+        $property->setValue($binaryResponse, true);
+
+        $workerOnCloseCalled = false;
+        $this->connection->context = new \stdClass();
+        $this->connection->onClose = function (TcpConnection $conn) use (&$workerOnCloseCalled): void {
+            $workerOnCloseCalled = true;
+            $conn->context = null;
+        };
+
+        $strategy->convert($binaryResponse, [], $this->connection);
+
+        $onCloseCallback = $this->connection->onClose;
+        $onCloseCallback($this->connection);
+
+        $this->assertTrue($workerOnCloseCalled, 'early-disconnect cleanup must chain to the worker-level onClose callback');
+        $this->assertNull($this->connection->context, 'worker-level onClose should still run during early disconnect cleanup');
+        $this->assertNull($this->connection->onBufferDrain, 'buffer-drain callback must be removed when onClose fires first');
         $this->assertFileDoesNotExist($tempFile);
     }
 


### PR DESCRIPTION
## Description

Closes #571

## Changes

- Add a worker-level `onClose` in `ServerWorker` that cancels both per-connection timers (connection-timeout and keepalive) and clears `$connection->context`.
- Extract the duplicated timer-cancellation logic into one private helper `cancelConnectionTimers()`, used by `onMessage`, `onClose` and the error handler.
- Timer callbacks now capture a `WeakReference` to the connection instead of the connection itself, making retention structurally impossible.
- `BinaryFileResponseStrategy` onClose chaining preserved (worker-level onClose is the base of the chain) — verified by new tests for both buffer-drain and early-disconnect paths.

## Tests

- Real `TcpConnection` over `stream_socket_pair` + real `Select` loop:
  - closing cancels connection-timeout and keepalive timers (event-loop timer count returns to baseline)
  - closed connection collectable after `destroy()` + one loop tick (`WeakReference`)
  - `connectionTimeout` still closes idle connections
  - `keepaliveTimeout` still closes inactive keep-alive connections
  - `keepaliveTimeout = 0` unchanged (no timer armed)
- `BinaryFileResponseStrategyTest`: chaining tests with worker-level onClose installed
- Full suite: 1699 tests, 13656 assertions, 23 skipped — green; `composer lint` clean

## Changelog

Entry added under [Unreleased] → Fixed, referencing (#571).

## Code Review

- [x] Passed subagent code review (approve; findings fixed in follow-up commit)
- [x] All review comments addressed