### PR TITLE
fix: apply static_files allowed_extensions allowlist to files only (closes #637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `StaticFilesMiddleware` no longer 404s every file in a subdirectory when `static_files.allowed_extensions` is configured: the allowlist and the residue-extension checks are file-only rules and are now applied exclusively to the last path component, while every component still gets the dotfile, leak-extension and blocked-name checks ([#637](https://github.com/crazy-goat/workerman-bundle/issues/637))
+
 - Run the `services_resetter` on every request path — including kernel boot/handle exceptions, trusted-host rejections, and kernels that do not implement `TerminableInterface` — so request-scoped Symfony service state cannot leak between requests in a long-running Workerman process ([#572](https://github.com/crazy-goat/workerman-bundle/issues/572))
 
 - `MemoryRebootStrategy` now bases its reload verdict on the memory reading taken **after** the `gc_collect_cycles()` it triggers, so a worker whose memory drops back under `limit` as a result of the collection is no longer reloaded unnecessarily. When the worker is already above `limit`, the collection runs synchronously instead of being scheduled on a later event-loop tick; the deferred `Timer::add(0, ...)` path is kept for the preventive "above `gc_limit`, below `limit`" case, and a collection blocked by `gc_cooldown` leaves the verdict on the current reading. Memory is measured with `memory_get_usage()` (emalloc accounting) — stated explicitly in the config docs, since the allocator arena behind `memory_get_usage(true)` would mask the effect of the collection ([#561](https://github.com/crazy-goat/workerman-bundle/issues/561))

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -3,6 +3,17 @@
 Subagents: read this before starting a task, append new entries after
 finishing (see [README.md](README.md) for rules).
 
+## Static files
+
+### File-only rules must be gated on the last path component
+
+`StaticFilesMiddleware` walks every relative-path component
+(`isFilePathBlocked()`), so file-only rules — the `allowed_extensions`
+allowlist and residue-extension blocking — must be applied only to the
+final component (`array_key_last`, `$isFile` flag). Directory components
+have no extension and were denied whenever an allowlist was configured,
+making every subdirectory file 404 (issue #637).
+
 ## Test suite
 
 ### "Address already in use" when running `composer test`

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -11,8 +11,10 @@ finishing (see [README.md](README.md) for rules).
 (`isFilePathBlocked()`), so file-only rules — the `allowed_extensions`
 allowlist and residue-extension blocking — must be applied only to the
 final component (`array_key_last`, `$isFile` flag). Directory components
-have no extension and were denied whenever an allowlist was configured,
-making every subdirectory file 404 (issue #637).
+must not be evaluated by file-only rules even when their names contain dots
+(`assets.dist/`, `backup.bak/`) — before the fix they were denied whenever
+an allowlist was configured, making every subdirectory file 404 (issue
+#637).
 
 ## Test suite
 

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -161,13 +161,12 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         $relativePath = str_replace('\\', '/', $relativePath);
 
         $components = explode('/', ltrim($relativePath, '/'));
-        $componentPath = $this->rootRealPath;
-        foreach ($components as $component) {
+        $lastIndex = array_key_last($components);
+        foreach ($components as $index => $component) {
             if ($component === '') {
                 continue;
             }
-            $componentPath .= DIRECTORY_SEPARATOR . $component;
-            if ($this->isComponentBlocked($component, $componentPath)) {
+            if ($this->isComponentBlocked($component, $index === $lastIndex)) {
                 return true;
             }
         }
@@ -175,7 +174,7 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         return false;
     }
 
-    private function isComponentBlocked(string $name, ?string $componentPath = null): bool
+    private function isComponentBlocked(string $name, bool $isFile = false): bool
     {
         if (str_starts_with($name, '.')) {
             return true;
@@ -207,12 +206,10 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
         // Residue suffixes are a leak signal only as the final extension of
         // a file. An interior or directory occurrence (`app.dist.js`,
         // `assets.dist/`) is not — its contents are still protected by the
-        // checks above, and the allowlist below when configured. The
-        // directory stat is only paid when the final extension is a residue
-        // candidate, keeping the common asset path stat-free.
-        if (in_array($ext, self::RESIDUE_EXTENSIONS, true)
-            && ($componentPath === null || !is_dir($componentPath))
-        ) {
+        // checks above, and the allowlist below when configured. Directory
+        // components never reach this branch: the file/directory distinction
+        // is carried by the $isFile flag, so no per-component stat is needed.
+        if ($isFile && in_array($ext, self::RESIDUE_EXTENSIONS, true)) {
             return true;
         }
 
@@ -220,7 +217,9 @@ final readonly class StaticFilesMiddleware implements MiddlewareInterface
             return true;
         }
 
-        return $this->allowedExtensions !== [] && !in_array($ext, $this->allowedExtensions, true);
+        // The allowlist applies to files only: directory components have no
+        // extension and must never be denied by it (issue #637).
+        return $isFile && $this->allowedExtensions !== [] && !in_array($ext, $this->allowedExtensions, true);
     }
 
     private function getPublicPathFile(Request $request): string|false

--- a/tests/StaticFilesMiddlewareTest.php
+++ b/tests/StaticFilesMiddlewareTest.php
@@ -1003,6 +1003,87 @@ final class StaticFilesMiddlewareTest extends TestCase
         }
     }
 
+    public function testAllowlistedFileInSubdirectoryIsServed(): void
+    {
+        $subDir = $this->rootDirectory . '/assets/css';
+        mkdir($subDir, 0777, true);
+        $cssFile = $subDir . '/app.css';
+        file_put_contents($cssFile, 'body { color: red; }');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+
+            $request = $this->createRequest('/assets/css/app.css');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should NOT be called for allowlisted file in subdirectory');
+            $this->assertEquals(200, $response->getStatusCode(), 'Allowlisted file in subdirectory should be served');
+        } finally {
+            unlink($cssFile);
+            rmdir($subDir);
+            rmdir(dirname($subDir));
+        }
+    }
+
+    public function testExtensionlessFileInSubdirectoryIsBlockedWithAllowlist(): void
+    {
+        $subDir = $this->rootDirectory . '/subdir';
+        mkdir($subDir, 0777, true);
+        $secretFile = $subDir . '/Dockerfile';
+        file_put_contents($secretFile, 'sensitive content');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+
+            $request = $this->createRequest('/subdir/Dockerfile');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should NOT be called for extensionless file in subdirectory');
+            $this->assertEquals(404, $response->getStatusCode(), 'Extensionless file in subdirectory should be blocked');
+        } finally {
+            unlink($secretFile);
+            rmdir($subDir);
+        }
+    }
+
+    public function testAllowlistedFileServedUnderResidueSuffixDirectory(): void
+    {
+        $dir = $this->rootDirectory . '/assets.dist';
+        mkdir($dir, 0777, true);
+        file_put_contents($dir . '/logo.png', 'png');
+
+        try {
+            $middleware = new StaticFilesMiddleware($this->rootDirectory, ['css', 'js', 'png']);
+
+            $request = $this->createRequest('/assets.dist/logo.png');
+            $called = false;
+            $next = function (Request $req) use (&$called): Response {
+                $called = true;
+                return new Response(404);
+            };
+
+            $response = $middleware($request, $next);
+
+            $this->assertFalse($called, 'Next should NOT be called for allowlisted file under residue-suffix directory');
+            $this->assertEquals(200, $response->getStatusCode(), 'Allowlisted file under residue-suffix directory should be served');
+        } finally {
+            @unlink($dir . '/logo.png');
+            @rmdir($dir);
+        }
+    }
+
     /**
      * @dataProvider extensionlessFileProvider
      */


### PR DESCRIPTION
## Description

Closes #637

Regression from 6334ee6 (PR #603, issue #580): with `servers[].static_files.allowed_extensions` configured, **every file in a subdirectory returned 404** — only files in the root directory were served.

Root cause: `StaticFilesMiddleware::isFilePathBlocked()` walks every component of the relative path and applied the file-only allowlist check to directory components too. A directory such as `assets` has no extension, is not in the allowlist, so the whole request was denied.

## Changes

- `src/Middleware/StaticFilesMiddleware.php`: pass `\` (last component, via `array_key_last`) down to `isComponentBlocked()`; gate both the `allowed_extensions` allowlist check and the `RESIDUE_EXTENSIONS` check on it. Dotfile, leak-extension and blocked-name checks still apply to every component. The `is_dir()` stat per component is dropped — the flag carries that information.
- `tests/StaticFilesMiddlewareTest.php`: 3 regression tests — allowlisted file in a subdirectory is served; extensionless file in a subdirectory is blocked; `assets.dist/` directory still serves an allowlisted file beneath it.
- `docs/helpers/faq.md`: knowledge-base entry documenting the file-only-rules pitfall (minor wording fix from code review).
- `CHANGELOG.md`: entry under [Unreleased] / Fixed.

## Changelog

Fixed: `StaticFilesMiddleware` no longer 404s every file in a subdirectory when `allowed_extensions` is configured — the allowlist and residue-extension checks apply to files only.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed