### PR TITLE
fix(dto): reject CR and LF in header values (closes #581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Reject bare CR and LF, along with the rest of the non-TAB control-byte range, in incoming header values. `RequestConverter` now covers `\x00-\x08` and `\x0A-\x1F` (plus `\x7F`) while retaining legal TAB values, preventing malformed header data from reaching the Symfony server bag ([#581](https://github.com/crazy-goat/workerman-bundle/issues/581))
+
 - URL-decode cookie values in `parseCookiesFromServerBag()` with `rawurldecode()` semantics, so values written by Symfony's `Cookie` (which `rawurlencode()`s in `__toString()`) round-trip exactly as they do under PHP-FPM. Decoding matches PHP's SAPI (`php_raw_url_decode`: `%XX` decoded, literal `+` preserved) and runs strictly after splitting the header on `;` and `=`, so an encoded `%3B` in a value is never reinterpreted as a cookie separator and the duplicate-`Cookie`-header smuggling fix ([#217](https://github.com/crazy-goat/workerman-bundle/issues/217)) stays intact
   ([#583](https://github.com/crazy-goat/workerman-bundle/issues/583))
 

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -66,6 +66,12 @@ activity bookkeeping is second-granular (`time()`), "closed within X"
 timeout tests must run the loop for more than two sweep intervals (e.g.
 2.2 s with a 1 s interval) to avoid second-boundary phase flakes.
 
+## Byte-oriented test helpers
+
+PHPStan requires `chr()` arguments to be provably within `0..255`. When a test
+helper accepts an integer byte, guard that range before calling `chr()` rather
+than suppressing the diagnostic.
+
 ## Long-running worker gotchas
 
 ### Symfony container / service state survives requests

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,11 +72,9 @@ Duplicate `Host`, `Content-Length`, and `Authorization` headers are suspicious a
 
 ### Control Character Rejection
 
-Header values containing control characters (`\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F`, `\x7F`) are rejected with an `\InvalidArgumentException`. This prevents:
+Header values containing bytes `\x00-\x08`, `\x0A-\x1F`, or `\x7F` are rejected with a `MalformedRequestException` (TAB, `\x09`, remains accepted because it is legal in field values). The request handler returns `400 Bad Request` for this client input. This protects against log forging and other protocol-level attacks through malformed header values.
 
-- HTTP response splitting via CR/LF injection in header values
-- Log forging via control characters in custom headers
-- Protocol-level attacks through malformed header values
+This check is not the response-splitting defence by itself. Response headers are independently protected by the `strpbrk()` CR/LF checks in Workerman's response writer and in the bundle's `DefaultResponseStrategy` and `StreamedResponseStrategy` header builders, which omit unsafe response headers rather than emitting them.
 
 ### Request URI and Method Validation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -74,7 +74,7 @@ Duplicate `Host`, `Content-Length`, and `Authorization` headers are suspicious a
 
 Header values containing bytes `\x00-\x08`, `\x0A-\x1F`, or `\x7F` are rejected with a `MalformedRequestException` (TAB, `\x09`, remains accepted because it is legal in field values). The request handler returns `400 Bad Request` for this client input. This protects against log forging and other protocol-level attacks through malformed header values.
 
-This check is not the response-splitting defence by itself. Response headers are independently protected by the `strpbrk()` CR/LF checks in Workerman's response writer and in the bundle's `DefaultResponseStrategy` and `StreamedResponseStrategy` header builders, which omit unsafe response headers rather than emitting them.
+This check is not the response-splitting defence by itself. Response headers are independently protected by the `strpbrk()` CR/LF checks in Workerman's response writer (which covers the default `WorkermanResponse` path) and in the bundle's `StreamedResponseStrategy` header builder, which omit unsafe response headers rather than emitting them.
 
 ### Request URI and Method Validation
 

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -184,7 +184,7 @@ final class RequestConverter
 
             // Validate header value for control characters
             $stringValue = (string) $value;
-            if (\preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $stringValue)) {
+            if (\preg_match('/[\x00-\x08\x0A-\x1F\x7F]/', $stringValue)) {
                 throw new MalformedRequestException(
                     \sprintf('Header "%s" contains control characters: "%s"', $nameLower, \addcslashes($stringValue, "\x00..\x1F\x7F")),
                 );

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -316,6 +316,40 @@ final class RequestConverterTest extends TestCase
         }
     }
 
+    public function testHeaderControlCharacterBoundaryIsRejectedExceptTab(): void
+    {
+        for ($byte = 0; $byte <= 0x1F; ++$byte) {
+            $this->assertHeaderByteValidation($byte);
+        }
+        $this->assertHeaderByteValidation(0x7F);
+    }
+
+    private function assertHeaderByteValidation(int $byte): void
+    {
+        if ($byte < 0 || $byte > 255) {
+            throw new \InvalidArgumentException('Header byte must fit in one byte');
+        }
+
+        $value = 'before' . chr($byte) . 'after';
+        $buffer = "GET /control-byte HTTP/1.1\r\nHost: x\r\nX-A: {$value}\r\n\r\n";
+        $rawRequest = new Request($buffer);
+
+        if ($byte === 0x09) {
+            $symfonyRequest = RequestConverter::toSymfonyRequest($rawRequest);
+            $this->assertSame($value, $symfonyRequest->server->get('HTTP_X_A'));
+
+            return;
+        }
+
+        try {
+            RequestConverter::toSymfonyRequest($rawRequest);
+            $this->fail(sprintf('Expected byte 0x%02X to be rejected', $byte));
+        } catch (MalformedRequestException $e) {
+            $this->assertInstanceOf(ClientInputExceptionInterface::class, $e);
+            $this->assertStringContainsString('control characters', $e->getMessage());
+        }
+    }
+
     public function testNonArrayFileEntryIsNotSilentlyDropped(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Description

Closes #581

## Changes

- `src/DTO/RequestConverter.php`: the header-value control-character filter now rejects `\x00-\x08` and `\x0A-\x1F` (plus `\x7F`) — closing the CR (`0x0D`) and LF (`0x0A`) gaps that Workerman's CRLF-only header split lets through. TAB (`0x09`) remains accepted (legal per RFC 9110 §5.5).
- `tests/RequestConverterTest.php`: byte-by-byte boundary test covering every value 0x00–0x1F and 0x7F; TAB round-trips byte-exact.
- `docs/security.md`: documents the actual rejected set and TAB exception; no longer claims response-splitting protection from this check alone — attributes it to the response-writer `strpbrk()` filters (Workerman writer + `StreamedResponseStrategy` builder).
- `CHANGELOG.md`: Security entry under [Unreleased].
- `docs/helpers/faq.md`: pitfall entry — PHPStan needs a proven 0..255 range before `chr()` in byte-oriented tests.

The #577 prerequisite (worker-kill DoS) is already merged: the rejection remains a `MalformedRequestException` → 400, worker survives (verified via `ControlByteWorkerDosE2ETest`).

## Changelog

Security: reject bare CR and LF (and the rest of the non-TAB control-byte range) in incoming header values.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed

## Validation

- `composer test`: 1,713 tests / 13,754 assertions passing
- `composer lint` (php-cs-fixer, phpstan, rector): clean