### PR TITLE
fix(core): bound dropped-underscore-header logging per worker (closes #638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bound the dropped-underscore-header diagnostics in `RequestConverter` to 64 distinct names per worker process: the log-once-per-worker bookkeeping was an unbounded static map keyed by client-supplied header names, so a single unauthenticated peer could drive unbounded memory growth and sustained log-write amplification. Once the cap is reached, one suppression notice is logged and recording stops ([#638](https://github.com/crazy-goat/workerman-bundle/issues/638))
+
 - `StaticFilesMiddleware` no longer 404s every file in a subdirectory when `static_files.allowed_extensions` is configured: the allowlist and the residue-extension checks are file-only rules and are now applied exclusively to the last path component, while every component still gets the dotfile, leak-extension and blocked-name checks ([#637](https://github.com/crazy-goat/workerman-bundle/issues/637))
 
 - Run the `services_resetter` on every request path — including kernel boot/handle exceptions, trusted-host rejections, and kernels that do not implement `TerminableInterface` — so request-scoped Symfony service state cannot leak between requests in a long-running Workerman process ([#572](https://github.com/crazy-goat/workerman-bundle/issues/572))

--- a/docs/helpers/decisions.md
+++ b/docs/helpers/decisions.md
@@ -46,6 +46,11 @@ code paths:
   extensions (`.bak`, `.env`, etc.) are blocked (#580/#582, #603/#609).
 - Master process identification is hardened (#584, #608).
 - HTTP headers starting with underscore are dropped (#578, #605).
+- Dropped-underscore-header logging is bounded per worker: at most 64
+  distinct client-supplied header names are recorded and logged, then a
+  single suppression notice (issue #638). The map is capped and the
+  suppression flag is a separate scalar, so attacker-sent names can
+  neither grow worker memory nor amplify log writes.
 - SFX redirect policy is unified across modes (#585, #606).
 - Transport-owned headers are stripped to prevent duplicate
   `Content-Length` (#579, #602).

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -50,6 +50,15 @@ PHP 8.2 / Symfony 6.4 matrix leg. If a PR adds meaningful logic, verify
 the gate locally (`composer test:coverage && composer coverage:check`) so
 CI doesn't tell you first. Requires PCOV or Xdebug locally.
 
+## Underscore header test fixtures need a literal `_` character
+
+When building a raw HTTP header fixture to exercise the underscore-header
+drop path, put a real `_` in the name (e.g. `X-Dropped_1`). Writing the
+word `X-Underscore-1` produces hyphens only (`x-underscore-1`), which
+parses as a normal header and sails past the drop filter — the test then
+exercises nothing. See [decisions.md](decisions.md) for the bounded-logging
+decision behind #638.
+
 ## Git hooks
 
 ### Pre-push hook runs `composer lint` before every push

--- a/src/DTO/RequestConverter.php
+++ b/src/DTO/RequestConverter.php
@@ -21,8 +21,23 @@ final class RequestConverter
     private const METHOD_REGEX = '/^[A-Z]+$/';
     private const MAX_METHOD_LENGTH = 32;
 
+    /**
+     * Number of distinct underscore header names logged per worker before
+     * further names are suppressed. The names come straight off the wire, so
+     * this constant — not client input — bounds both the static map's memory
+     * and the number of log lines written by logDroppedUnderscoreHeader().
+     */
+    private const MAX_LOGGED_UNDERSCORE_HEADERS = 64;
+
     /** @var array<string, true> Header names already logged in this worker. */
     private static array $loggedUnderscoreHeaders = [];
+
+    /**
+     * True once MAX_LOGGED_UNDERSCORE_HEADERS distinct names were logged and
+     * further names are suppressed. Kept out of the map so client-supplied
+     * header names can never collide with bookkeeping keys.
+     */
+    private static bool $underscoreHeaderLogSuppressed = false;
 
     /**
      * Validates that a URI does not contain control characters.
@@ -230,6 +245,11 @@ final class RequestConverter
 
     /**
      * Log an underscore-containing header once per worker before dropping it.
+     *
+     * Bounded by a constant: at most MAX_LOGGED_UNDERSCORE_HEADERS distinct
+     * names are recorded and logged per worker, followed by a single
+     * suppression notice. Unauthenticated clients cannot grow the static map
+     * or the log volume without limit.
      */
     private static function logDroppedUnderscoreHeader(string $name): void
     {
@@ -238,16 +258,29 @@ final class RequestConverter
             return;
         }
 
+        if (\count(self::$loggedUnderscoreHeaders) >= self::MAX_LOGGED_UNDERSCORE_HEADERS) {
+            if (!self::$underscoreHeaderLogSuppressed) {
+                self::$underscoreHeaderLogSuppressed = true;
+                self::writeDroppedHeaderLog('[warning] Reached log limit for dropped underscore header names; further names are suppressed');
+            }
+
+            return;
+        }
+
         self::$loggedUnderscoreHeaders[$nameLower] = true;
-        $message = \sprintf(
+        self::writeDroppedHeaderLog(\sprintf(
             '[warning] Dropped HTTP header "%s": header names containing underscores are not forwarded to Symfony',
             \addcslashes($name, "\0..\37\177"),
-        );
+        ));
+    }
 
-        // Workerman initialises the output stream before serving requests. Keep
-        // direct RequestConverter users safe when conversion happens outside a
-        // running Worker (for example, in a unit test or a CLI utility), or
-        // when Workerman has no log file configured.
+    /**
+     * Write the message through Workerman's log, falling back to error_log
+     * when conversion happens outside a running Worker or no log file is
+     * configured.
+     */
+    private static function writeDroppedHeaderLog(string $message): void
+    {
         if (Worker::$logFile === '') {
             \error_log($message);
 

--- a/tests/RequestConverterTest.php
+++ b/tests/RequestConverterTest.php
@@ -892,6 +892,56 @@ final class RequestConverterTest extends TestCase
         }
     }
 
+    /**
+     * AC #638: the per-worker bookkeeping for dropped underscore header names
+     * must be bounded by a constant — client-supplied header names must not
+     * drive unbounded static-map memory growth or log volume.
+     */
+    public function testDroppedUnderscoreHeaderLogIsBoundedPerWorker(): void
+    {
+        $this->resetUnderscoreHeaderLogState();
+        $logFile = tempnam(sys_get_temp_dir(), 'request_converter_log_');
+        $this->assertNotFalse($logFile);
+
+        $previousDaemonize = Worker::$daemonize;
+        $previousLogFile = Worker::$logFile;
+
+        try {
+            Worker::$daemonize = true;
+            Worker::$logFile = $logFile;
+
+            // 66 distinct client-controlled names: two beyond the 64-entry cap.
+            for ($i = 0; $i < 66; ++$i) {
+                $headerName = 'X-Dropped_' . $i;
+                $buffer = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
+                $buffer .= $headerName . ": value\r\n\r\n";
+                RequestConverter::toSymfonyRequest(new Request($buffer));
+            }
+
+            $log = file_get_contents($logFile);
+            $this->assertIsString($log);
+
+            $this->assertSame(64, substr_count($log, '[warning] Dropped HTTP header'));
+            $this->assertSame(1, substr_count($log, 'further names are suppressed'));
+            $this->assertStringNotContainsString('x-dropped_64', $log);
+            $this->assertStringNotContainsString('x-dropped_65', $log);
+
+            // The static map itself must not exceed the cap either.
+            $this->assertCount(64, $this->getLoggedUnderscoreHeaderMap());
+
+            // Repeating a name inside the cap still logs nothing new.
+            RequestConverter::toSymfonyRequest(new Request(
+                "GET /test HTTP/1.1\r\nHost: localhost\r\nX-Dropped_0: value\r\n\r\n",
+            ));
+            $this->assertSame(1, substr_count((string) file_get_contents($logFile), 'x-dropped_0'));
+        } finally {
+            Worker::$daemonize = $previousDaemonize;
+            Worker::$logFile = $previousLogFile;
+            $this->resetUnderscoreHeaderLogState();
+            @unlink($logFile);
+        }
+    }
+
     public function testMultipleCookieHeadersJoinedWithSemicolon(): void
     {
         $buffer = "GET /test HTTP/1.1\r\n";
@@ -1303,6 +1353,27 @@ final class RequestConverterTest extends TestCase
         $reflection = new \ReflectionMethod(RequestConverter::class, $methodName);
 
         return $reflection->invokeArgs(null, $args);
+    }
+
+    /**
+     * Reset the per-worker underscore-header bookkeeping via reflection so
+     * tests are deterministic regardless of execution order.
+     */
+    private function resetUnderscoreHeaderLogState(): void
+    {
+        $class = new \ReflectionClass(RequestConverter::class);
+        $class->getProperty('loggedUnderscoreHeaders')->setValue(null, []);
+        $class->getProperty('underscoreHeaderLogSuppressed')->setValue(null, false);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function getLoggedUnderscoreHeaderMap(): array
+    {
+        $class = new \ReflectionClass(RequestConverter::class);
+
+        return $class->getProperty('loggedUnderscoreHeaders')->getValue();
     }
 
     /**


### PR DESCRIPTION
## Description

Closes #638

The log-once-per-worker bookkeeping for dropped underscore headers is an unbounded, process-lifetime static keyed by **client-supplied header names**. An unauthenticated peer sending many distinct names (X_a1, X_a2, ... X_aN) drives unbounded memory growth in every worker and sustained log-write amplification — the failure mode #577 closed one release ago, reintroduced on a different path.

Replace the unbounded map with a constant-bounded design (the issue's suggested "cap the map" option, matching the project's established pattern for worker caches):

- `MAX_LOGGED_UNDERSCORE_HEADERS = 64` — at most 64 distinct names are ever recorded/logged per worker
- once-only suppression flag stored outside the map (map keys are client-controlled; a sentinel key would be forgeable)
- log-write fallback logic extracted into `writeDroppedHeaderLog()` (two call sites now, no behavior change)

## Changes

- `src/DTO/RequestConverter.php`: cap + suppression flag + extracted log writer
- `tests/RequestConverterTest.php`: `testDroppedUnderscoreHeaderLogIsBoundedPerWorker` (66 names → exactly 64 drops + 1 suppression, reflection-verified map size, repeated-name dedup)
- `docs/helpers/faq.md` + `docs/helpers/decisions.md`: test-fixture pitfall + bounded-logging decision
- `CHANGELOG.md`: [Unreleased] Fixed entry (#638)

## Changelog

Fixed: bound the dropped-underscore-header diagnostics in `RequestConverter` to 64 distinct names per worker process (memory + log volume bounded by a constant, not client input).

## Validation

- `composer lint`: php-cs-fixer, PHPStan (level 8), Rector — all clean (also enforced by pre-push hook on both pushes)
- `phpunit tests/RequestConverterTest.php`: 79 tests, 293 assertions, green
- `composer test` full suite: 1725 tests, 13882 assertions — 4 failures in `tests/ProcessTest.php` confirmed **pre-existing** (reproduced on pristine master; isolated `ProcessTest` run passes 5/5; timing/environment-sensitive, unrelated to this change)
- Coverage gate (80%) not verifiable locally (no PCOV/Xdebug) — all new lines are unit-tested; CI matrix leg will verify

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed