### PR TITLE
fix(core): run services_resetter on every request path (closes #572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Run the `services_resetter` on every request path — including kernel boot/handle exceptions, trusted-host rejections, and kernels that do not implement `TerminableInterface` — so request-scoped Symfony service state cannot leak between requests in a long-running Workerman process ([#572](https://github.com/crazy-goat/workerman-bundle/issues/572))
+
 - Stop manually splitting buffered responses into 8 KiB sends. `DefaultResponseStrategy` now returns the complete body to Workerman's transport, avoiding redundant `substr()` copies and write syscalls; preserve the request's HTTP protocol version on converted responses ([#556](https://github.com/crazy-goat/workerman-bundle/issues/556))
 
 - Cancel `ServerWorker`'s per-connection timeout and keep-alive timers on connection close, centralize timer cleanup in one helper shared by `onMessage` and `onClose`, and keep `BinaryFileResponseStrategy` temp-file cleanup chained correctly with the worker-level `onClose` base callback ([#571](https://github.com/crazy-goat/workerman-bundle/issues/571))

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -82,3 +82,9 @@ handlers, caching repositories, static/global state) leaks data between
 requests. See [docs/troubleshooting.md](../troubleshooting.md) for
 detection and mitigation (`kernel.reset`, `EntityManager::clear()`,
 reload strategies).
+
+The `services_resetter` must run independently of `TerminableInterface` and
+also on kernel/response exceptions. `terminateIfNeeded()` owns the reset and
+must clear request references even when no kernel termination is available;
+controller failure paths reset before rethrowing so the handler can still
+send its error response (issue #572).

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -54,18 +54,21 @@ final class SymfonyController
             try {
                 $this->symfonyRequest->getHost();
             } catch (SuspiciousOperationException) {
+                $this->resetServices();
+                $this->symfonyRequest = null;
+
                 return new Response(400);
             }
         }
 
-        $this->kernel->boot();
-
         try {
+            $this->kernel->boot();
             $this->symfonyResponse = $this->kernel->handle($this->symfonyRequest);
             $this->symfonyResponse->prepare($this->symfonyRequest);
 
             return $this->responseConverter->convert($this->symfonyResponse, $connection, $request->protocolVersion());
         } catch (\Throwable $e) {
+            $this->resetServices();
             $this->symfonyRequest = null;
             $this->symfonyResponse = null;
             throw $e;
@@ -85,17 +88,21 @@ final class SymfonyController
      */
     public function terminateIfNeeded(): void
     {
-        if ($this->kernel instanceof TerminableInterface
-            && $this->symfonyRequest instanceof SymfonyRequest
-            && $this->symfonyResponse instanceof SymfonyResponse
-        ) {
-            try {
+        if (!$this->symfonyRequest instanceof SymfonyRequest && !$this->symfonyResponse instanceof SymfonyResponse) {
+            return;
+        }
+
+        try {
+            if ($this->kernel instanceof TerminableInterface
+                && $this->symfonyRequest instanceof SymfonyRequest
+                && $this->symfonyResponse instanceof SymfonyResponse
+            ) {
                 $this->kernel->terminate($this->symfonyRequest, $this->symfonyResponse);
-            } finally {
-                $this->resetServices();
-                $this->symfonyRequest = null;
-                $this->symfonyResponse = null;
             }
+        } finally {
+            $this->resetServices();
+            $this->symfonyRequest = null;
+            $this->symfonyResponse = null;
         }
     }
 

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -76,10 +76,17 @@ final class SymfonyController
     }
 
     /**
-     * Terminate the kernel if it implements TerminableInterface.
+     * Terminate the kernel and/or reset request-scoped services.
      *
      * This method should be called AFTER the response has been sent to the client,
      * typically in a deferred timer callback to avoid blocking response delivery.
+     *
+     * This method owns the services_resetter reset on every request path:
+     * kernel termination runs only for TerminableInterface kernels with both
+     * Symfony request and response objects available, while service reset and
+     * reference clearing happen unconditionally here (and in the exception /
+     * trusted-host-rejection paths inside {@see __invoke}). The guard below
+     * keeps this call idempotent so the reset never runs twice per request.
      *
      * After termination, the stored request and response references are cleared
      * to prevent memory leaks and ensure idempotency.

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -491,8 +491,10 @@ final class TestNonTerminableKernel implements KernelInterface
 {
     public bool $bootCalled = false;
 
-    public function __construct(private readonly ?SymfonyResponse $responseToReturn = null)
-    {
+    public function __construct(
+        private readonly ?SymfonyResponse $responseToReturn = null,
+        private readonly ?\Symfony\Component\DependencyInjection\ContainerInterface $container = null,
+    ) {
     }
 
     public function boot(): void
@@ -575,7 +577,11 @@ final class TestNonTerminableKernel implements KernelInterface
 
     public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
     {
-        throw new \RuntimeException('Not implemented');
+        if (!$this->container instanceof \Symfony\Component\DependencyInjection\ContainerInterface) {
+            throw new \RuntimeException('Not implemented');
+        }
+
+        return $this->container;
     }
 
     public function getStartTime(): float
@@ -694,8 +700,10 @@ final class TestThrowingKernel implements KernelInterface, TerminableInterface
     public bool $bootCalled = false;
     public bool $terminateCalled = false;
 
-    public function __construct(private readonly \Throwable $exception)
-    {
+    public function __construct(
+        private readonly \Throwable $exception,
+        private readonly ?\Symfony\Component\DependencyInjection\ContainerInterface $container = null,
+    ) {
     }
 
     public function terminate(\Symfony\Component\HttpFoundation\Request $request, \Symfony\Component\HttpFoundation\Response $response): void
@@ -783,7 +791,11 @@ final class TestThrowingKernel implements KernelInterface, TerminableInterface
 
     public function getContainer(): \Symfony\Component\DependencyInjection\ContainerInterface
     {
-        throw new \RuntimeException('Not implemented');
+        if (!$this->container instanceof \Symfony\Component\DependencyInjection\ContainerInterface) {
+            throw new \RuntimeException('Not implemented');
+        }
+
+        return $this->container;
     }
 
     public function getStartTime(): float
@@ -889,6 +901,21 @@ final class SymfonyControllerTest extends TestCase
         // Second call should not trigger terminate again (request/response are nullified)
         $controller->terminateIfNeeded();
         $this->assertSame(1, $kernel->terminateCount, 'Terminate should not be called twice');
+    }
+
+    public function testServicesResetterRunsForNonTerminableKernel(): void
+    {
+        $resetter = $this->createMock(ResetInterface::class);
+        $resetter->expects($this->once())->method('reset');
+        $container = $this->createMock(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('has')->with('services_resetter')->willReturn(true);
+        $container->method('get')->with('services_resetter')->willReturn($resetter);
+
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse(), $container);
+        $controller = new SymfonyController($kernel, $this->createResponseConverter());
+
+        $controller(new Request("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n"), $this->connection);
+        $controller->terminateIfNeeded();
     }
 
     public function testResponseHeadersAreConverted(): void
@@ -1339,6 +1366,26 @@ final class SymfonyControllerTest extends TestCase
         $this->assertFalse($kernel->terminateCalled, 'terminate() must not be called when __invoke threw — references should be null');
     }
 
+    public function testServicesResetterRunsWhenKernelHandleThrows(): void
+    {
+        $resetter = $this->createMock(ResetInterface::class);
+        $resetter->expects($this->once())->method('reset');
+        $container = $this->createMock(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('has')->with('services_resetter')->willReturn(true);
+        $container->method('get')->with('services_resetter')->willReturn($resetter);
+        $kernel = new TestThrowingKernel(new \RuntimeException('kernel crash'), $container);
+        $controller = new SymfonyController($kernel, $this->createResponseConverter());
+
+        try {
+            $controller(new Request("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n"), $this->connection);
+            $this->fail('Expected exception was not thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('kernel crash', $e->getMessage());
+        }
+
+        $controller->terminateIfNeeded();
+    }
+
     public function testTerminateIfNeededCallsServicesResetter(): void
     {
         $symfonyResponse = new SymfonyResponse('test content');
@@ -1422,5 +1469,22 @@ final class SymfonyControllerTest extends TestCase
         $suspiciousRequest = SymfonyRequest::create('http://attacker.com/');
         $this->expectException(SuspiciousOperationException::class);
         $suspiciousRequest->getHost();
+    }
+
+    public function testTrustedHostRejectionResetsServicesAndClearsReferences(): void
+    {
+        $resetter = $this->createMock(ResetInterface::class);
+        $resetter->expects($this->once())->method('reset');
+        $container = $this->createMock(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('has')->with('services_resetter')->willReturn(true);
+        $container->method('get')->with('services_resetter')->willReturn($resetter);
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse(), $container);
+        $controller = new SymfonyController($kernel, $this->createResponseConverter(), null, ['^example\\.com$']);
+
+        $response = $controller(new Request("GET /test HTTP/1.1\r\nHost: attacker.com\r\n\r\n"), $this->connection);
+        $this->assertSame(400, $response->getStatusCode());
+
+        // A second lifecycle call must be a no-op after the early return cleanup.
+        $controller->terminateIfNeeded();
     }
 }


### PR DESCRIPTION
## Description

Closes #572

`services_resetter` never ran on the exception path, and never at all for a non-Terminable kernel. In a long-running Workerman process this retains request-scoped Symfony service state between requests, growing memory over time — and the exception path is remotely triggerable via malformed requests.

## Changes

- **src/Middleware/SymfonyController.php**: service reset is now decoupled from `TerminableInterface` and runs on every request path:
  - kernel boot/handle/response-conversion exceptions (reset before rethrow)
  - trusted-host rejection (reset before early 400 return)
  - non-terminable kernels (reset via `terminateIfNeeded()`)
  - normal terminable-kernel requests
  - kernel termination itself remains conditional; request/response references are cleared after every cleanup path; the reset stays idempotent (runs exactly once per request)
  - kernel `boot()` moved inside the `try` block (previously a `boot()` failure leaked stale references)
- **tests/SymfonyControllerTest.php**: added coverage for non-terminable kernels, kernel-handle exceptions, and trusted-host rejection cleanup
- **docs/helpers/faq.md**: knowledge-base note that `services_resetter` must run independently of kernel termination and on failure paths
- **CHANGELOG.md**: entry under [Unreleased] → Fixed

## Changelog

```
### Fixed

- Run the `services_resetter` on every request path — including kernel boot/handle exceptions, trusted-host rejections, and kernels that do not implement `TerminableInterface` — so request-scoped Symfony service state cannot leak between requests in a long-running Workerman process (#572)
```

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed (1 nit: docblock updated in 4318391)

## Validation

- `composer lint`: php-cs-fixer, PHPStan, rector — clean
- Targeted `SymfonyControllerTest`: 25 tests green
- Full `composer test` (unit + E2E daemon): 1,715 tests, 13,757 assertions, 23 pre-existing skips