### PR TITLE
docs: add subagent-based finding verification to workflow step 14

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -334,6 +334,35 @@ dedicated GitHub issue.
    description, and suggested fix (including findings outside the scope of the
    issue just closed).
 
+**Verify each candidate finding with a review subagent (read-only) before
+offering or creating an issue.** For every candidate finding the subagent
+must confirm:
+
+1. **The finding is real** - read the cited file/line(s) on the current
+   branch and confirm the behavior actually occurs and is reachable; check
+   whether it is by-design and already documented (those are skipped, not
+   filed).
+2. **No similar issue exists on GitHub** - search open *and* closed issues.
+   `gh issue list` returns at most 30 issues by default, so always pass an
+   explicit limit:
+
+```bash
+gh issue list --state open --limit 150 --json number,title,labels,body
+gh issue list --state closed --limit 150 --json number,title,labels
+gh search issues --repo <owner>/<repo> --state open --limit 50 "<keyword>"
+```
+
+   Same or overlapping scope counts as tracked; known related issues (e.g.
+   referenced from CHANGELOG entries) must be checked explicitly.
+3. **A recommendation per finding**: (a) create a new issue - with proposed
+   title and labels per the project's conventions (`bug` / `enhancement` /
+   `code-quality` / `minor` / …), (b) skip - already tracked (cite the issue
+   number), or (c) skip - not real or by-design and documented.
+
+The verification subagent must not modify files and must not create/close/
+edit issues itself. Only findings that pass verification (real + untracked)
+are offered to the user / created.
+
 **Then ask:** "Create GitHub issue(s) for these findings?"
 
 - If yes, create an issue via `gh` (adjust labels to the project's conventions):
@@ -430,7 +459,9 @@ git checkout master && git pull origin master
 
 # 11. Report + offer GitHub issue for discovered problems
 #    show: biggest problem(s), discovered bugs / places to improve
-#    ask: "Create GitHub issue(s)?" → if yes: gh issue create ...
+#    verify each candidate with a review subagent (finding is real?
+#    no duplicate on GitHub? use --limit >30 in issue lists)
+#    then ask: "Create GitHub issue(s)?" → if yes: gh issue create ...
 ```
 
 ---
@@ -445,6 +476,7 @@ session's context lean:
 | 1    | Triage open issues, return ranked shortlist | Issue bodies + comments are token-heavy |
 | 3    | Implement the issue (worker/coder)         | Coding context is token-heavy; agent returns structured report (files, biggest problem, discovered bugs) |
 | 4    | Code review of the implementation diff     | Full diff + surrounding code is token-heavy |
+| 14   | Verify candidate findings before creating GitHub issues (read-only: is the finding real? is it already tracked?) | GitHub duplicate search (open + closed, `--limit` > 30) plus code verification across several findings is query-heavy |
 
 All subagents have read/write/edit/bash tools and operate on the same
 repository. Give each one a clear, scoped instruction and a defined output

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -346,11 +346,11 @@ must confirm:
    `gh issue list` returns at most 30 issues by default, so always pass an
    explicit limit:
 
-```bash
-gh issue list --state open --limit 150 --json number,title,labels,body
-gh issue list --state closed --limit 150 --json number,title,labels
-gh search issues --repo <owner>/<repo> --state open --limit 50 "<keyword>"
-```
+   ```bash
+   gh issue list --state open --limit 150 --json number,title,labels,body
+   gh issue list --state closed --limit 150 --json number,title,labels
+   gh search issues --repo <owner>/<repo> --state open --limit 50 "<keyword>"
+   ```
 
    Same or overlapping scope counts as tracked; known related issues (e.g.
    referenced from CHANGELOG entries) must be checked explicitly.
@@ -360,8 +360,9 @@ gh search issues --repo <owner>/<repo> --state open --limit 50 "<keyword>"
    number), or (c) skip - not real or by-design and documented.
 
 The verification subagent must not modify files and must not create/close/
-edit issues itself. Only findings that pass verification (real + untracked)
-are offered to the user / created.
+edit issues itself. Like steps 3 and 4, it reads `docs/helpers/`
+(faq.md, decisions.md) first. Only findings that pass verification (real +
+untracked) are offered to the user / created.
 
 **Then ask:** "Create GitHub issue(s) for these findings?"
 
@@ -468,7 +469,7 @@ git checkout master && git pull origin master
 
 ## Subagent Usage Summary
 
-Three steps of this workflow are delegated to subagents to keep the main
+Four steps of this workflow are delegated to subagents to keep the main
 session's context lean:
 
 | Step | Subagent task                              | Why delegate                          |
@@ -479,9 +480,10 @@ session's context lean:
 | 14   | Verify candidate findings before creating GitHub issues (read-only: is the finding real? is it already tracked?) | GitHub duplicate search (open + closed, `--limit` > 30) plus code verification across several findings is query-heavy |
 
 All subagents have read/write/edit/bash tools and operate on the same
-repository. Give each one a clear, scoped instruction and a defined output
-format (ranked list with rationale / numbered findings list / coder report
-with biggest problem + discovered bugs).
+repository (the step-14 verifier is instructed to run read-only). Give each
+one a clear, scoped instruction and a defined output format (ranked list
+with rationale / numbered findings list / coder report with biggest problem
++ discovered bugs / per-finding verification verdict).
 
 **Knowledge base:** implementation and review subagents read
 `docs/helpers/` before starting and append learnings after finishing


### PR DESCRIPTION
## Description

Documents the finding-verification step added to the repository workflow (**docs/workflow.md**, step 14): before a discovered implementation finding is offered or created as a GitHub issue, a `review` subagent must verify read-only that (1) the finding is real (file:line evidence, reachable, not by-design-and-documented), (2) no similar issue exists on GitHub — open + closed lists with explicit `--limit 150`, since `gh issue list` returns at most 30 by default, plus `gh search issues` by keyword — and (3) return a per-finding recommendation: create (with proposed title/labels) / already tracked (cite number) / skip.

Only findings that pass verification (real + untracked) are offered to the user. This PR formalizes what was done manually after #555 (verification via review subagent → issue #625; finding B skipped as by-design/documented).

## Changes

- `docs/workflow.md` step 14: new verification sub-section between the findings report and the "Create GitHub issue(s)?" question
- Quick Reference: step 11 line updated to mention verification + `--limit >30`
- Subagent Usage Summary: fourth row (step 14) added, intro matches ("Four steps"), read-only note in the footer, verification verdict added to the output-format list
- Step-14 verifier reads `docs/helpers/` first, like steps 3 and 4

## Changelog

Docs-only change to the internal workflow document — no CHANGELOG entry (same as #623).

## Code Review

- [x] Passed subagent code review (4 findings — stale "Three steps", unindented code fence, summary footer, knowledge-base pointer — all addressed in `71bb44a`)
- [x] All review comments addressed