### PR TITLE
fix(runtime): bound ServerWorker timer heap with a shared sweeper (closes #555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))
 
-- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic ([#555](https://github.com/crazy-goat/workerman-bundle/issues/555)). Note: `connection_timeout: 0` now disables the timeout (previously it armed an immediate close), matching the existing `keepalive_timeout: 0` semantics.
+- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic ([#555](https://github.com/crazy-goat/workerman-bundle/issues/555)). Note: when `ServerWorker` is constructed directly with `connectionTimeout: 0`, the timeout is now disabled (previously it armed an immediate close); the YAML configuration still enforces a minimum of 1 second.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))
 
+- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic ([#555](https://github.com/crazy-goat/workerman-bundle/issues/555))
+
 ### Security
 
 - Fix the config-cache permission guard so it checks the object that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))
 
-- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic ([#555](https://github.com/crazy-goat/workerman-bundle/issues/555))
+- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic ([#555](https://github.com/crazy-goat/workerman-bundle/issues/555)). Note: `connection_timeout: 0` now disables the timeout (previously it armed an immediate close), matching the existing `keepalive_timeout: 0` semantics.
 
 ### Security
 

--- a/docs/helpers/decisions.md
+++ b/docs/helpers/decisions.md
@@ -17,10 +17,17 @@ not reintroduce chunked sends for regular responses.
 `StreamedResponseStrategy` (docs fix #622). Any new response path must go
 through the strategy layer, not the handler.
 
-### Per-connection timers are cancelled on connection close
+### One worker-level sweeper enforces connection/keepalive timeouts (supersedes per-connection timers)
 
-All timers registered per connection must be cancelled in the close
-handler, otherwise they fire for dead connections (fix #571, #616).
+ServerWorker enforces `connection_timeout` and `keepalive_timeout` via one
+persistent worker-level sweeper plus `context->lastActivity` /
+`context->requestCompleted` timestamps instead of per-connection timers
+(#555, 8294c49). This supersedes the earlier "Per-connection timers are
+cancelled on connection close" decision (fix #571, #616): the sweeper
+intentionally survives connection close, and `onClose` clears the context
+so closed connections are skipped. Timeouts are enforced with sweep
+interval granularity (`max(1, intdiv(min(timeout), 4))` seconds), not
+exactly, and activity is whole-second granular.
 
 ### Negative realpath cache is capped
 

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -60,6 +60,12 @@ When invoking `ServerWorker::onWorkerStart` directly in a unit test, initialize
 event loop before `onWorkerStart`; direct callback tests otherwise register
 process-level alarm timers instead of timers on the test loop.
 
+Timer-count assertions see an empty loop after `runEventLoopFor`:
+`Select::stop()` calls `deleteAllTimer()`. And because the sweeper's
+activity bookkeeping is second-granular (`time()`), "closed within X"
+timeout tests must run the loop for more than two sweep intervals (e.g.
+2.2 s with a 1 s interval) to avoid second-boundary phase flakes.
+
 ## Long-running worker gotchas
 
 ### Symfony container / service state survives requests

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -53,6 +53,13 @@ Always raise the limit explicitly (`--limit 100`, max 1000) or paginate
 with `--page N` — otherwise issues beyond the first page are silently
 missed during triage.
 
+## Worker timer tests
+
+When invoking `ServerWorker::onWorkerStart` directly in a unit test, initialize
+`Workerman\Timer` with the test event loop first. Production initializes the
+event loop before `onWorkerStart`; direct callback tests otherwise register
+process-level alarm timers instead of timers on the test loop.
+
 ## Long-running worker gotchas
 
 ### Symfony container / service state survives requests

--- a/docs/security.md
+++ b/docs/security.md
@@ -205,13 +205,13 @@ The HTTP server exposes configurable timeouts to protect against slowloris-style
 
 The maximum time (in seconds) to wait for a complete request (headers + body) on a newly established connection. If the client does not send the complete request within this window, the connection is closed. This prevents slow-read attacks where an attacker sends headers or body data byte-by-byte.
 
-Default: `120` seconds.
+Default: `120` seconds. Timeout checks run from a shared worker-level sweeper, so a connection may remain open until the next sweep (at most approximately one quarter of the smallest configured timeout, with a minimum one-second interval).
 
 ### keepalive_timeout
 
 The maximum idle time (in seconds) to keep a keep-alive connection open after the previous request has been fully processed. If no new request arrives within this window, the connection is closed. This prevents idle connections from consuming worker capacity indefinitely.
 
-Default: `30` seconds.
+Default: `30` seconds. As with `connection_timeout`, enforcement uses the shared sweeper's interval rather than a dedicated timer for each connection.
 
 ### body_size_cap (per-server)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -205,7 +205,7 @@ The HTTP server exposes configurable timeouts to protect against slowloris-style
 
 The maximum time (in seconds) to wait for a complete request (headers + body) on a newly established connection. If the client does not send the complete request within this window, the connection is closed. This prevents slow-read attacks where an attacker sends headers or body data byte-by-byte.
 
-Default: `120` seconds. Timeout checks run from a shared worker-level sweeper, so a connection may remain open until the next sweep (at most approximately one quarter of the smallest configured timeout, with a minimum one-second interval).
+Default: `120` seconds. Timeout checks run from a shared worker-level sweeper, so a connection may remain open until the next sweep (at most approximately one quarter of the smallest configured timeout, with a minimum one-second interval). Because activity is tracked at whole-second granularity, a connection may also be closed up to about one second *before* its exact timeout.
 
 ### keepalive_timeout
 

--- a/src/Worker/ServerWorker.php
+++ b/src/Worker/ServerWorker.php
@@ -63,25 +63,17 @@ final readonly class ServerWorker
         $bodySizeCap = $serverConfig['body_size_cap'] ?? null;
 
         $worker->onClose = function (TcpConnection $connection): void {
-            $this->cancelConnectionTimers($connection);
             $connection->context = null;
         };
 
-        $worker->onConnect = function (TcpConnection $connection) use ($connectionTimeout, $bodySizeCap): void {
+        $worker->onConnect = function (TcpConnection $connection) use ($bodySizeCap): void {
             if ($bodySizeCap !== null) {
                 $connection->maxPackageSize = $bodySizeCap;
             }
 
             $connection->context ??= new \stdClass();
-            $connectionReference = \WeakReference::create($connection);
-            $connection->context->connectionTimerId = Timer::add(
-                $connectionTimeout,
-                static function () use ($connectionReference): void {
-                    $connectionReference->get()?->close();
-                },
-                [],
-                false,
-            );
+            $connection->context->lastActivity = time();
+            $connection->context->requestCompleted = false;
 
             // Defence-in-depth backstop: if a throwable escapes
             // HttpRequestHandler's own try/catch (e.g. from a future
@@ -101,16 +93,39 @@ final readonly class ServerWorker
                     $e->getLine(),
                 ));
 
-                // Clean up per-connection timers so they don't keep
-                // firing on a defunct connection after close().
-                $this->cancelConnectionTimers($connection);
-
                 $connection->close();
             };
         };
 
-        $worker->onWorkerStart = function (Worker $worker) use ($kernelFactory, $serverConfig, $keepaliveTimeout): void {
+        $worker->onWorkerStart = function (Worker $worker) use ($connectionTimeout, $kernelFactory, $keepaliveTimeout, $serverConfig): void {
             Http::requestClass(Request::class);
+
+            $timeouts = array_filter(
+                [$connectionTimeout, $keepaliveTimeout],
+                static fn(int $timeout): bool => $timeout > 0,
+            );
+            if ($timeouts !== []) {
+                $sweepInterval = max(1, intdiv(min($timeouts), 4));
+                Timer::add($sweepInterval, static function () use ($connectionTimeout, $keepaliveTimeout, $worker): void {
+                    $now = time();
+                    foreach ($worker->connections as $connection) {
+                        if (!$connection->context instanceof \stdClass) {
+                            continue;
+                        }
+
+                        $lastActivity = $connection->context->lastActivity ?? null;
+                        $requestCompleted = $connection->context->requestCompleted ?? false;
+                        if (!is_int($lastActivity)) {
+                            continue;
+                        }
+
+                        $timeout = $requestCompleted ? $keepaliveTimeout : $connectionTimeout;
+                        if ($timeout > 0 && $now - $lastActivity >= $timeout) {
+                            $connection->close();
+                        }
+                    }
+                }, [], true);
+            }
 
             $serveFiles = $serverConfig['serve_files'] ?? false;
             $rootDir = $serveFiles ? $serverConfig['root_dir'] ?? null : null;
@@ -121,26 +136,16 @@ final readonly class ServerWorker
 
             $handler = $this->configureHandler($kernel, $serverConfig, $rootDir);
 
-            $worker->onMessage = function (TcpConnection $connection, Request $request) use ($handler, $keepaliveTimeout): void {
-                $this->cancelConnectionTimers($connection);
-
+            $worker->onMessage = function (TcpConnection $connection, Request $request) use ($handler): void {
                 try {
                     $handler($connection, $request);
                 } finally {
                     $request->resetHeaders();
                 }
 
-                if ($keepaliveTimeout > 0) {
-                    $connection->context ??= new \stdClass();
-                    $connectionReference = \WeakReference::create($connection);
-                    $connection->context->keepaliveTimerId = Timer::add(
-                        $keepaliveTimeout,
-                        static function () use ($connectionReference): void {
-                            $connectionReference->get()?->close();
-                        },
-                        [],
-                        false,
-                    );
+                if ($connection->context instanceof \stdClass) {
+                    $connection->context->lastActivity = time();
+                    $connection->context->requestCompleted = true;
                 }
             };
         };
@@ -192,23 +197,6 @@ final readonly class ServerWorker
         }
 
         return $callable;
-    }
-
-    private function cancelConnectionTimers(TcpConnection $connection): void
-    {
-        if (!$connection->context instanceof \stdClass) {
-            return;
-        }
-
-        if (isset($connection->context->keepaliveTimerId)) {
-            Timer::del($connection->context->keepaliveTimerId);
-            unset($connection->context->keepaliveTimerId);
-        }
-
-        if (isset($connection->context->connectionTimerId)) {
-            Timer::del($connection->context->connectionTimerId);
-            unset($connection->context->connectionTimerId);
-        }
     }
 
     /**

--- a/tests/Fixtures/control_byte_dos_e2e_runner.php
+++ b/tests/Fixtures/control_byte_dos_e2e_runner.php
@@ -61,7 +61,6 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
-use Workerman\Timer;
 use Workerman\Worker;
 
 if (!is_dir($workDir) && !mkdir($workDir, 0700, true) && !is_dir($workDir)) {
@@ -252,14 +251,6 @@ $worker->onConnect = static function (TcpConnection $connection): void {
             $e->getFile(),
             $e->getLine(),
         ));
-        if (isset($connection->context->keepaliveTimerId)) {
-            Timer::del($connection->context->keepaliveTimerId);
-            unset($connection->context->keepaliveTimerId);
-        }
-        if (isset($connection->context->connectionTimerId)) {
-            Timer::del($connection->context->connectionTimerId);
-            unset($connection->context->connectionTimerId);
-        }
         $connection->close();
     };
 };

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -28,6 +28,8 @@ final class ServerWorkerTest extends TestCase
         $this->tempDir = sys_get_temp_dir() . '/workerman-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
 
+        Timer::init(new Select());
+
         if (Worker::$outputStream === null) {
             $stream = fopen('php://memory', 'w');
             if ($stream === false) {
@@ -42,6 +44,8 @@ final class ServerWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
+        Timer::delAll();
+
         $files = glob($this->tempDir . '/*');
         if (is_array($files)) {
             foreach ($files as $file) {
@@ -538,8 +542,6 @@ final class ServerWorkerTest extends TestCase
 
         $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
         $connection->context = new \stdClass();
-        $connection->context->connectionTimerId = null;
-        $connection->context->keepaliveTimerId = null;
         $onMessage = $worker->onMessage;
         $this->assertNotNull($onMessage);
         $request = new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -786,7 +788,6 @@ final class ServerWorkerTest extends TestCase
 
         $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
         $connection->context = new \stdClass();
-        $connection->context->connectionTimerId = null;
 
         $onConnect = $worker->onConnect;
         $this->assertNotNull($onConnect, 'onConnect must be set');
@@ -835,7 +836,6 @@ final class ServerWorkerTest extends TestCase
 
         $connection = (new \ReflectionClass(TcpConnection::class))->newInstanceWithoutConstructor();
         $connection->context = new \stdClass();
-        $connection->context->connectionTimerId = null;
 
         $onConnect = $worker->onConnect;
         $this->assertNotNull($onConnect);
@@ -928,11 +928,10 @@ final class ServerWorkerTest extends TestCase
         $this->assertNotNull($worker->onMessage, 'onMessage should be set after onWorkerStart');
     }
 
-    public function testOnCloseCancelsPerConnectionTimersAndClearsContext(): void
+    public function testOnCloseClearsContextAndLeavesSharedSweeperRunning(): void
     {
-        $worker = $this->createStartedWorkerForTimerTests('ows-close-timers', 5, 5);
         $eventLoop = new Select();
-        Timer::init($eventLoop);
+        $worker = $this->createStartedWorkerForTimerTests('ows-close-timers', 5, 5, $eventLoop);
 
         [$idleConnection, $idlePeer] = $this->createRealConnection($eventLoop);
         [$keepaliveConnection, $keepalivePeer] = $this->createRealConnection($eventLoop);
@@ -941,25 +940,25 @@ final class ServerWorkerTest extends TestCase
 
         try {
             $baseline = $eventLoop->getTimerCount();
-            $this->assertSame(0, $baseline);
+            $this->assertSame(1, $baseline);
 
             $onConnect = $worker->onConnect;
             $this->assertNotNull($onConnect);
             $onConnect($idleConnection);
-            $this->assertSame($baseline + 1, $eventLoop->getTimerCount(), 'connection timeout timer should be armed on connect');
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'connecting must not add a per-connection timer');
 
             $idleConnection->close();
-            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing before a request must cancel the connection-timeout timer');
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing before a request must not remove the shared sweeper');
             $this->assertNull($idleConnection->context, 'worker-level onClose should clear connection context');
 
             $onConnect($keepaliveConnection);
             $onMessage = $worker->onMessage;
             $this->assertNotNull($onMessage);
             $onMessage($keepaliveConnection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
-            $this->assertSame($baseline + 1, $eventLoop->getTimerCount(), 'keepalive timer should be armed after a request');
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'requests must not add a per-connection timer');
 
             $keepaliveConnection->close();
-            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing after a request must cancel the keepalive timer');
+            $this->assertSame($baseline, $eventLoop->getTimerCount(), 'closing after a request must not remove the shared sweeper');
             $this->assertNull($keepaliveConnection->context, 'worker-level onClose should clear connection context after keepalive close');
         } finally {
             Timer::delAll();
@@ -970,9 +969,8 @@ final class ServerWorkerTest extends TestCase
 
     public function testClosedConnectionIsCollectableAfterDestroyAndEventLoopTick(): void
     {
-        $worker = $this->createStartedWorkerForTimerTests('ows-weakref', 5, 5);
         $eventLoop = new Select();
-        Timer::init($eventLoop);
+        $worker = $this->createStartedWorkerForTimerTests('ows-weakref', 5, 5, $eventLoop);
 
         [$connection, $peer] = $this->createRealConnection($eventLoop);
         $this->bindConnectionToWorker($connection, $worker);
@@ -1000,9 +998,8 @@ final class ServerWorkerTest extends TestCase
 
     public function testConnectionTimeoutStillClosesIdleConnections(): void
     {
-        $worker = $this->createStartedWorkerForTimerTests('ows-connection-timeout', 1, 5);
         $eventLoop = new Select();
-        Timer::init($eventLoop);
+        $worker = $this->createStartedWorkerForTimerTests('ows-connection-timeout', 1, 5, $eventLoop);
 
         [$connection, $peer] = $this->createRealConnection($eventLoop);
         $this->bindConnectionToWorker($connection, $worker);
@@ -1016,7 +1013,7 @@ final class ServerWorkerTest extends TestCase
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
-            $this->assertSame(0, $eventLoop->getTimerCount());
+            $this->assertSame(0, $eventLoop->getTimerCount(), 'stopping the test event loop clears its timers');
         } finally {
             Timer::delAll();
             @fclose($peer);
@@ -1025,9 +1022,8 @@ final class ServerWorkerTest extends TestCase
 
     public function testKeepaliveTimeoutStillClosesInactiveConnections(): void
     {
-        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-timeout', 5, 1);
         $eventLoop = new Select();
-        Timer::init($eventLoop);
+        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-timeout', 5, 1, $eventLoop);
 
         [$connection, $peer] = $this->createRealConnection($eventLoop);
         $this->bindConnectionToWorker($connection, $worker);
@@ -1045,7 +1041,7 @@ final class ServerWorkerTest extends TestCase
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
-            $this->assertSame(0, $eventLoop->getTimerCount());
+            $this->assertSame(0, $eventLoop->getTimerCount(), 'stopping the test event loop clears its timers');
         } finally {
             Timer::delAll();
             @fclose($peer);
@@ -1054,9 +1050,8 @@ final class ServerWorkerTest extends TestCase
 
     public function testKeepaliveTimeoutZeroDoesNotScheduleKeepaliveTimer(): void
     {
-        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-zero', 5, 0);
         $eventLoop = new Select();
-        Timer::init($eventLoop);
+        $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-zero', 5, 0, $eventLoop);
 
         [$connection, $peer] = $this->createRealConnection($eventLoop);
         $this->bindConnectionToWorker($connection, $worker);
@@ -1068,14 +1063,44 @@ final class ServerWorkerTest extends TestCase
             $this->assertNotNull($onMessage);
 
             $onConnect($connection);
-            $this->assertSame(1, $eventLoop->getTimerCount(), 'connection timeout timer should be armed before the first request');
+            $this->assertSame(1, $eventLoop->getTimerCount(), 'the shared sweeper should be armed before the first request');
 
             $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
-            $this->assertSame(0, $eventLoop->getTimerCount(), 'keepaliveTimeout=0 must leave no timer armed after a request');
+            $this->assertSame(1, $eventLoop->getTimerCount(), 'keepaliveTimeout=0 must not add a per-connection timer');
 
             $this->runEventLoopFor($eventLoop, 0.05);
 
             $this->assertSame(TcpConnection::STATUS_ESTABLISHED, $connection->getStatus(), 'keepaliveTimeout=0 should not close active keep-alive connections');
+        } finally {
+            $connection->destroy();
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testRepeatedRequestsDoNotGrowSelectTimerHeap(): void
+    {
+        $eventLoop = new Select();
+        $worker = $this->createStartedWorkerForTimerTests('ows-bounded-timers', 120, 30, $eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $onMessage = $worker->onMessage;
+            $this->assertNotNull($onConnect);
+            $this->assertNotNull($onMessage);
+            $onConnect($connection);
+
+            for ($requestNumber = 0; $requestNumber < 100_000; ++$requestNumber) {
+                $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+            }
+
+            $scheduler = (new \ReflectionProperty(Select::class, 'scheduler'))->getValue($eventLoop);
+            assert($scheduler instanceof \SplPriorityQueue);
+            $this->assertSame(1, $eventLoop->getTimerCount());
+            $this->assertSame(1, $scheduler->count(), 'the persistent sweeper must be the only Select heap entry');
         } finally {
             $connection->destroy();
             Timer::delAll();
@@ -1094,7 +1119,7 @@ final class ServerWorkerTest extends TestCase
         return null;
     }
 
-    private function createStartedWorkerForTimerTests(string $name, int $connectionTimeout, int $keepaliveTimeout): Worker
+    private function createStartedWorkerForTimerTests(string $name, int $connectionTimeout, int $keepaliveTimeout, Select $eventLoop): Worker
     {
         $handler = $this->getMockBuilder(StaticFileHandlerInterface::class)
             ->disableOriginalConstructor()
@@ -1111,6 +1136,8 @@ final class ServerWorkerTest extends TestCase
         $kernel = $this->createMock(KernelInterface::class);
         $kernel->method('boot');
         $kernel->method('getContainer')->willReturn($container);
+
+        Timer::init($eventLoop);
 
         new ServerWorker(
             new KernelFactory(fn(): KernelInterface => $kernel, []),

--- a/tests/ServerWorkerTest.php
+++ b/tests/ServerWorkerTest.php
@@ -1009,7 +1009,7 @@ final class ServerWorkerTest extends TestCase
             $this->assertNotNull($onConnect);
             $onConnect($connection);
 
-            $this->runEventLoopFor($eventLoop, 1.3);
+            $this->runEventLoopFor($eventLoop, 2.2);
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
@@ -1037,7 +1037,7 @@ final class ServerWorkerTest extends TestCase
             $onConnect($connection);
             $onMessage($connection, new Request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
 
-            $this->runEventLoopFor($eventLoop, 1.3);
+            $this->runEventLoopFor($eventLoop, 2.2);
 
             $this->assertSame(TcpConnection::STATUS_CLOSED, $connection->getStatus());
             $this->assertNull($connection->context);
@@ -1048,7 +1048,7 @@ final class ServerWorkerTest extends TestCase
         }
     }
 
-    public function testKeepaliveTimeoutZeroDoesNotScheduleKeepaliveTimer(): void
+    public function testKeepaliveTimeoutZeroKeepsOnlySweeperTimer(): void
     {
         $eventLoop = new Select();
         $worker = $this->createStartedWorkerForTimerTests('ows-keepalive-zero', 5, 0, $eventLoop);
@@ -1071,6 +1071,27 @@ final class ServerWorkerTest extends TestCase
             $this->runEventLoopFor($eventLoop, 0.05);
 
             $this->assertSame(TcpConnection::STATUS_ESTABLISHED, $connection->getStatus(), 'keepaliveTimeout=0 should not close active keep-alive connections');
+        } finally {
+            $connection->destroy();
+            Timer::delAll();
+            @fclose($peer);
+        }
+    }
+
+    public function testZeroTimeoutsDoNotArmSweeper(): void
+    {
+        $eventLoop = new Select();
+        $worker = $this->createStartedWorkerForTimerTests('ows-zero-timeouts', 0, 0, $eventLoop);
+
+        [$connection, $peer] = $this->createRealConnection($eventLoop);
+        $this->bindConnectionToWorker($connection, $worker);
+
+        try {
+            $onConnect = $worker->onConnect;
+            $this->assertNotNull($onConnect);
+            $onConnect($connection);
+
+            $this->assertSame(0, $eventLoop->getTimerCount(), 'zero/negative timeouts must not arm the sweeper');
         } finally {
             $connection->destroy();
             Timer::delAll();


### PR DESCRIPTION
## Description

Closes #555

Per-request `Timer::add`/`Timer::del` pairs on the default `Select` event loop left stale `SplPriorityQueue` heap entries alive until their scheduled run time (up to `connection_timeout`/`keepalive_timeout`), measured at +8 MB retained after 150 000 keep-alive requests. That garbage counts toward `memory_get_usage()` and interacts with `MemoryRebootStrategy` (128 MB default), forcing avoidable worker reloads.

The fix replaces per-connection timers with:
- `context->lastActivity` / `context->requestCompleted` timestamps updated only after the handler returns (plus an `instanceof \stdClass` guard for connections closed mid-handling), and
- one persistent worker-level sweeper (`max(1, intdiv(min(timeout), 4))` interval) that closes idle / slow-read connections.

Behavior preserved: separate incomplete-request (`connection_timeout`) and keep-alive (`keepalive_timeout`) enforcement, `0` disables, throwable backstop (#577), and the slow-read semantics (activity is not updated on partial data — same as before).

## Changes

- `src/Worker/ServerWorker.php`: remove per-connection timer bookkeeping; add shared sweeper + activity timestamps
- `tests/ServerWorkerTest.php`: `testRepeatedRequestsDoNotGrowSelectTimerHeap` (100 000 simulated requests, `SplPriorityQueue` inspected directly — exactly 1 heap entry), timeout behavior tests, phase-flake fix (loop window >2 sweep intervals), `testZeroTimeoutsDoNotArmSweeper`
- `tests/Fixtures/control_byte_dos_e2e_runner.php`: drop inert legacy timer cleanup, mirror current `ServerWorker` errorHandler
- `docs/security.md`: document sweeper granularity (late + up to ~1 s early)
- `docs/helpers/`: new decision (sweeper supersedes #571 per-connection-timer decision), faq gotchas
- `CHANGELOG.md`: entry under [Unreleased] → Fixed, incl. `connectionTimeout: 0` semantic note (direct construction; YAML keeps `min: 1`)

## Changelog

```
### Fixed

- Replace per-request connection timers with one worker-level sweeper and activity timestamps, preventing cancelled `Select` timer entries from retaining memory under sustained keep-alive traffic (#555). Note: when `ServerWorker` is constructed directly with `connectionTimeout: 0`, the timeout is now disabled (previously it armed an immediate close); the YAML configuration still enforces a minimum of 1 second.
```

## Code Review

- [x] Passed subagent code review (round 1: 6 findings → fixed; round 2: clean verification, 1 doc nit → fixed)
- [x] All review comments addressed

Local validation: 1704 tests / 13672 assertions green, php-cs-fixer + PHPStan (level 8) + rector clean, E2E daemon suite passes.