### PR TITLE
docs: add subagent knowledge base in docs/helpers (faq, decisions)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@ This directory contains documentation for the WorkermanBundle.
 - [build-packaging.md](build-packaging.md) — PHAR and standalone binary packaging
 - [security.md](security.md) — Security hardening and trusted hosts
 - [troubleshooting.md](troubleshooting.md) — Long-running worker pitfalls and mitigations
+- [helpers/](helpers/README.md) — Knowledge base maintained by subagents (FAQ, decisions)
 
 All other user-facing documentation is in the [main README](../README.md).

--- a/docs/helpers/README.md
+++ b/docs/helpers/README.md
@@ -1,0 +1,33 @@
+# Knowledge Base (docs/helpers/)
+
+This directory is a persistent knowledge base maintained by subagents
+(`worker` / `coder` while implementing, `review` while reviewing). Lessons
+learned here carry over to future tasks, so the same mistakes are not made
+twice and past decisions do not need to be re-derived.
+
+## Files
+
+- [faq.md](faq.md) — frequently asked questions, recurring pitfalls and
+  their solutions (test daemon ports, pre-push hook, coverage gate, `gh`
+  default limits, long-running worker gotchas)
+- [decisions.md](decisions.md) — important project decisions with rationale
+  (architecture choices, security policies, conventions) and a reference to
+  the issue/PR/commit that introduced them
+
+## Rules
+
+1. **Read before you start.** Any subagent about to implement or review
+   changes reads `docs/helpers/faq.md` and `docs/helpers/decisions.md` first
+   and follows any guidance that applies to the task.
+2. **Append after you finish.** After implementation or review, append
+   short entries for anything non-obvious you learned: a pitfall you hit
+   (and its solution) or a decision you made (and why).
+3. **One topic per entry.** Keep entries short: the problem, the
+   solution/decision, optionally an issue/PR/commit reference. Do not
+   restate what is already documented in the README or `docs/`.
+   `docs/troubleshooting.md` already covers long-running worker state
+   pollution — link to it instead of duplicating it.
+4. **In doubt, ask.** If unsure whether an entry belongs in the knowledge
+   base (or where), ask the user before adding it.
+5. **Commit entries as part of the change** they were learned from — do not
+   leave the knowledge base behind in the working tree.

