### PR TITLE
docs: complete README configuration reference and add TLS example (closes #590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Complete the README "Configuration reference": every top-level `workerman` key is now covered — `servers`, `reload_strategy` and `build` were missing, and `build` delegates to `docs/build-packaging.md`. New per-server and per-strategy option tables document `reuse_port`, `local_cert`, `local_pk`, `dispersion`, `allowed_exceptions`, `source_dir`, `file_pattern` and the deprecated `serve_files`/`root_dir` keys; the memory strategy section now documents all four options including `gc_cooldown` (default 60 s), which is also added to its YAML example. A working `https://` configuration example (with the `wss://` note and the symlinked-path rejection) was added to `docs/security.md`, and the `static_files.allowed_extensions` trap — silently ignored by a service-registered `StaticFilesMiddleware` — is called out in the reference and the middleware section ([#590](https://github.com/crazy-goat/workerman-bundle/issues/590))
+
 - The `response_chunk_size` option now configures only streamed responses; it no longer affects regular buffered responses, and the (final, DI-registered) `DefaultResponseStrategy` no longer accepts a constructor chunk-size argument ([#556](https://github.com/crazy-goat/workerman-bundle/issues/556))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ workerman:
 > In production, consider using the `user` and `group` config keys to drop privileges after binding, or front it with a reverse proxy (e.g. nginx, Caddy).
 
 > **Note:** `listen` is effectively required. Omitting it creates a worker that does not accept connections — no traffic reaches your application.
-> Supported URI schemes: `http://`, `https://`, `ws://` (WebSocket), `wss://` (WebSocket over SSL), `tcp://` (raw TCP).
+> Supported URI schemes: `http://`, `https://`, `ws://` (WebSocket), `wss://` (WebSocket over SSL). `https://` and `wss://` listeners additionally require `local_cert` and `local_pk` — see the [TLS example](docs/security.md#ssl-certificate-and-key-validation).
 
 ## Configuration reference
 
@@ -162,6 +162,53 @@ All top-level `workerman` configuration options:
 | `keepalive_timeout` | `int` | `30` | Max idle seconds for keep-alive connections before closing. See [security.md](docs/security.md). |
 | `response_chunk_size` | `int` | `2048` | Streamed response chunk size in bytes. |
 | `trusted_hosts` | `string[]` | `[]` | List of regex patterns for trusted hostnames. Requests with a non-matching `Host` header are rejected with `SuspiciousOperationException`. See [security.md](docs/security.md). |
+| `servers` | `array` | `[]` | List of server definitions — one entry per worker group and listening socket. See [servers[] options](#servers-options). |
+| `reload_strategy` | `array` | see [reload_strategy options](#reload_strategy-options) | Worker reload strategy configuration. See [reload_strategy options](#reload_strategy-options). |
+| `build` | `array` | see [build-packaging.md](docs/build-packaging.md#configuration) | PHAR and standalone binary build configuration (`build_dir`, `kernel_class`, `phar_filename`, `bin_filename`, `bin_php_version`, `sfx.*`, `exclude_patterns`, `exclude_files`, `custom_ini`). See [docs/build-packaging.md](docs/build-packaging.md#configuration). |
+
+### servers[] options
+
+Each entry of `servers` is a server definition:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `name` | `string` | *(required)* | Server process name. |
+| `listen` | `string\|null` | `null` | Listen address. Supported schemes: `http://`, `https://`, `ws://`, `wss://`. `https://` and `wss://` additionally require `local_cert` and `local_pk`. Omitting `listen` creates a worker that does not accept connections. |
+| `local_cert` | `string\|null` | `null` | Path to the SSL certificate file (PEM). Required for `https://` and `wss://`. Symlinked paths are rejected — see the [TLS example](docs/security.md#ssl-certificate-and-key-validation). |
+| `local_pk` | `string\|null` | `null` | Path to the SSL private key file (PEM). Required for `https://` and `wss://`. Symlinked paths are rejected — see the [TLS example](docs/security.md#ssl-certificate-and-key-validation). |
+| `processes` | `int\|null` | `null` (CPU cores × 2) | Number of worker processes for this server. |
+| `reuse_port` | `bool` | `false` | Enable `SO_REUSEPORT` on the listening socket so multiple processes can bind the same port. |
+| `body_size_cap` | `int\|null` | `null` | Per-server maximum request body size in bytes. Overrides the global `max_package_size` for this server. See [security.md](docs/security.md#body_size_cap-per-server). |
+| `middlewares` | `string[]` | `[]` | Service IDs of middlewares applied to every request on this server. See [Middlewares](#middlewares). |
+| `static_files` | `array` | `[]` | Static file serving configuration. **Caveat:** the `allowed_extensions` sub-key below only takes effect with the deprecated `serve_files`/`root_dir` path — it is silently ignored by a `StaticFilesMiddleware` registered as a service, which is exactly the setup recommended below. See [docs/security.md](docs/security.md#static-files-protection). |
+| `serve_files` | `bool` | `false` | **Deprecated (0.9.3)** Serve files from `root_dir`. Use `StaticFilesMiddleware` instead — see [Static files middleware](#static-files-middleware). |
+| `root_dir` | `string\|null` | `null` | **Deprecated (0.9.3)** Root directory served when `serve_files` is `true`. Use `StaticFilesMiddleware` instead — see [Static files middleware](#static-files-middleware). |
+
+The deprecated `serve_files`/`root_dir` path reads one sub-key from `static_files`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `allowed_extensions` | `string[]` | `[]` | List of allowed file extensions without leading dot (e.g. `css`, `js`, `png`). When set, only files with these extensions are served. Only consulted on the deprecated `serve_files`/`root_dir` path; a service-registered `StaticFilesMiddleware` reads its allowlist from the `$allowedExtensions` constructor argument instead — setting this key does nothing for middleware users. |
+
+### reload_strategy options
+
+`reload_strategy` configures five worker restart strategies. All strategies can be combined; each has an `active` switch:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `exception.active` | `bool` | `true` | Reload the worker each time an exception is thrown during request handling. |
+| `exception.allowed_exceptions` | `string[]` | `['Symfony\Component\HttpKernel\Exception\HttpExceptionInterface', 'Symfony\Component\Serializer\Exception\ExceptionInterface']` | Exception class names (fully qualified) that do not trigger a reload. |
+| `max_requests.active` | `bool` | `false` | Reload the worker on every N requests to prevent memory leaks. |
+| `max_requests.requests` | `int` | `1000` | Maximum number of requests after which the worker is reloaded. |
+| `max_requests.dispersion` | `int` | `20` | Percentage dispersion of `requests` to prevent all workers from restarting simultaneously (1000 requests and 20% dispersion restart between 800 and 1000). |
+| `file_monitor.active` | `bool` | `false` | Reload all workers each time code changes. |
+| `file_monitor.source_dir` | `string[]` | `['%kernel.project_dir%/src', '%kernel.project_dir%/config']` | Source directories monitored for changes. |
+| `file_monitor.file_pattern` | `string[]` | `['*.php', '*.yaml']` | File patterns monitored inside `source_dir`. |
+| `always.active` | `bool` | `false` | Reload the worker after each request. |
+| `memory.active` | `bool` | `false` | Reload the worker when memory usage reaches a threshold. |
+| `memory.limit` | `int` | `134217728` (128 MB) | Memory threshold (`memory_get_usage()`, not real usage) after which the worker is reloaded. |
+| `memory.gc_limit` | `int` | `100663296` (96 MB) | Memory usage after which `gc_collect_cycles()` is attempted to free memory. |
+| `memory.gc_cooldown` | `int` | `60` | Minimum seconds between garbage collection attempts. |
 
 ### Start application
 
@@ -258,8 +305,8 @@ There are a few restart strategies that are implemented and can be enabled or di
  - **always**  
    Reload worker after each request.
  - **memory**  
-   Reload worker when memory usage reaches a certain threshold. Three options are available:
-   `active` (default: `false`) toggles the strategy, `limit` (default: `134217728` — 128 MB) is the memory threshold in bytes that triggers a worker reload, and `gc_limit` (default: `100663296` — 96 MB) attempts `gc_collect_cycles()` to free memory before the reload check. Memory is measured with `memory_get_usage()` (emalloc accounting), not `memory_get_usage(true)` (real usage): emalloc accounting drops as soon as collectable cycles are freed, whereas the allocator arena behind real usage does not shrink from `gc_collect_cycles()` — with real usage the post-collection re-check could never avoid a reload. When the worker is at risk of reloading (already above `limit`), the collection runs synchronously so the reload verdict is based on the post-collection reading; otherwise it is deferred to the next event-loop tick to keep the request path short. `gc_cooldown` (default: `60`) is the minimum number of seconds between collection attempts; a collection blocked by the cooldown leaves the reload verdict on the current memory reading.
+   Reload worker when memory usage reaches a certain threshold. Four options are available:
+   `active` (default: `false`) toggles the strategy, `limit` (default: `134217728` — 128 MB) is the memory threshold in bytes that triggers a worker reload, `gc_limit` (default: `100663296` — 96 MB) attempts `gc_collect_cycles()` to free memory before the reload check, and `gc_cooldown` (default: `60`) is the minimum interval in seconds between two collection attempts. Memory is measured with `memory_get_usage()` (emalloc accounting), not `memory_get_usage(true)` (real usage): emalloc accounting drops as soon as collectable cycles are freed, whereas the allocator arena behind real usage does not shrink from `gc_collect_cycles()` — with real usage the post-collection re-check could never avoid a reload. When the worker is at risk of reloading (already above `limit`), the collection runs synchronously so the reload verdict is based on the post-collection reading; otherwise it is deferred to the next event-loop tick to keep the request path short. A collection blocked by the cooldown leaves the reload verdict on the current memory reading.
 
    ```yaml
    workerman:
@@ -268,6 +315,7 @@ There are a few restart strategies that are implemented and can be enabled or di
          active: true
          limit: 268435456       # 256 MB
          gc_limit: 201326592    # 192 MB
+         gc_cooldown: 180       # at least 3 minutes between collection attempts
    ```
  
 > **Note:** It is highly recommended to install the `php-inotify` extension for file monitoring. Without it, monitoring will work in polling mode, which can be very CPU and disk intensive for large projects.
@@ -372,6 +420,8 @@ workerman:
 ```
 
 The `StaticFilesMiddleware` resolves requests against the configured root directory, serves matching files directly, and passes through to the next handler for non-file requests. Directory traversal attacks are prevented by ensuring the resolved path stays within the root directory.
+
+> **Note:** The middleware's hardening is configured via constructor arguments — `$allowedExtensions` for the extension allowlist and `$followSymlinks` for symlink handling. The `static_files` server key (including `allowed_extensions`) only applies to the deprecated `serve_files`/`root_dir` path and has **no effect** on a service-registered middleware. See [Security: Static Files Protection](docs/security.md#static-files-protection).
 
 ### Execution order
 

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -88,3 +88,15 @@ also on kernel/response exceptions. `terminateIfNeeded()` owns the reset and
 must clear request references even when no kernel termination is available;
 controller failure paths reset before rethrowing so the handler can still
 send its error response (issue #572).
+
+## Documentation claims vs. runtime support
+
+### README lists `tcp://` as a supported scheme, but `ListenScheme` rejects it
+
+`README.md` and the `listen` node's `info()` text list `tcp://` among the
+supported URI schemes, but `ListenScheme::fromListen()` throws
+`UnsupportedListenSchemeException` for it — `tests/Worker/ListenSchemeTest.php`
+asserts `tcp://0.0.0.0:9090` is *invalid*. Only `http://`, `https://`,
+`ws://` and `wss://` work. Keep the documented scheme list in sync with the
+enum unless real `tcp://` support (a `Tcp` case with transport `tcp` and no
+protocol) is added (issue #590).

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -91,12 +91,13 @@ send its error response (issue #572).
 
 ## Documentation claims vs. runtime support
 
-### README lists `tcp://` as a supported scheme, but `ListenScheme` rejects it
+### README used to list `tcp://` as a supported scheme, but `ListenScheme` rejects it
 
-`README.md` and the `listen` node's `info()` text list `tcp://` among the
+Older README versions and the `listen` node's `info()` text listed `tcp://` among the
 supported URI schemes, but `ListenScheme::fromListen()` throws
 `UnsupportedListenSchemeException` for it — `tests/Worker/ListenSchemeTest.php`
 asserts `tcp://0.0.0.0:9090` is *invalid*. Only `http://`, `https://`,
-`ws://` and `wss://` work. Keep the documented scheme list in sync with the
+`ws://` and `wss://` work. The README and the `info()` text now match the enum
+(issue #590); keep them in sync with the
 enum unless real `tcp://` support (a `Tcp` case with transport `tcp` and no
-protocol) is added (issue #590).
+protocol) is added.

--- a/docs/security.md
+++ b/docs/security.md
@@ -280,7 +280,23 @@ workerman:
 
 ## SSL Certificate and Key Validation
 
-When configuring HTTPS or WSS servers, the `local_cert` and `local_pk` options specify the paths to the SSL certificate and private key files. These paths are validated before being passed to the TLS stream context:
+When configuring HTTPS or WSS servers, the `local_cert` and `local_pk` options specify the paths to the SSL certificate and private key files:
+
+```yaml
+# config/packages/workerman.yaml
+workerman:
+    servers:
+        - name: 'TLS webserver'
+          listen: 'https://0.0.0.0:443'
+          local_cert: '%kernel.project_dir%/config/tls/server.crt'
+          local_pk: '%kernel.project_dir%/config/tls/server.key'
+```
+
+The same `local_cert`/`local_pk` pair is used for `wss://` (WebSocket over SSL) listeners — no additional keys are needed. Both files must be PEM-encoded, existing, and readable by the server process.
+
+> **Note:** **Symlinked certificate and key paths are rejected.** If your deployment points `local_cert` or `local_pk` at a symlink, the server fails to start with `SSL certificate path must not be a symlink: <path>` or `SSL private key path must not be a symlink: <path>` — deploy the actual files instead.
+
+These paths are validated before being passed to the TLS stream context:
 
 ### Regular File Check
 

--- a/src/DependencyInjection/ConfigurationTreeBuilder.php
+++ b/src/DependencyInjection/ConfigurationTreeBuilder.php
@@ -106,7 +106,7 @@ final readonly class ConfigurationTreeBuilder
                             ->cannotBeEmpty()
                             ->end()
                         ->scalarNode('listen')
-                            ->info('Listen address. Supported protocols: http://, https://, ws://, wss://, tcp://')
+                            ->info('Listen address. Supported protocols: http://, https://, ws://, wss://')
                             ->defaultNull()
                             ->example('http://0.0.0.0:80')
                             ->end()


### PR DESCRIPTION
## Description

Closes #590

The README "Configuration reference" claimed to list *all* top-level options but omitted the three array options (`servers`, `reload_strategy`, `build`). This PR makes the reference complete and truthful, adds the missing per-server and reload-strategy documentation, and adds the first TLS example.

## Changes

- **README.md** — reference table now covers all 17 top-level keys; `build` delegates to `docs/build-packaging.md#configuration`
- **README.md** — new `servers[]` options table (`name`, `listen`, `local_cert`, `local_pk`, `processes`, `reuse_port`, `body_size_cap`, `middlewares`, `static_files`; `serve_files`/`root_dir` marked deprecated → middleware)
- **README.md** — `static_files` row carries an explicit caveat: `allowed_extensions` only takes effect on the deprecated `serve_files` path and is silently ignored by a service-registered `StaticFilesMiddleware` (see #591)
- **README.md** — new `reload_strategy` options table covering all five strategies incl. `dispersion`, `allowed_exceptions`, `source_dir`, `file_pattern`; memory strategy corrected "three options" → "four options", `gc_cooldown` (60s) documented and added to the YAML example
- **README.md** — scheme list narrowed to the four schemes `ListenScheme` actually supports (`tcp://` removed, see below)
- **docs/security.md** — working `https://` TLS example with `local_cert`/`local_pk`, `wss://` note, symlinked cert path rejection documented
- **src/DependencyInjection/ConfigurationTreeBuilder.php** — `listen` `info()` text no longer advertises `tcp://` (matches `config:dump-reference` with runtime behaviour; found in code review)
- **docs/helpers/faq.md** — knowledge-base entry on the `tcp://` docs-vs-runtime mismatch
- **CHANGELOG.md** — entry under [Unreleased] → Changed

## Verification

- Defaults cross-checked key-by-key against `config:dump-reference workerman --format=xml` output — all exact
- `composer lint` passes; targeted tests 36/36 (ConfigurationTreeBuilder + ListenScheme)
- Full local suite: 1721 tests, 4 pre-existing `ProcessTest` timing failures **identical on master** (known flake surface, #592) — no regression from this PR

## Changelog

Docs: complete README configuration reference (servers, reload_strategy, build), add TLS example and fix memory strategy option count (#590).

## Code Review

- [x] Passed subagent code review (2 findings fixed, re-review clean)
- [x] All review comments addressed