### PR TITLE
feat: single-send large responses in DefaultResponseStrategy (closes #556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `response_chunk_size` option now configures only streamed responses; it no longer affects regular buffered responses, and the (final, DI-registered) `DefaultResponseStrategy` no longer accepts a constructor chunk-size argument ([#556](https://github.com/crazy-goat/workerman-bundle/issues/556))
+
 ### Fixed
 
 - Stop manually splitting buffered responses into 8 KiB sends. `DefaultResponseStrategy` now returns the complete body to Workerman's transport, avoiding redundant `substr()` copies and write syscalls; preserve the request's HTTP protocol version on converted responses ([#556](https://github.com/crazy-goat/workerman-bundle/issues/556))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stop manually splitting buffered responses into 8 KiB sends. `DefaultResponseStrategy` now returns the complete body to Workerman's transport, avoiding redundant `substr()` copies and write syscalls; preserve the request's HTTP protocol version on converted responses ([#556](https://github.com/crazy-goat/workerman-bundle/issues/556))
+
 - Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ All top-level `workerman` configuration options:
 | `max_package_size` | `int` | `10485760` (10 MB) | Maximum accepted package size in bytes. |
 | `connection_timeout` | `int` | `120` | Max seconds to wait for a complete request before closing the connection (slowloris protection). See [security.md](docs/security.md). |
 | `keepalive_timeout` | `int` | `30` | Max idle seconds for keep-alive connections before closing. See [security.md](docs/security.md). |
-| `response_chunk_size` | `int` | `2048` | Response chunk size in bytes. |
+| `response_chunk_size` | `int` | `2048` | Streamed response chunk size in bytes. |
 | `trusted_hosts` | `string[]` | `[]` | List of regex patterns for trusted hostnames. Requests with a non-matching `Host` header are rejected with `SuspiciousOperationException`. See [security.md](docs/security.md). |
 
 ### Start application

--- a/benchmarks/ResponseConverterBench.php
+++ b/benchmarks/ResponseConverterBench.php
@@ -65,21 +65,21 @@ final class ResponseConverterBench
 
     public function benchSimpleResponse(): void
     {
-        $this->converter->convert($this->simpleResponse, $this->connection);
+        $this->converter->convert($this->simpleResponse, $this->connection, '1.1');
     }
 
     public function benchHeaderHeavyResponse(): void
     {
-        $this->converter->convert($this->headerHeavyResponse, $this->connection);
+        $this->converter->convert($this->headerHeavyResponse, $this->connection, '1.1');
     }
 
     public function benchIrregularHeadersResponse(): void
     {
-        $this->converter->convert($this->irregularHeadersResponse, $this->connection);
+        $this->converter->convert($this->irregularHeadersResponse, $this->connection, '1.1');
     }
 
     public function benchLargeBodyResponse(): void
     {
-        $this->converter->convert($this->largeBodyResponse, $this->connection);
+        $this->converter->convert($this->largeBodyResponse, $this->connection, '1.1');
     }
 }

--- a/benchmarks/ResponseConverterBench.php
+++ b/benchmarks/ResponseConverterBench.php
@@ -32,6 +32,7 @@ final class ResponseConverterBench
     private Response $simpleResponse;
     private Response $headerHeavyResponse;
     private Response $irregularHeadersResponse;
+    private Response $largeBodyResponse;
 
     public function init(): void
     {
@@ -56,6 +57,10 @@ final class ResponseConverterBench
             'www-authenticate' => 'Bearer',
             'dnt' => '1',
         ]);
+
+        $this->largeBodyResponse = new Response(str_repeat('a', 1024 * 1024), Response::HTTP_OK, [
+            'Content-Type' => 'text/html',
+        ]);
     }
 
     public function benchSimpleResponse(): void
@@ -71,5 +76,10 @@ final class ResponseConverterBench
     public function benchIrregularHeadersResponse(): void
     {
         $this->converter->convert($this->irregularHeadersResponse, $this->connection);
+    }
+
+    public function benchLargeBodyResponse(): void
+    {
+        $this->converter->convert($this->largeBodyResponse, $this->connection);
     }
 }

--- a/src/DependencyInjection/ConfigurationTreeBuilder.php
+++ b/src/DependencyInjection/ConfigurationTreeBuilder.php
@@ -83,7 +83,7 @@ final readonly class ConfigurationTreeBuilder
                 ->defaultValue(30)
                 ->end()
             ->integerNode('response_chunk_size')
-                ->info('Response chunk size')
+                ->info('Streamed response chunk size')
                 ->defaultValue(2048)
                 ->end()
             ->arrayNode('trusted_hosts')

--- a/src/DependencyInjection/ServicesConfigurator.php
+++ b/src/DependencyInjection/ServicesConfigurator.php
@@ -285,9 +285,6 @@ final readonly class ServicesConfigurator
         $container
             ->register('workerman.default_response_strategy', DefaultResponseStrategy::class)
             ->addTag('workerman.response_converter.strategy', ['priority' => 0])
-            ->setArguments([
-                $container->getParameter('workerman.response_chunk_size'),
-            ])
         ;
     }
 }

--- a/src/Http/HttpRequestHandler.php
+++ b/src/Http/HttpRequestHandler.php
@@ -143,8 +143,15 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
 
     /**
      * Send the response to the connection, unless already sent by a middleware.
+     *
+     * The response is stamped with the request's protocol version so the
+     * status line matches the client (e.g. HTTP/1.0 requests receive an
+     * HTTP/1.0 response line). When the connection will be closed after
+     * this response (HTTP/1.0 or a Connection: close request header), a
+     * matching Connection: close header is emitted instead of Workerman's
+     * default keep-alive.
      */