--- a/docs/helpers/decisions.md
+++ b/docs/helpers/decisions.md
@@ -1,0 +1,65 @@
+# Decisions — Notable Project Decisions with Rationale
+
+Subagents: read this before starting a task, append new entries after
+finishing (see [README.md](README.md) for rules).
+
+## Architecture / behavior
+
+### Large responses are sent in a single write
+
+`DefaultResponseStrategy` sends large responses in one write instead of
+chunked streaming (`feat: single-send large responses`, #556, #620). Do
+not reintroduce chunked sends for regular responses.
+
+### `StreamedResponseStrategy` is the only direct response sender
+
+`HttpRequestHandler` delegates actual response sending exclusively to
+`StreamedResponseStrategy` (docs fix #622). Any new response path must go
+through the strategy layer, not the handler.
+
+### Per-connection timers are cancelled on connection close
+
+All timers registered per connection must be cancelled in the close
+handler, otherwise they fire for dead connections (fix #571, #616).
+
+### Negative realpath cache is capped
+
+`StaticFilesMiddleware` caps the negative realpath cache so long-lived
+workers do not grow it unboundedly when files are missing (#570, #607).
+
+## Security policy
+
+The following hardening measures were consolidated through the security
+review (#582–#586 series) — keep them intact when touching the related
+code paths:
+
+- Cache directory permissions and ownership are checked before `require`
+  (#586, #611).
+- Static file serving allows only an explicit allowlist; backup/credential
+  extensions (`.bak`, `.env`, etc.) are blocked (#580/#582, #603/#609).
+- Master process identification is hardened (#584, #608).
+- HTTP headers starting with underscore are dropped (#578, #605).
+- SFX redirect policy is unified across modes (#585, #606).
+- Transport-owned headers are stripped to prevent duplicate
+  `Content-Length` (#579, #602).
+
+Do not loosen these without an explicit, documented reason.
+
+## Process / repository policy
+
+### 80% line-coverage floor, single source of truth
+
+`composer.json`'s `coverage:check` script is the only place the 80%
+threshold is defined (#589, #601) — update it there, not in CI YAML.
+
+### Pre-push hook runs `composer lint`
+
+`bin/install-git-hook.php` installs a pre-push hook that runs
+php-cs-fixer, phpstan and rector (dry-run). Keep `composer lint` /
+`lint-fix` as the canonical lint entry points.
+
+### Subagents maintain this knowledge base
+
+`worker`/`coder` and `review` subagents read and append to
+`docs/helpers/` (see [README.md](README.md)). This keeps project memory
+persistent across sessions.

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -1,0 +1,65 @@
+# FAQ — Recurring Pitfalls and Solutions
+
+Subagents: read this before starting a task, append new entries after
+finishing (see [README.md](README.md) for rules).
+
+## Test suite
+
+### "Address already in use" when running `composer test`
+
+`composer test` boots a real Workerman daemon that binds ports **8888**
+and **9999** for E2E tests. If a stale daemon (or anything else) is holding
+those ports, PHPUnit fails with connection errors.
+
+```bash
+# Stop the daemon (safe even if not running):
+php tests/App/index.php stop
+```
+
+### How the test suite works
+
+```bash
+composer test            # unit + E2E (no coverage)
+composer test:coverage   # unit + E2E with coverage → var/coverage.xml
+composer coverage:check  # enforces the 80% floor (see decisions.md)
+```
+
+The `test` script restarts the daemon with `-d` (daemon mode), sleeps 1s,
+runs PHPUnit, then stops the daemon. Phpunit itself is run with
+`php -d phar.readonly=0`. If tests were interrupted, stop the daemon
+manually as above.
+
+### CI enforces an 80% line-coverage floor
+
+Defined once in `composer.json` (`coverage:check` →
+`bin/check-coverage.php var/coverage.xml 80.0`) and checked on the
+PHP 8.2 / Symfony 6.4 matrix leg. If a PR adds meaningful logic, verify
+the gate locally (`composer test:coverage && composer coverage:check`) so
+CI doesn't tell you first. Requires PCOV or Xdebug locally.
+
+## Git hooks
+
+### Pre-push hook runs `composer lint` before every push
+
+Installed by `php bin/install-git-hook.php` (post-install/post-update).
+Every push runs php-cs-fixer (dry-run), phpstan and rector (dry-run).
+To skip in an emergency: `git push --no-verify`.
+
+## GitHub CLI
+
+### `gh issue list` returns at most 30 issues by default
+
+Always raise the limit explicitly (`--limit 100`, max 1000) or paginate
+with `--page N` — otherwise issues beyond the first page are silently
+missed during triage.
+
+## Long-running worker gotchas
+
+### Symfony container / service state survives requests
+
+Workerman keeps the kernel and DI container alive across requests, so any
+stateful service (Doctrine `EntityManager` identity map, buffering Monolog
+handlers, caching repositories, static/global state) leaks data between
+requests. See [docs/troubleshooting.md](../troubleshooting.md) for
+detection and mitigation (`kernel.reset`, `EntityManager::clear()`,
+reload strategies).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -70,6 +70,8 @@ session stays free to orchestrate, review findings, and handle the next steps.
 ```bash
 # The subagent receives a task like:
 # "Implement issue #<NUMBER> on branch feat/issue-<NUMBER>-<description>.
+#  Read docs/helpers/ (faq.md, decisions.md) first — it documents
+#  recurring pitfalls and project decisions that apply to this task.
 #  Read the issue body first, then make the smallest correct change.
 #  Run the relevant tests for the changed behavior.
 #  Commit and push when done.
@@ -120,9 +122,15 @@ its own context). The subagent checks:
 ```bash
 # The subagent receives a task like:
 # "Code review the changes in files: <list of files>.
+#  Read docs/helpers/ (faq.md, decisions.md) first and flag any
+#  violations of documented decisions.
 #  Check: type correctness, error handling, PSR-12 compliance,
 #  missing tests, outdated documentation.
 #  List all issues to fix."
+
+After the review, the subagent should append any non-obvious findings to
+`docs/helpers/` (see "Knowledge Base (docs/helpers/)" below) — typically
+as part of the fix commits that follow.
 ```
 
 > **Why a subagent:** code review reads the full diff plus surrounding code,
@@ -359,6 +367,27 @@ gh issue create \
 
 ---
 
+## Knowledge Base (docs/helpers/)
+
+`worker`/`coder` (implementation) and `review` (code review) subagents
+maintain a persistent knowledge base in `docs/helpers/` so lessons learned
+carry over to future tasks:
+
+- `docs/helpers/faq.md` — frequently asked questions, recurring pitfalls
+  (test daemon ports, pre-push lint hook, coverage gate, `gh` default
+  limits) and their solutions
+- `docs/helpers/decisions.md` — important project decisions with rationale
+  (response strategy, security policy, coverage floor)
+- `docs/helpers/README.md` — structure and rules for the knowledge base
+
+Subagents **read** the knowledge base before starting a task and **append**
+short entries after finishing (one topic: the problem, the
+solution/decision, optionally an issue/commit reference). Entries are
+committed as part of the regular fix/feat commits — no extra PRs. In doubt,
+extend `docs/troubleshooting.md` or ask the user before adding a new entry.
+
+---
+
 ## Quick Reference – Full Cycle
 
 ```bash
@@ -421,6 +450,10 @@ All subagents have read/write/edit/bash tools and operate on the same
 repository. Give each one a clear, scoped instruction and a defined output
 format (ranked list with rationale / numbered findings list / coder report
 with biggest problem + discovered bugs).
+
+**Knowledge base:** implementation and review subagents read
+`docs/helpers/` before starting and append learnings after finishing
+(see "Knowledge Base (docs/helpers/)" above).
 
 ---
 


### PR DESCRIPTION
## Description

Introduces the persistent knowledge base pattern from the php-zvec workflow: implementation and review subagents `read` docs/helpers/ before starting a task and `append` short entries after finishing, so lessons learned carry over to future tasks.

## Changes

- Added `docs/helpers/README.md` — structure and rules for the knowledge base
- Added `docs/helpers/faq.md` — recurring pitfalls: test daemon ports 8888/9999, composer test lifecycle, pre-push lint hook, 80% coverage gate, `gh issue list` default limit, long-running worker gotchas
- Added `docs/helpers/decisions.md` — notable decisions with rationale: single-send large responses (#556), StreamedResponseStrategy as only direct sender (#622), per-connection timer cancellation (#571), realpath cache cap (#570), security hardening series (#578-#586), coverage floor policy (#589), pre-push hook policy
- Updated `docs/workflow.md` — knowledge base instructions in the impl/review subagent prompts, new "Knowledge Base (docs/helpers/)" section, summary table note
- Updated `docs/README.md` index

## Changelog

Docs-only change; no changelog entry needed.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed