### PR TITLE
fix(dto): URL-decode cookie values like PHP's SAPI (closes #583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- URL-decode cookie values in `parseCookiesFromServerBag()` with `rawurldecode()` semantics, so values written by Symfony's `Cookie` (which `rawurlencode()`s in `__toString()`) round-trip exactly as they do under PHP-FPM. Decoding matches PHP's SAPI (`php_raw_url_decode`: `%XX` decoded, literal `+` preserved) and runs strictly after splitting the header on `;` and `=`, so an encoded `%3B` in a value is never reinterpreted as a cookie separator and the duplicate-`Cookie`-header smuggling fix ([#217](https://github.com/crazy-goat/workerman-bundle/issues/217)) stays intact
+  ([#583](https://github.com/crazy-goat/workerman-bundle/issues/583))
+
 - Fix the config-cache permission guard so it checks the object that
   actually governs file replacement: the **containing directory**. The
   previous check only examined the cache file's world-writable bit, but on

--- a/benchmarks/RequestConverterBench.md
+++ b/benchmarks/RequestConverterBench.md
@@ -24,3 +24,18 @@ Working tree after the underscore-header filter.
 | `benchHeaderHeavyRequest` | 6.042 μs |
 | `benchMultipartRequest` | 5.737 μs |
 | `benchResetHeaders` | 0.113 μs |
+
+## Cookie value URL-decoding (issue #583)
+
+Source commit: `fbd0318` adds one `rawurldecode()` per cookie value on the hot
+path (for FPM parity). Measured with the same environment as above, 1000
+revisions × 5 iterations:
+
+| Subject | Before (#583) | After (fbd0318) | Δ |
+| --- | ---: | ---: | ---: |
+| `benchSimpleRequest` | 2.736 μs | 2.842 μs | +0.106 μs |
+| `benchHeaderHeavyRequest` (1 cookie) | 5.794 μs | 6.001 μs | +0.207 μs |
+
+Per-cookie decode cost ≈ 0.1–0.2 μs; within run-to-run noise (an independent
+run measured 6.06 μs before vs 6.18 μs after on `benchHeaderHeavyRequest`).
+No regression considered material.

--- a/docs/helpers/decisions.md
+++ b/docs/helpers/decisions.md
@@ -70,3 +70,15 @@ php-cs-fixer, phpstan and rector (dry-run). Keep `composer lint` /
 `worker`/`coder` and `review` subagents read and append to
 `docs/helpers/` (see [README.md](README.md)). This keeps project memory
 persistent across sessions.
+
+### Cookie values are raw-URL-decoded exactly like PHP's SAPI (#583)
+
+`RequestConverter::parseCookiesFromServerBag()` decodes cookie values with
+`rawurldecode()` semantics **after** splitting on `;`/`=`, mirroring PHP's
+`php_default_treat_data()` → `php_raw_url_decode()` step that populates
+`$_COOKIE` under FPM and every other SAPI. Verified from `main/php_variables.c`
+(PHP-8.2) and live probes: `%XX` sequences decode, a literal `+` stays `+`
+(it is NOT turned into a space — despite the widespread assumption that cookie
+values are `urldecode()`d), and cookie names are not decoded at all. Decoding
+is ordered after splitting so an encoded `%3B` can never re-open the #217
+smuggling class.

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,7 +57,10 @@ split.
 Known intentional deviations from `$_COOKIE`, kept for backwards
 compatibility: duplicate cookie names keep the last value (PHP keeps the
 first), and PHP's cookie-name rewriting (` ` and `.` → `_`, `name[key]` array
-syntax) is not reproduced — the bundle treats names verbatim.
+syntax) is not reproduced — the bundle treats names verbatim. One further
+whitespace micro-deviation: PHP strips leading whitespace of a value
+(`a= b` → `b`) but keeps trailing whitespace, while the bundle trims both
+ends on the raw pair.
 
 ### Duplicate Sensitive Headers
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -32,6 +32,33 @@ Cookie: token=xyz789
 → Cookies correctly parsed as two cookies: session=abc123, token=xyz789
 ```
 
+### Cookie Value Decoding (PHP SAPI Parity)
+
+The bundle deliberately reproduces PHP's SAPI cookie-decoding semantics.
+`parseCookiesFromServerBag()` splits the joined header on `;` and the first
+`=` of each pair, then URL-decodes the value with `rawurldecode()` semantics
+— matching the `php_raw_url_decode()` step that populates `$_COOKIE` under
+PHP-FPM and every other SAPI: `%XX` sequences decode to their byte, while a
+literal `+` in a cookie value is **preserved** and does not become a space
+despite the common assumption that cookies use `urldecode()` semantics.
+Cookie names are not decoded, exactly like PHP.
+
+This is what makes the Symfony write path round-trip: Symfony's
+`Cookie::__toString()` serialises values with `rawurlencode()`, and without
+this decode a cookie holding base64 (`=`, `+`, `/`), a signature separator
+(`:`), or any non-ASCII byte came back to the application in its encoded form
+— silently different from what PHP-FPM would deliver for the same header.
+
+Decoding must always run **after** splitting: an encoded `%3B` in a value is
+data, never a cookie separator, so the duplicate-`Cookie`-header smuggling fix
+above stays intact. Do not "optimise" this decode away or move it before the
+split.
+
+Known intentional deviations from `$_COOKIE`, kept for backwards
+compatibility: duplicate cookie names keep the last value (PHP keeps the
+first), and PHP's cookie-name rewriting (` ` and `.` → `_`, `name[key]` array
+syntax) is not reproduced — the bundle treats names verbatim.
+
 ### Duplicate Sensitive Headers
 
 Duplicate `Host`, `Content-Length`, and `Authorization` headers are suspicious and may indicate request smuggling or header injection attacks. Only the first value of each is propagated to Symfony; subsequent values are silently discarded.

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -296,6 +296,14 @@ final class RequestConverter
      * This replaces Workerman's built-in cookie() call to ensure correct
      * handling when duplicate Cookie headers are present (see security issue #217).
      *
+     * Values are URL-decoded after splitting on ';' and '=' with rawurldecode()
+     * semantics, mirroring PHP's SAPI: PHP populates $_COOKIE via
+     * php_raw_url_decode(), so %XX sequences are decoded but a literal '+' is
+     * preserved (it does not become a space — see docs/security.md). Decoding
+     * must never run before splitting, or an encoded '%3B' in a value would be
+     * reinterpreted as a cookie separator and reintroduce the smuggling class
+     * closed by #217. Cookie names are not decoded, matching PHP.
+     *
      * @param array<string, mixed> $server
      *
      * @return array<string, string>
@@ -320,7 +328,7 @@ final class RequestConverter
             if ($name === '') {
                 continue;
             }
-            $cookies[$name] = $parts[1] ?? '';
+            $cookies[$name] = \rawurldecode($parts[1] ?? '');
         }
 
         return $cookies;

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -874,6 +874,127 @@ final class RequestConverterTest extends TestCase
         $this->assertSame('xyz789', $symfonyRequest->cookies->get('token'));
     }
 
+    public function testCookieValueRoundTripThroughSymfonyCookie(): void
+    {
+        $value = 'aGVsbG8=|x+y:/%';
+        $serialized = (string) new \Symfony\Component\HttpFoundation\Cookie('remember', $value);
+        $pair = \explode(';', $serialized, 2)[0];
+
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: {$pair}\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame($value, $symfonyRequest->cookies->get('remember'));
+    }
+
+    public function testRawCookieValueIsNotReencoded(): void
+    {
+        $value = 'a=b+c/d';
+        $serialized = (string) new \Symfony\Component\HttpFoundation\Cookie('rawk', $value, raw: true);
+        $pair = \explode(';', $serialized, 2)[0];
+
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: {$pair}\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame($value, $symfonyRequest->cookies->get('rawk'));
+    }
+
+    public function testEncodedSemicolonInValueIsNotTreatedAsSeparator(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: token=a%3Bb%26c\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame(['token' => 'a;b&c'], $symfonyRequest->cookies->all());
+    }
+
+    public function testEncodedPercentDecodesExactlyOnce(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: pct=%25; double=a%2525b\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame('%', $symfonyRequest->cookies->get('pct'));
+        $this->assertSame('a%25b', $symfonyRequest->cookies->get('double'));
+    }
+
+    public function testCookieDecodingMatchesPhpSapi(): void
+    {
+        // Expected values are exactly what PHP's $_COOKIE produces for the same
+        // header: php_default_treat_data() decodes cookie values with
+        // php_raw_url_decode() semantics (%XX decoded, '+' preserved verbatim)
+        // and does not decode cookie names.
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: plus=a+b; pct20=a%20b; pct3D=a%3Db; nonascii=%C4%85%C4%87; name%3Bx=keep\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame('a+b', $symfonyRequest->cookies->get('plus'));
+        $this->assertSame('a b', $symfonyRequest->cookies->get('pct20'));
+        $this->assertSame('a=b', $symfonyRequest->cookies->get('pct3D'));
+        $this->assertSame('ąć', $symfonyRequest->cookies->get('nonascii'));
+        $this->assertSame('keep', $symfonyRequest->cookies->get('name%3Bx'));
+    }
+
+    public function testEmptyAndValuelessCookies(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: empty=; valueless; named=%20\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame('', $symfonyRequest->cookies->get('empty'));
+        $this->assertSame('', $symfonyRequest->cookies->get('valueless'));
+        $this->assertSame(' ', $symfonyRequest->cookies->get('named'));
+    }
+
+    public function testDuplicateCookieNamesLastWins(): void
+    {
+        // Existing bundle behaviour: the last occurrence wins. PHP's $_COOKIE
+        // keeps the first occurrence instead; the divergence is documented in
+        // docs/security.md and intentionally not changed here.
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: dup=first; dup=second%20value\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame('second value', $symfonyRequest->cookies->get('dup'));
+    }
+
+    public function testMultipleCookieHeadersWithEncodedValuesStaySeparate(): void
+    {
+        $buffer = "GET /test HTTP/1.1\r\n";
+        $buffer .= "Host: localhost\r\n";
+        $buffer .= "Cookie: session=a%3Db\r\n";
+        $buffer .= "Cookie: token=x%20y\r\n";
+        $buffer .= "\r\n";
+
+        $symfonyRequest = RequestConverter::toSymfonyRequest(new Request($buffer));
+
+        $this->assertSame('session=a%3Db; token=x%20y', $symfonyRequest->server->get('HTTP_COOKIE'));
+        $this->assertSame('a=b', $symfonyRequest->cookies->get('session'));
+        $this->assertSame('x y', $symfonyRequest->cookies->get('token'));
+    }
+
     public function testMultipleHostHeadersKeepsFirstOnly(): void
     {
         $buffer = "GET /test HTTP/1.1\r\n";


### PR DESCRIPTION
## Description

Closes #583

Cookie values from the `Cookie:` header were passed through verbatim by `parseCookiesFromServerBag()`, but Symfony's `Cookie::__toString()` serialises values with `rawurlencode()`. Any value containing `=`, `+`, `/`, `|`, `%`, or non-ASCII bytes silently round-tripped to a different string — exactly what base64 remember-me tokens, signed cookies, and CSRF cookies contain — and diverged from PHP-FPM behavior.

## Changes

- `src/DTO/RequestConverter.php`: decode each cookie value with `rawurldecode()` **strictly after** splitting on `;`/`=`, so an encoded `%3B` can never be reinterpreted as a cookie separator (the #217 smuggling fix stays intact). Names are not decoded, matching PHP.
- `tests/RequestConverterTest.php`: 8 new tests — Symfony round-trip (covers `= + / | : %`), `raw: true` cookies, `%3B` ordering, `%25` single-decode, PHP-SAPI parity (`+` preserved, `%20`/`%3D`/non-ASCII, encoded names), empty/valueless, duplicate last-wins, multiple headers.
- `docs/security.md`: new "Cookie Value Decoding (PHP SAPI Parity)" section incl. documented deviations (duplicate names last-wins vs PHP first-wins, no name rewriting, whitespace micro-deviation).
- `benchmarks/RequestConverterBench.md`: before/after numbers (per-cookie decode ≈ 0.1–0.2 µs, no material regression).
- `CHANGELOG.md`: entry under [Unreleased] → Security.
- `docs/helpers/decisions.md`: knowledge-base entry.

**Important finding (verified, not assumed):** PHP's SAPI decodes cookie values with *raw* URL-decode semantics — `%XX` decodes, a literal `+` is **preserved**. Verified against PHP core (`php_default_treat_data(PARSE_COOKIE, …)` → `php_raw_url_decode` in `main/php_variables.c`) and live probes on the built-in server (same SAPI-independent decode path FPM uses). The issue body's claim of `urldecode()` semantics (`+` → space) is incorrect; per the issue's own instruction, `rawurldecode()` was chosen and documented. This prevents a future contributor from "fixing" it back to `urldecode()`.

## Changelog

Security: URL-decode cookie values with `rawurldecode()` semantics for PHP-FPM parity (decode after split; #217 smuggling fix intact).

## Code Review

- [x] Passed subagent code review (2 rounds; round 2 verdict: "Code looks good, no issues to fix")
- [x] All review comments addressed
- [x] `composer lint` clean, full suite 1712 tests OK