-    private function sendResponse(TcpConnection $connection, Http\Response $response): void
+    private function sendResponse(TcpConnection $connection, Http\Response $response, Request $request): void
     {
         $responseAlreadySent = $connection->context instanceof \stdClass
             && isset($connection->context->responseSentDirectly);
@@ -152,6 +159,11 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
             unset($connection->context->responseSentDirectly);
 
             return;
+        }
+
+        $response->withProtocolVersion($request->protocolVersion());
+        if ($this->shouldCloseConnection($request)) {
+            $response->header('Connection', 'close');
         }
 
         $connection->send(Http::encode($response, $connection), true);
@@ -297,12 +309,12 @@ final class HttpRequestHandler implements StaticFileHandlerInterface, Middleware
 
         try {
             $response = $pipeline($request, $controllerCall);
-            $this->sendResponse($connection, $response);
+            $this->sendResponse($connection, $response, $request);
         } catch (\Throwable $e) {
             $clientError = $this->isClientError($e);
             $this->logThrowable($e, $clientError);
             try {
-                $this->sendResponse($connection, $this->buildErrorResponse($clientError));
+                $this->sendResponse($connection, $this->buildErrorResponse($clientError), $request);
             } catch (\Throwable $sendError) {
                 // Best-effort: if even the error-response send fails, log
                 // and close. We must not let the throwable escape __invoke()

--- a/src/Http/Response/ResponseConverter.php
+++ b/src/Http/Response/ResponseConverter.php
@@ -33,13 +33,13 @@ final readonly class ResponseConverter
         $this->strategies = iterator_to_array($strategies, false);
     }
 
-    public function convert(SymfonyResponse $response, TcpConnection $connection): WorkermanResponse
+    public function convert(SymfonyResponse $response, TcpConnection $connection, string $protocolVersion): WorkermanResponse
     {
         $headers = $this->extractHeaders($response);
 
         foreach ($this->strategies as $strategy) {
             if ($strategy->supports($response)) {
-                return $strategy->convert($response, $headers, $connection);
+                return $strategy->convert($response, $headers, $connection, $protocolVersion);
             }
         }
 

--- a/src/Http/Response/ResponseConverterStrategyInterface.php
+++ b/src/Http/Response/ResponseConverterStrategyInterface.php
@@ -22,6 +22,9 @@ interface ResponseConverterStrategyInterface
      *        with transport-owned headers (Content-Length, Accept-Ranges,
      *        Transfer-Encoding) already stripped and single-valued headers
      *        flattened to strings (except Set-Cookie)
+     * @param string $protocolVersion The request's HTTP protocol version
+     *        (e.g. '1.1' or '1.0'); strategies that build their own status
+     *        line must derive it from this value
      */
-    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse;
+    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection, string $protocolVersion): WorkermanResponse;
 }

--- a/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
+++ b/src/Http/Response/Strategy/BinaryFileResponseStrategy.php
@@ -34,8 +34,12 @@ final readonly class BinaryFileResponseStrategy implements ResponseConverterStra
         return $response instanceof BinaryFileResponse;
     }
 
-    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse
+    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection, string $protocolVersion): WorkermanResponse
     {
+        // $protocolVersion is intentionally unused: this strategy returns a
+        // regular WorkermanResponse (with or without withFile()); the status
+        // line and Connection header are handled by Workerman and by
+        // HttpRequestHandler::sendResponse().
         /** @var BinaryFileResponse $response */
         $workermanResponse = new WorkermanResponse(
             $response->getStatusCode(),

--- a/src/Http/Response/Strategy/DefaultResponseStrategy.php
+++ b/src/Http/Response/Strategy/DefaultResponseStrategy.php
@@ -16,8 +16,12 @@ final readonly class DefaultResponseStrategy implements ResponseConverterStrateg
         return true;
     }
 
-    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse
+    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection, string $protocolVersion): WorkermanResponse
     {
+        // $protocolVersion is intentionally unused: this strategy returns a
+        // regular WorkermanResponse whose status line is derived by Workerman
+        // itself; HttpRequestHandler::sendResponse() stamps the request's
+        // protocol version centrally before encoding.
         return new WorkermanResponse(
             $response->getStatusCode(),
             $headers,

--- a/src/Http/Response/Strategy/DefaultResponseStrategy.php
+++ b/src/Http/Response/Strategy/DefaultResponseStrategy.php
@@ -11,13 +11,6 @@ use Workerman\Protocols\Http\Response as WorkermanResponse;
 
 final readonly class DefaultResponseStrategy implements ResponseConverterStrategyInterface
 {
-    private const MIN_CHUNK_SIZE = 8192;
-
-    public function __construct(
-        private int $chunkSize = 2048,
-    ) {
-    }
-
     public function supports(SymfonyResponse $response): true
     {
         return true;
@@ -25,70 +18,10 @@ final readonly class DefaultResponseStrategy implements ResponseConverterStrateg
 
     public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse
     {
-        $content = strval($response->getContent());
-        $contentLength = strlen($content);
-
-        if ($contentLength <= $this->chunkSize) {
-            return new WorkermanResponse(
-                $response->getStatusCode(),
-                $headers,
-                $content,
-            );
-        }
-
-        $this->sendChunked($content, $contentLength, $headers, $connection, $response->getStatusCode());
-
-        return new WorkermanResponse($response->getStatusCode(), $headers, '');
-    }
-
-    /**
-     * @param array<string, string|list<string|null>> $headers
-     */
-    private function sendChunked(string $content, int $contentLength, array $headers, TcpConnection $connection, int $statusCode): void
-    {
-        $sendChunkSize = max($this->chunkSize, self::MIN_CHUNK_SIZE);
-
-        $head = $this->buildHeaderString($headers, $contentLength, $statusCode);
-        $connection->send($head, true);
-
-        $offset = 0;
-        while ($offset < $contentLength) {
-            $connection->send(substr($content, $offset, $sendChunkSize), true);
-            $offset += $sendChunkSize;
-        }
-
-        if ($connection->context instanceof \stdClass) {
-            $connection->context->responseSentDirectly = true;
-        }
-    }
-
-    /**
-     * @param array<string, string|list<string|null>> $headers
-     */
-    private function buildHeaderString(array $headers, int $contentLength, int $statusCode): string
-    {
-        $reason = WorkermanResponse::PHRASES[$statusCode] ?? 'Unknown';
-        $head = "HTTP/1.1 {$statusCode} {$reason}\r\n";
-
-        foreach ($headers as $name => $values) {
-            if (strpbrk($name, ":\r\n") !== false) {
-                continue;
-            }
-            // Belt-and-braces: ResponseConverter already strips Content-Length,
-            // but keep the guard so a future caller cannot reintroduce it.
-            if (strcasecmp($name, 'Content-Length') === 0) {
-                continue;
-            }
-            foreach ((array) $values as $value) {
-                if ($value !== null && strpbrk($value, "\r\n") !== false) {
-                    continue;
-                }
-                $head .= "{$name}: {$value}\r\n";
-            }
-        }
-
-        $head .= "Content-Length: {$contentLength}\r\n";
-
-        return $head . "\r\n";
+        return new WorkermanResponse(
+            $response->getStatusCode(),
+            $headers,
+            strval($response->getContent()),
+        );
     }
 }

--- a/src/Http/Response/Strategy/StreamedResponseStrategy.php
+++ b/src/Http/Response/Strategy/StreamedResponseStrategy.php
@@ -103,6 +103,11 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
             if (strcasecmp($name, 'Transfer-Encoding') === 0) {
                 continue;
             }
+            // For HTTP/1.0 this strategy owns the Connection header (the body
+            // is close-delimited); never emit a conflicting app-provided value.
+            if ($protocolVersion === '1.0' && strcasecmp($name, 'Connection') === 0) {
+                continue;
+            }
             foreach ((array) $values as $value) {
                 if ($value !== null && strpbrk($value, "\r\n") !== false) {
                     continue;

--- a/src/Http/Response/Strategy/StreamedResponseStrategy.php
+++ b/src/Http/Response/Strategy/StreamedResponseStrategy.php
@@ -31,17 +31,25 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
         return $response instanceof StreamedResponse;
     }
 
-    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection): WorkermanResponse
+    public function convert(SymfonyResponse $response, array $headers, TcpConnection $connection, string $protocolVersion): WorkermanResponse
     {
+        $isHttp10 = $protocolVersion === '1.0';
         $sendChunkSize = max($this->chunkSize, self::MIN_CHUNK_SIZE);
 
-        $head = $this->buildHeaderString($headers, $response->getStatusCode());
+        $head = $this->buildHeaderString($headers, $response->getStatusCode(), $protocolVersion);
         $connection->send($head, true);
 
+        // HTTP/1.0 has no chunked transfer encoding; the body is streamed raw
+        // and the connection is closed by HttpRequestHandler (the head carries
+        // Connection: close). For HTTP/1.1 each flushed chunk is hex-framed.
+        $frame = static fn(string $chunk): string => $isHttp10
+            ? $chunk
+            : dechex(strlen($chunk)) . "\r\n{$chunk}\r\n";
+
         $initialLevel = ob_get_level();
-        $obStarted = ob_start(function (string $chunk) use ($connection): string {
+        $obStarted = ob_start(function (string $chunk) use ($connection, $frame): string {
             if ($chunk !== '') {
-                $connection->send(dechex(strlen($chunk)) . "\r\n{$chunk}\r\n", true);
+                $connection->send($frame($chunk), true);
             }
 
             return '';
@@ -64,7 +72,9 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
             ob_end_flush();
         }
 
-        $connection->send("0\r\n\r\n", true);
+        if (!$isHttp10) {
+            $connection->send("0\r\n\r\n", true);
+        }
 
         if ($connection->context instanceof \stdClass) {
             $connection->context->responseSentDirectly = true;
@@ -76,10 +86,10 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
     /**
      * @param array<string, string|list<string|null>> $headers
      */
-    private function buildHeaderString(array $headers, int $statusCode): string
+    private function buildHeaderString(array $headers, int $statusCode, string $protocolVersion): string
     {
         $reason = WorkermanResponse::PHRASES[$statusCode] ?? 'Unknown';
-        $head = "HTTP/1.1 {$statusCode} {$reason}\r\n";
+        $head = "HTTP/{$protocolVersion} {$statusCode} {$reason}\r\n";
 
         foreach ($headers as $name => $values) {
             if (strpbrk($name, ":\r\n") !== false) {
@@ -101,7 +111,11 @@ final readonly class StreamedResponseStrategy implements ResponseConverterStrate
             }
         }
 
-        $head .= "Transfer-Encoding: chunked\r\n";
+        if ($protocolVersion === '1.0') {
+            $head .= "Connection: close\r\n";
+        } else {
+            $head .= "Transfer-Encoding: chunked\r\n";
+        }
 
         return $head . "\r\n";
     }

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -64,7 +64,10 @@ final class SymfonyController
             $this->symfonyResponse = $this->kernel->handle($this->symfonyRequest);
             $this->symfonyResponse->prepare($this->symfonyRequest);
 
-            return $this->responseConverter->convert($this->symfonyResponse, $connection);
+            $response = $this->responseConverter->convert($this->symfonyResponse, $connection);
+            $response->withProtocolVersion($request->protocolVersion());
+
+            return $response;
         } catch (\Throwable $e) {
             $this->symfonyRequest = null;
             $this->symfonyResponse = null;

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -64,10 +64,7 @@ final class SymfonyController
             $this->symfonyResponse = $this->kernel->handle($this->symfonyRequest);
             $this->symfonyResponse->prepare($this->symfonyRequest);
 
-            $response = $this->responseConverter->convert($this->symfonyResponse, $connection);
-            $response->withProtocolVersion($request->protocolVersion());
-
-            return $response;
+            return $this->responseConverter->convert($this->symfonyResponse, $connection, $request->protocolVersion());
         } catch (\Throwable $e) {
             $this->symfonyRequest = null;
             $this->symfonyResponse = null;

--- a/tests/ContentLengthDesyncTest.php
+++ b/tests/ContentLengthDesyncTest.php
@@ -127,7 +127,7 @@ final class ContentLengthDesyncTest extends TestCase
     public function testLargeBodyPathEmitsSingleContentLength(): void
     {
         $converter = new ResponseConverter([
-            new DefaultResponseStrategy(2048),
+            new DefaultResponseStrategy(),
         ]);
 
         $body = str_repeat('a', 4096);
@@ -135,11 +135,11 @@ final class ContentLengthDesyncTest extends TestCase
             'Content-Length' => (string) strlen($body),
         ]);
 
-        $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection);
 
-        $sent = implode('', $this->getSent());
-        $this->assertSame(1, substr_count($sent, 'Content-Length:'));
-        $this->assertStringContainsString('Content-Length: 4096', $sent);
+        $wire = (string) $workermanResponse;
+        $this->assertSame(1, substr_count($wire, 'Content-Length:'));
+        $this->assertStringContainsString('Content-Length: 4096', $wire);
     }
 
     /**

--- a/tests/ContentLengthDesyncTest.php
+++ b/tests/ContentLengthDesyncTest.php
@@ -105,7 +105,7 @@ final class ContentLengthDesyncTest extends TestCase
             'Content-Length' => '5',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $head = (string) $workermanResponse;
 
@@ -135,7 +135,7 @@ final class ContentLengthDesyncTest extends TestCase
             'Content-Length' => (string) strlen($body),
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $wire = (string) $workermanResponse;
         $this->assertSame(1, substr_count($wire, 'Content-Length:'));
@@ -157,7 +157,7 @@ final class ContentLengthDesyncTest extends TestCase
             'Content-Length' => '999',
         ]);
 
-        $converter->convert($streamedResponse, $this->connection);
+        $converter->convert($streamedResponse, $this->connection, '1.1');
 
         $sent = implode('', $this->getSent());
         $this->assertSame(0, substr_count($sent, 'Content-Length:'), 'Streamed path must not emit Content-Length even if the app set one');
@@ -177,7 +177,7 @@ final class ContentLengthDesyncTest extends TestCase
         $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('a', '1'));
         $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('b', '2'));
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $head = (string) $workermanResponse;
 
@@ -215,7 +215,7 @@ final class ContentLengthDesyncTest extends TestCase
             'Content-Length' => '999',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $head = (string) $workermanResponse;
 
@@ -237,7 +237,7 @@ final class ContentLengthDesyncTest extends TestCase
             'ETag' => '"abc"',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $head = (string) $workermanResponse;
 
@@ -260,7 +260,7 @@ final class ContentLengthDesyncTest extends TestCase
         ]);
         $response->prepare(Request::create('/', \Symfony\Component\HttpFoundation\Request::METHOD_HEAD));
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $output = (string) $workermanResponse;
 
@@ -290,7 +290,7 @@ final class ContentLengthDesyncTest extends TestCase
         ]);
         $binaryResponse->prepare($this->createSymfonyRequest(range: 'bytes=0-99'));
 
-        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection, '1.1');
 
         // Drive the real Workerman serializer. For files < 2MB, encode() sends
         // head + body in one send() call and returns ''.
@@ -330,7 +330,7 @@ final class ContentLengthDesyncTest extends TestCase
         ]);
         $binaryResponse->prepare($this->createSymfonyRequest());
 
-        $workermanResponse = $converter->convert($binaryResponse, $this->connection);
+        $workermanResponse = $converter->convert($binaryResponse, $this->connection, '1.1');
 
         $return = Http::encode($workermanResponse, $this->connection);
         $this->assertSame('', $return);

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -496,6 +496,7 @@ final class HttpRequestHandlerTest extends TestCase
 
         $this->assertTrue($connection->closed, 'HTTP/1.0 request should close the connection');
         $this->assertStringStartsWith("HTTP/1.0 200 OK\r\n", $connection->sentData[0]);
+        $this->assertStringContainsString("Connection: close\r\n", $connection->sentData[0]);
     }
 
     public function testLargeResponseIsSentInOneTransportWrite(): void

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -495,6 +495,21 @@ final class HttpRequestHandlerTest extends TestCase
         ($this->handler)($connection, $request);
 
         $this->assertTrue($connection->closed, 'HTTP/1.0 request should close the connection');
+        $this->assertStringStartsWith("HTTP/1.0 200 OK\r\n", $connection->sentData[0]);
+    }
+
+    public function testLargeResponseIsSentInOneTransportWrite(): void
+    {
+        $body = str_repeat('a', 1024 * 1024);
+        $kernel = new HttpHandlerTestKernel(new SymfonyResponse($body));
+        $controller = new SymfonyController($kernel, new ResponseConverter([new DefaultResponseStrategy()]));
+        $handler = new HttpRequestHandler($controller, $this->rebootStrategy, new NullLogger());
+        $connection = new MockTcpConnection();
+
+        $handler($connection, new Request(self::HTTP11));
+
+        $this->assertCount(1, $connection->sentData);
+        $this->assertStringEndsWith("\r\n{$body}", $connection->sentData[0]);
     }
 
     public function testInvokeHttp11KeepsConnectionOpen(): void

--- a/tests/HttpRequestHandlerTest.php
+++ b/tests/HttpRequestHandlerTest.php
@@ -1029,8 +1029,9 @@ final class HttpRequestHandlerTest extends TestCase
 
         $connection = new MockTcpConnection();
         $response = new \Workerman\Protocols\Http\Response(200, [], 'Body content');
+        $request = new Request(self::HTTP11);
 
-        $method->invoke($this->handler, $connection, $response);
+        $method->invoke($this->handler, $connection, $response, $request);
 
         $this->assertCount(1, $connection->sentData);
         $this->assertStringContainsString('Body content', $connection->sentData[0]);
@@ -1046,8 +1047,9 @@ final class HttpRequestHandlerTest extends TestCase
         $connection->context->responseSentDirectly = true;
 
         $response = new \Workerman\Protocols\Http\Response(200, [], 'Body content');
+        $request = new Request(self::HTTP11);
 
-        $method->invoke($this->handler, $connection, $response);
+        $method->invoke($this->handler, $connection, $response, $request);
 
         $this->assertCount(0, $connection->sentData, 'Should skip send when responseSentDirectly is set');
         $this->assertFalse(

--- a/tests/ResponseConverterTest.php
+++ b/tests/ResponseConverterTest.php
@@ -29,7 +29,7 @@ final class ResponseConverterTest extends TestCase
         $converter = new ResponseConverter($strategies);
 
         $regularResponse = new Response('regular');
-        $workermanResponse = $converter->convert($regularResponse, $this->connection);
+        $workermanResponse = $converter->convert($regularResponse, $this->connection, '1.1');
 
         $this->assertSame('regular', $workermanResponse->rawBody());
     }
@@ -41,7 +41,7 @@ final class ResponseConverterTest extends TestCase
 
         // Empty strategies array
         $converter = new ResponseConverter([]);
-        $converter->convert(new Response(), $this->connection);
+        $converter->convert(new Response(), $this->connection, '1.1');
     }
 
     public function testConvertPreservesHeaders(): void
@@ -55,7 +55,7 @@ final class ResponseConverterTest extends TestCase
         ]);
 
         // Should not throw - headers are passed to strategy
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame('content', $workermanResponse->rawBody());
@@ -73,7 +73,7 @@ final class ResponseConverterTest extends TestCase
         ]);
 
         // Should not throw - headers are normalized and passed to strategy
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame('text/html', $workermanResponse->getHeader('Content-Type'));
@@ -88,7 +88,7 @@ final class ResponseConverterTest extends TestCase
         };
 
         $converter = new ResponseConverter($generator());
-        $response = $converter->convert(new Response('test'), $this->connection);
+        $response = $converter->convert(new Response('test'), $this->connection, '1.1');
 
         $this->assertSame('test', $response->rawBody());
     }
@@ -107,7 +107,7 @@ final class ResponseConverterTest extends TestCase
             echo 'streamed content';
         });
 
-        $workermanResponse = $converter->convert($streamedResponse, $this->connection);
+        $workermanResponse = $converter->convert($streamedResponse, $this->connection, '1.1');
 
         // Content is sent directly via $connection->send(), not buffered in response
         $this->assertSame('', $workermanResponse->rawBody());
@@ -126,7 +126,7 @@ final class ResponseConverterTest extends TestCase
             'dnt' => '1',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertSame('"abc123"', $workermanResponse->getHeader('ETag'));
         $this->assertSame('deadbeef', $workermanResponse->getHeader('Content-MD5'));
@@ -146,8 +146,8 @@ final class ResponseConverterTest extends TestCase
             'etag' => '"v2"',
         ]);
 
-        $r1 = $converter->convert($response1, $this->connection);
-        $r2 = $converter->convert($response2, $this->connection);
+        $r1 = $converter->convert($response1, $this->connection, '1.1');
+        $r2 = $converter->convert($response2, $this->connection, '1.1');
 
         // Both calls hit the static cache on the second invocation
         $this->assertSame('"v1"', $r1->getHeader('ETag'));
@@ -164,14 +164,14 @@ final class ResponseConverterTest extends TestCase
             'content-type' => 'text/html',
             'x-custom-one' => 'first',
         ]);
-        $converter->convert($response1, $this->connection);
+        $converter->convert($response1, $this->connection, '1.1');
 
         // Second call on same instance hits cache entries
         $response2 = new Response('b', \Symfony\Component\HttpFoundation\Response::HTTP_OK, [
             'content-type' => 'application/json',
             'x-custom-two' => 'second',
         ]);
-        $workermanResponse = $converter->convert($response2, $this->connection);
+        $workermanResponse = $converter->convert($response2, $this->connection, '1.1');
 
         $this->assertSame('application/json', $workermanResponse->getHeader('Content-Type'));
         $this->assertSame('second', $workermanResponse->getHeader('X-Custom-Two'));
@@ -189,7 +189,7 @@ final class ResponseConverterTest extends TestCase
             'dnt' => '0',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertSame('text/plain', $workermanResponse->getHeader('Content-Type'));
         $this->assertSame('"abc"', $workermanResponse->getHeader('ETag'));
@@ -215,7 +215,7 @@ final class ResponseConverterTest extends TestCase
             'X-Custom' => 'kept',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertNull(
             $workermanResponse->getHeader($this->normalizeForAssertion($headerName)),
@@ -252,7 +252,7 @@ final class ResponseConverterTest extends TestCase
         $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('a', '1'));
         $response->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie('b', '2'));
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $setCookie = $workermanResponse->getHeader('Set-Cookie');
         $this->assertIsArray($setCookie, 'Set-Cookie must keep its array shape to emit one line per cookie');
@@ -274,7 +274,7 @@ final class ResponseConverterTest extends TestCase
             'Content-Range' => 'bytes 0-99/5000',
         ]);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertSame('bytes 0-99/5000', $workermanResponse->getHeader('Content-Range'));
     }
@@ -294,7 +294,7 @@ final class ResponseConverterTest extends TestCase
         // Force a header with only null values, as Symfony can produce.
         $response->headers->set('X-Empty', null);
 
-        $workermanResponse = $converter->convert($response, $this->connection);
+        $workermanResponse = $converter->convert($response, $this->connection, '1.1');
 
         $this->assertNull($workermanResponse->getHeader('X-Empty'));
         $this->assertSame('kept', $workermanResponse->getHeader('X-Custom'));

--- a/tests/Strategy/BinaryFileResponseStrategyTest.php
+++ b/tests/Strategy/BinaryFileResponseStrategyTest.php
@@ -60,7 +60,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertNotNull($workermanResponse->file);
@@ -77,7 +77,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Type' => ['application/pdf'],
             'Content-Disposition' => ['attachment; filename="report.pdf"'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertNotNull($workermanResponse->file);
@@ -88,7 +88,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $strategy = new BinaryFileResponseStrategy();
         $binaryResponse = new BinaryFileResponse($this->testFile, Response::HTTP_NOT_FOUND);
 
-        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $this->assertSame(404, $workermanResponse->getStatusCode());
     }
@@ -106,7 +106,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('tempFileObject');
         $property->setValue($binaryResponse, $tempFile);
 
-        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame('Temp file content', $workermanResponse->rawBody());
@@ -128,7 +128,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Range' => ['bytes 0-4/29'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertNotNull($workermanResponse->file);
@@ -153,7 +153,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertFileExists($tempFile);
@@ -185,7 +185,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         // Simulate connection close without buffer drain (early disconnect)
         $onCloseCallback = $this->connection->onClose;
@@ -215,7 +215,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         // Trigger via onClose fallback
         $onCloseCallback = $this->connection->onClose;
@@ -241,7 +241,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         };
         $this->connection->onClose = $existingOnClose;
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Simulate buffer drain (primary path)
         $onBufferDrain = $this->connection->onBufferDrain;
@@ -276,7 +276,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
             $conn->context = null;
         };
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $onBufferDrain = $this->connection->onBufferDrain;
         $this->assertNotNull($onBufferDrain);
@@ -312,7 +312,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         };
         $this->connection->onBufferDrain = $existingOnBufferDrain;
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Simulate buffer drain
         $onBufferDrain = $this->connection->onBufferDrain;
@@ -334,7 +334,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $onBufferDrain = $this->connection->onBufferDrain;
         $this->assertNotNull($onBufferDrain);
@@ -360,7 +360,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $onCloseCallback = $this->connection->onClose;
         $this->assertNotNull($onCloseCallback);
@@ -386,7 +386,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Fire buffer drain
         $onBufferDrain = $this->connection->onBufferDrain;
@@ -413,7 +413,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Fire onClose (early disconnect)
         $onCloseCallback = $this->connection->onClose;
@@ -447,7 +447,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
             $conn->context = null;
         };
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $onCloseCallback = $this->connection->onClose;
         $onCloseCallback($this->connection);
@@ -473,7 +473,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Fire buffer drain (deletes file)
         $onBufferDrain = $this->connection->onBufferDrain;
@@ -492,7 +492,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $binaryResponse = new BinaryFileResponse($this->testFile, Response::HTTP_OK);
 
-        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertNotNull($workermanResponse->file);
@@ -509,7 +509,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         unlink($tempFile);
 
-        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $this->assertSame(404, $workermanResponse->getStatusCode());
     }
@@ -533,7 +533,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
 
         $workermanResponse = $strategy->convert($binaryResponse, [
             'Content-Type' => ['text/plain'],
-        ], $this->connection);
+        ], $this->connection, '1.1');
 
         $this->assertSame(404, $workermanResponse->getStatusCode());
     }
@@ -561,7 +561,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         $onCloseCallback = $this->connection->onClose;
         assert(is_callable($onCloseCallback));
@@ -595,7 +595,7 @@ final class BinaryFileResponseStrategyTest extends TestCase
         $property = $reflection->getProperty('deleteFileAfterSend');
         $property->setValue($binaryResponse, true);
 
-        $strategy->convert($binaryResponse, [], $this->connection);
+        $strategy->convert($binaryResponse, [], $this->connection, '1.1');
 
         // Trigger via buffer drain (primary path)
         $onBufferDrain = $this->connection->onBufferDrain;

--- a/tests/Strategy/DefaultResponseStrategyTest.php
+++ b/tests/Strategy/DefaultResponseStrategyTest.php
@@ -23,7 +23,7 @@ final class DefaultResponseStrategyTest extends TestCase
         $strategy = new DefaultResponseStrategy();
         $symfonyResponse = new Response('Hello World', \Symfony\Component\HttpFoundation\Response::HTTP_OK, ['Content-Type' => 'text/plain']);
 
-        $workermanResponse = $strategy->convert($symfonyResponse, ['Content-Type' => ['text/plain']], $this->connection);
+        $workermanResponse = $strategy->convert($symfonyResponse, ['Content-Type' => ['text/plain']], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame('Hello World', $workermanResponse->rawBody());
@@ -34,7 +34,7 @@ final class DefaultResponseStrategyTest extends TestCase
         $strategy = new DefaultResponseStrategy();
         $symfonyResponse = new Response();
 
-        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame('', $workermanResponse->rawBody());
@@ -49,7 +49,7 @@ final class DefaultResponseStrategyTest extends TestCase
         $this->connection->expects($this->never())
             ->method('send');
 
-        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection, '1.1');
 
         $this->assertSame(1024, strlen($workermanResponse->rawBody()));
     }
@@ -64,7 +64,7 @@ final class DefaultResponseStrategyTest extends TestCase
             ->expects($this->never())
             ->method('send');
 
-        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertSame($body, $workermanResponse->rawBody());
@@ -81,6 +81,7 @@ final class DefaultResponseStrategyTest extends TestCase
             $symfonyResponse,
             ['Content-Type' => 'text/plain', 'X-Test' => 'value'],
             $this->connection,
+            '1.1',
         );
 
         $wire = (string) $workermanResponse;

--- a/tests/Strategy/DefaultResponseStrategyTest.php
+++ b/tests/Strategy/DefaultResponseStrategyTest.php
@@ -42,7 +42,7 @@ final class DefaultResponseStrategyTest extends TestCase
 
     public function testSmallBodyReturnsWorkermanResponse(): void
     {
-        $strategy = new DefaultResponseStrategy(2048 * 1024);
+        $strategy = new DefaultResponseStrategy();
         $body = str_repeat('a', 1024);
         $symfonyResponse = new Response($body);
 
@@ -54,43 +54,40 @@ final class DefaultResponseStrategyTest extends TestCase
         $this->assertSame(1024, strlen($workermanResponse->rawBody()));
     }
 
-    public function testLargeBodySendsChunkedResponse(): void
+    public function testLargeBodyReturnsCompleteResponseWithoutManualChunking(): void
     {
-        $chunkSize = 2048;
-        $strategy = new DefaultResponseStrategy($chunkSize);
-        $chunkCount = 5;
-        $sendChunkSize = max($chunkSize, 8192);
-        $bodySize = $sendChunkSize * $chunkCount;
-        $body = str_repeat('a', $bodySize);
+        $strategy = new DefaultResponseStrategy();
+        $body = str_repeat('a', 8192 * 5);
         $symfonyResponse = new Response($body);
 
-        $this->connection->context = new \stdClass();
-
-        $sendCalls = [];
-        $expectedSendCount = 1 + $chunkCount;
         $this->connection
-            ->expects($this->exactly($expectedSendCount))
-            ->method('send')
-            ->willReturnCallback(function (mixed $data, bool $raw = false) use (&$sendCalls): void {
-                $sendCalls[] = ['data' => $data, 'raw' => $raw];
-            });
+            ->expects($this->never())
+            ->method('send');
 
         $workermanResponse = $strategy->convert($symfonyResponse, [], $this->connection);
 
-        $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
+        $this->assertSame($body, $workermanResponse->rawBody());
+        $this->assertStringContainsString('Content-Length: ' . strlen($body), (string) $workermanResponse);
+    }
 
-        $this->assertCount($expectedSendCount, $sendCalls);
-        $this->assertStringStartsWith('HTTP/1.1 200 OK', $sendCalls[0]['data']);
-        $this->assertStringContainsString("Content-Length: {$bodySize}", $sendCalls[0]['data']);
-        $this->assertTrue($sendCalls[0]['raw']);
+    public function testResponseWireFormatPreservesHeadersAndBody(): void
+    {
+        $strategy = new DefaultResponseStrategy();
+        $body = str_repeat('body', 4096);
+        $symfonyResponse = new Response($body, \Symfony\Component\HttpFoundation\Response::HTTP_CREATED, ['Content-Type' => 'text/plain', 'X-Test' => 'value']);
 
-        for ($i = 1; $i <= $chunkCount; $i++) {
-            $this->assertTrue($sendCalls[$i]['raw']);
-            $this->assertSame($sendChunkSize, strlen((string) $sendCalls[$i]['data']));
-        }
+        $workermanResponse = $strategy->convert(
+            $symfonyResponse,
+            ['Content-Type' => 'text/plain', 'X-Test' => 'value'],
+            $this->connection,
+        );
 
-        $this->assertInstanceOf(\stdClass::class, $this->connection->context);
-        $this->assertTrue($this->connection->context->responseSentDirectly);
+        $wire = (string) $workermanResponse;
+
+        $this->assertStringStartsWith("HTTP/1.1 201 Created\r\n", $wire);
+        $this->assertStringContainsString("Content-Type: text/plain\r\n", $wire);
+        $this->assertStringContainsString("X-Test: value\r\n", $wire);
+        $this->assertStringEndsWith("\r\n{$body}", $wire);
     }
 }

--- a/tests/Strategy/StreamedResponseStrategyTest.php
+++ b/tests/Strategy/StreamedResponseStrategyTest.php
@@ -93,7 +93,7 @@ final class StreamedResponseStrategyTest extends TestCase
             echo 'chunk2';
         });
 
-        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.0');
+        $workermanResponse = $strategy->convert($streamedResponse, ['Connection' => 'keep-alive'], $this->connection, '1.0');
 
         $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
@@ -101,6 +101,7 @@ final class StreamedResponseStrategyTest extends TestCase
         $this->assertCount(2, $sendCalls, 'HTTP/1.0 must send head + raw body, no chunk framing, no terminator');
         $this->assertStringStartsWith('HTTP/1.0 200 OK', $sendCalls[0]['data']);
         $this->assertStringContainsString("Connection: close\r\n", $sendCalls[0]['data']);
+        $this->assertStringNotContainsString('Connection: keep-alive', $sendCalls[0]['data'], 'App-provided Connection must not duplicate the strategy-owned close header');
         $this->assertStringNotContainsString('Transfer-Encoding', $sendCalls[0]['data']);
         $this->assertTrue($sendCalls[0]['raw']);
 

--- a/tests/Strategy/StreamedResponseStrategyTest.php
+++ b/tests/Strategy/StreamedResponseStrategyTest.php
@@ -53,7 +53,7 @@ final class StreamedResponseStrategyTest extends TestCase
             echo 'chunk3';
         });
 
-        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.1');
 
         $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
@@ -69,6 +69,43 @@ final class StreamedResponseStrategyTest extends TestCase
 
         $this->assertSame("0\r\n\r\n", $sendCalls[2]['data']);
         $this->assertTrue($sendCalls[2]['raw']);
+
+        $this->assertInstanceOf(\stdClass::class, $this->connection->context);
+        $this->assertTrue($this->connection->context->responseSentDirectly);
+    }
+
+    public function testConvertHttp10UsesCloseDelimitedRawStream(): void
+    {
+        $this->connection->context = new \stdClass();
+
+        $sendCalls = [];
+        $this->connection
+            ->expects($this->exactly(2))
+            ->method('send')
+            ->willReturnCallback(function (mixed $data, bool $raw = false) use (&$sendCalls): void {
+                $sendCalls[] = ['data' => $data, 'raw' => $raw];
+            });
+
+        $strategy = new StreamedResponseStrategy();
+
+        $streamedResponse = new StreamedResponse(function (): void {
+            echo 'chunk1';
+            echo 'chunk2';
+        });
+
+        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.0');
+
+        $this->assertSame('', $workermanResponse->rawBody());
+        $this->assertSame(200, $workermanResponse->getStatusCode());
+
+        $this->assertCount(2, $sendCalls, 'HTTP/1.0 must send head + raw body, no chunk framing, no terminator');
+        $this->assertStringStartsWith('HTTP/1.0 200 OK', $sendCalls[0]['data']);
+        $this->assertStringContainsString("Connection: close\r\n", $sendCalls[0]['data']);
+        $this->assertStringNotContainsString('Transfer-Encoding', $sendCalls[0]['data']);
+        $this->assertTrue($sendCalls[0]['raw']);
+
+        $this->assertSame('chunk1chunk2', $sendCalls[1]['data'], 'Body must be streamed raw for HTTP/1.0');
+        $this->assertTrue($sendCalls[1]['raw']);
 
         $this->assertInstanceOf(\stdClass::class, $this->connection->context);
         $this->assertTrue($this->connection->context->responseSentDirectly);
@@ -100,7 +137,7 @@ final class StreamedResponseStrategyTest extends TestCase
             flush();
         });
 
-        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.1');
 
         $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
@@ -142,7 +179,7 @@ final class StreamedResponseStrategyTest extends TestCase
             echo 'content';
         }, Response::HTTP_CREATED);
 
-        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.1');
 
         $this->assertSame(201, $workermanResponse->getStatusCode());
         $this->assertStringStartsWith('HTTP/1.1 201 Created', $sendCalls[0]['data']);
@@ -168,7 +205,7 @@ final class StreamedResponseStrategyTest extends TestCase
             echo 'content';
         }, Response::HTTP_OK, $headers);
 
-        $workermanResponse = $strategy->convert($streamedResponse, $headers, $this->connection);
+        $workermanResponse = $strategy->convert($streamedResponse, $headers, $this->connection, '1.1');
 
         $this->assertSame(200, $workermanResponse->getStatusCode());
         $this->assertStringContainsString('Content-Type: text/plain', $sendCalls[0]['data']);
@@ -193,7 +230,7 @@ final class StreamedResponseStrategyTest extends TestCase
         $streamedResponse = new StreamedResponse(function (): void {
         });
 
-        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection);
+        $workermanResponse = $strategy->convert($streamedResponse, [], $this->connection, '1.1');
 
         $this->assertSame('', $workermanResponse->rawBody());
         $this->assertSame(200, $workermanResponse->getStatusCode());
@@ -224,7 +261,7 @@ final class StreamedResponseStrategyTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('intentional error');
 
-        $strategy->convert($streamedResponse, [], $this->connection);
+        $strategy->convert($streamedResponse, [], $this->connection, '1.1');
 
         $this->assertSame($initialLevel, ob_get_level(), 'OB level should be restored after exception');
     }


### PR DESCRIPTION
## Description

Closes #556

## Changes

- **DefaultResponseStrategy**: removed the manual 8 KiB `substr()` chunk loop. Buffered responses now return a single `WorkermanResponse` and let the transport (`Http::encode()` + `TcpConnection::send()`) handle framing — one write instead of N, no body copy (`src/Http/Response/Strategy/DefaultResponseStrategy.php`).
- **Protocol version**: the response status line now matches the request's protocol version, applied centrally in `HttpRequestHandler::sendResponse()` (covers controller responses, error responses, trusted-host 400, static files). `ResponseConverterStrategyInterface::convert()` threads `$protocolVersion` through so `StreamedResponseStrategy` derives its head line too.
- **HTTP/1.0 framing**: responses on close-destined connections (HTTP/1.0 or `Connection: close`) now emit `Connection: close` instead of Workerman's default keep-alive; streamed responses over HTTP/1.0 stream raw close-delimited (no chunked framing, which 1.0 clients do not support).
- **Config**: `response_chunk_size` now only affects streamed responses; the default strategy's constructor chunk-size argument was removed (final, DI-registered class; CHANGELOG notes the BC notice).
- **Benchmark**: `ResponseConverterBench` gained `benchLargeBodyResponse` (1 MiB subject).

## Wire-format note for reviewers

Byte-level output for HTTP/1.1 buffered responses is not literally identical to the old manual head: Workerman now adds `Connection: keep-alive` and a default `Content-Type: text/html;charset=utf-8` when unset. This is the `Http::encode()` behavior the issue asked to confirm, and keep-alive semantics are now correct by construction.

## Benchmark

Before (from issue #556 analysis, counting-stub benchmark): 50 KB → 8 `send()` calls (would be 1), 1 MB → 129 (would be 1); userland 18 μs/op (50 KB) / 18.064 μs/op (1 MB) chunked loop vs 0.065 / 0.050 single send.

After (new bench subject, post-change only — a baseline was not captured before implementation):

```text
benchLargeBodyResponse: 1.100 μs/op
Memory peak: 3.021 MB
Configuration: 10 revs, 1 iteration, 1 warmup
```

## Changelog

- **Fixed**: stop manually splitting buffered responses into 8 KiB sends; preserve the request's HTTP protocol version on converted responses
- **Changed**: `response_chunk_size` now configures only streamed responses; `DefaultResponseStrategy` no longer accepts a constructor chunk-size argument

## Code Review

- [x] Passed subagent code review (3 passes; final verdict: "Code looks good, no issues to fix.")
- [x] All review comments addressed

## Tests

- Full suite: 1702 tests, 13662 assertions, 23 skipped (pre-existing) — green
- `composer lint` (php-cs-fixer, phpstan level 8, rector) — green