### PR TITLE
docs: config-cache ownership upgrade note for warm-as-root deployments (closes #639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Behaviour change**: because the cache file must now be owned by the
   process that loads it (see previous entry), a config cache warmed up by
-  a different user than the runtime user (e.g. deploy user vs `www-data`)
-  is **refused at boot** instead of being loaded silently. Warm up with
-  the runtime user or `chown` the cache file to that user after warm-up
+  a different user than the runtime user (e.g. deploy user vs `www-data`,
+  or a Docker build that runs `cache:warmup` as `root` before switching to
+  the runtime user) is **refused at boot** instead of being loaded
+  silently: the launcher process aborts with a `RuntimeException` naming
+  both UIDs before any worker forks. Warm up with the runtime user or
+  `chown` the cache file to that user after warm-up — see [Config cache
+  and runtime user](README.md#config-cache-and-runtime-user) and the
+  [security docs](docs/security.md#config-cache-file-protection)
   ([#586](https://github.com/crazy-goat/workerman-bundle/issues/586))
 
 - Widen `StaticFilesMiddleware`'s built-in denylist to cover editor

--- a/README.md
+++ b/README.md
@@ -254,17 +254,23 @@ user, or chown the cache to that user).
 
 ```dockerfile
 FROM php:8.3-cli
-COPY . /app
+COPY --chown=www-data:www-data . /app
+WORKDIR /app
 USER www-data
 RUN bin/console cache:warmup
 CMD ["bin/console", "workerman:server", "start"]
 ```
+
+(`COPY --chown` makes `www-data` the owner of `/app`, so the runtime user can
+write `var/cache` during warm-up — a plain `COPY . /app` creates root-owned
+files that `www-data` cannot overwrite.)
 
 **Or re-own the cache file after warm-up**:
 
 ```dockerfile
 FROM php:8.3-cli
 COPY . /app
+WORKDIR /app
 RUN bin/console cache:warmup && chown -R www-data var/cache
 USER www-data
 CMD ["bin/console", "workerman:server", "start"]

--- a/README.md
+++ b/README.md
@@ -225,6 +225,55 @@ Or using the runtime directly:
 $ APP_RUNTIME=CrazyGoat\\WorkermanBundle\\Runtime php public/index.php start
 ```
 
+### Config cache and runtime user
+
+Since 0.25.0 the bundle refuses to load a configuration cache file that is not
+**owned by the process that loads it**: the cache file
+(`{cacheDir}/workerman/config.cache.php`, in Symfony's kernel cache directory,
+e.g. `var/cache/prod`) is a PHP file that is `require`d at boot, so a file
+replaced by another user would be owned by that user. The check is enforced
+in the launcher process, before any worker forks — an ownership mismatch
+aborts `workerman:server start` with a `RuntimeException`, not a warning. See
+[Config Cache File Protection](docs/security.md#config-cache-file-protection)
+for the full threat model.
+
+> **Note:** This is the upgrade-relevant change in 0.25.0. The most common
+> containerised layout trips it: the cache is warmed at image build time
+> (as `root`), the server runs as a non-root user.
+
+The error message names both UIDs and suggests the fix:
+
+```
+The configuration cache file "/app/var/cache/prod/workerman/config.cache.php" is owned by uid 0,
+not by the current process user (uid 33). The file may have been replaced by another user.
+Ensure the cache is written by the same user that loads it (e.g., warm up with the runtime
+user, or chown the cache to that user).
+```
+
+**Warm up with the runtime user** (recommended):
+
+```dockerfile
+FROM php:8.3-cli
+COPY . /app
+USER www-data
+RUN bin/console cache:warmup
+CMD ["bin/console", "workerman:server", "start"]
+```
+
+**Or re-own the cache file after warm-up**:
+
+```dockerfile
+FROM php:8.3-cli
+COPY . /app
+RUN bin/console cache:warmup && chown -R www-data var/cache
+USER www-data
+CMD ["bin/console", "workerman:server", "start"]
+```
+
+The same applies to any deploy-user/runtime-user split (deploy scripts, CI
+runs, `sudo`): the user that warms the cache must be the user that starts
+`workerman:server`, or the cache must be re-owned by that user in between.
+
 ### Manage the server
 
 ```bash

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -16,6 +16,18 @@ must not be evaluated by file-only rules even when their names contain dots
 an allowlist was configured, making every subdirectory file 404 (issue
 #637).
 
+## Config cache
+
+### Warm-as-root cache trips the ownership guard at boot
+
+Since 0.25.0 the config cache file (`{cacheDir}/workerman/config.cache.php`)
+must be owned by the process that loads it. Warming it as `root` in a
+Docker build and starting the server as another user is a hard boot
+`RuntimeException` (raised by the launcher process before any worker forks),
+not a warning. Worked examples live in README (§ "Config cache and runtime
+user") and security.md (§ "Containerised deployments (Docker)") — link to
+them instead of restating the pattern in issues or PRs.
+
 ## Test suite
 
 ### "Address already in use" when running `composer test`

--- a/docs/security.md
+++ b/docs/security.md
@@ -437,11 +437,18 @@ containing directory** before loading it:
   POSIX permissions.
 - **Ownership requirement**: the cache file must be written and loaded by
   the same user. Warm up the cache with the runtime user, or `chown` the
-  cache file to that user after warm-up.
+  cache file to that user after warm-up. A mismatch is refused in the
+  launcher process (`Runner::run()`, before any worker forks) with a
+  `RuntimeException` naming both UIDs.
 
 ### When this matters
 
 - **Multi-tenant environments**: Shared hosting or CI runners where the cache directory might be accessible to other users.
+- **Container image builds**: warming the cache as `root` during a Docker
+  build and starting the server as a non-root user (`USER www-data`) trips
+  the ownership check. This is the single most common containerised layout
+  and is now a hard boot failure, not a warning — see [Containerised
+  deployments (Docker)](#containerised-deployments-docker) below.
 - **Containerised deployments**: Containers with overly permissive `umask` settings (e.g., `umask 0000`) can produce world-writable cache files and directories.
 - **Development setups**: Developers running with `umask 0000` or cache directories created with `0777` permissions.
 
@@ -475,6 +482,51 @@ or re-own the cache file after warm-up:
 ```bash
 chown <runtime-user> var/cache/workerman/config.cache.php
 ```
+
+### Containerised deployments (Docker)
+
+The most common way to trip the ownership check is the standard Docker
+layout where the cache is warmed at image build time and the server runs
+as a different user:
+
+```dockerfile
+# Broken: cache warmed as root, server runs as www-data
+FROM php:8.3-cli
+COPY . /app
+RUN bin/console cache:warmup
+USER www-data
+CMD ["bin/console", "workerman:server", "start"]
+```
+
+The `cache:warmup` step runs as `root`, so `var/cache/<env>/workerman/config.cache.php`
+is owned by UID 0. When the container later starts the server as `www-data`,
+`ConfigLoader` refuses to load the cache file, and the launcher process
+aborts with a `RuntimeException` before any worker forks — the whole start
+sequence dies.
+
+**Warm up with the runtime user** (recommended):
+
+```dockerfile
+FROM php:8.3-cli
+COPY . /app
+USER www-data
+RUN bin/console cache:warmup
+CMD ["bin/console", "workerman:server", "start"]
+```
+
+**Or re-own the cache file after warm-up:**
+
+```dockerfile
+FROM php:8.3-cli
+COPY . /app
+RUN bin/console cache:warmup && chown -R www-data var/cache
+USER www-data
+CMD ["bin/console", "workerman:server", "start"]
+```
+
+The same applies to any deploy-user/runtime-user split: deploy scripts, CI
+runs and `sudo` invocations must either run the warm-up as the runtime user
+or re-own the cache afterwards.
 
 ## SFX Checksum Requirement
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -457,15 +457,19 @@ containing directory** before loading it:
 Ensure the cache directory has restrictive permissions:
 
 ```bash
-chmod 0700 var/cache/
+chmod 0700 var/cache/<env>/workerman/
 ```
 
 Or, if the web server and CLI users differ, use a shared group:
 
 ```bash
-chmod 0750 var/cache/
-chgrp <webserver-group> var/cache/
+chmod 0750 var/cache/<env>/workerman/
+chgrp <webserver-group> var/cache/<env>/workerman/
 ```
+
+(`<env>` is the Symfony environment segment, e.g. `prod`.) The guard checks the directory
+*containing* the cache file — `var/cache/<env>/workerman/` — so permissions must be set
+on that directory, not on `var/cache/` itself, and for every environment you deploy.
 
 Because the cache file must also be **owned by the runtime user** (see the
 Ownership check above), a cache warmed up by a different user — e.g. a
@@ -508,17 +512,23 @@ sequence dies.
 
 ```dockerfile
 FROM php:8.3-cli
-COPY . /app
+COPY --chown=www-data:www-data . /app
+WORKDIR /app
 USER www-data
 RUN bin/console cache:warmup
 CMD ["bin/console", "workerman:server", "start"]
 ```
+
+(`COPY --chown` makes `www-data` the owner of `/app`, so the runtime user can
+write `var/cache` during warm-up — a plain `COPY . /app` would create
+root-owned files that `www-data` cannot overwrite.)
 
 **Or re-own the cache file after warm-up:**
 
 ```dockerfile
 FROM php:8.3-cli
 COPY . /app
+WORKDIR /app
 RUN bin/console cache:warmup && chown -R www-data var/cache
 USER www-data
 CMD ["bin/console", "workerman:server", "start"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -497,6 +497,7 @@ as a different user:
 # Broken: cache warmed as root, server runs as www-data
 FROM php:8.3-cli
 COPY . /app
+WORKDIR /app
 RUN bin/console cache:warmup
 USER www-data
 CMD ["bin/console", "workerman:server", "start"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -480,7 +480,7 @@ sudo -u <runtime-user> bin/console cache:warmup
 or re-own the cache file after warm-up:
 
 ```bash
-chown <runtime-user> var/cache/workerman/config.cache.php
+chown <runtime-user> var/cache/<env>/workerman/config.cache.php
 ```
 
 ### Containerised deployments (Docker)


### PR DESCRIPTION
## Description

Closes #639

Documents the 0.25.0 behaviour change from PR #611: the config-cache ownership check (`ConfigLoader`) hard-fails (RuntimeException in the launcher process, before any worker forks) when the cache is warmed by a different user than the one running the server — the standard Docker `RUN cache:warmup` as root + `USER www-data` layout.

## Changes

- **README.md** — new "Config cache and runtime user" section: what the check is, why, the error-message shape, and before/fixed Dockerfile patterns (warm up as runtime user — recommended, or `chown` after warm-up) + deploy-user/CI/sudo generalization.
- **docs/security.md** — extended "Config Cache File Protection": containerised-build bullet, hard-failure mechanics, new "Containerised deployments (Docker)" subsection; remediation examples now target the guarded directory (`var/cache/<env>/workerman/`, previously pointed at `var/cache/` which the guard does not check), and the pre-existing `chown` example path was corrected (missing env segment).
- **CHANGELOG.md** — [Unreleased] entry now states the hard-failure/launcher-process nature, adds the container scenario and links the new docs.
- **docs/helpers/faq.md** — knowledge-base entry linking the new docs.

No PHP, config, tests, or behaviour changes.

## Changelog

- **Behaviour change** (from #586/#611): config cache warmed by a different user is refused at boot with a RuntimeException — upgrade + remediation docs added (README + security.md + CHANGELOG).

## Open decision for reviewers (issue suggests a or b)

The issue (#639) offers two resolutions: **(a)** docs-only (implemented here — strict check stays, remediation documented) or **(b)** strict-by-default + explicit opt-out config/env documented as a guard downgrade. Per docs/helpers/decisions.md ("do not loosen hardening without an explicit, documented reason"), (a) was chosen; (b) can ship later as its own issue if maintainers want the escape hatch. Docs are written so (b) slots in as a documented downgrade.

## Code Review

- [x] Passed subagent code review (3 rounds; round 3: "Code looks good, no issues to fix")
- [x] All review comments addressed

## Local validation

- `composer lint` green (via pre-push hook, 3 pushes)
- Targeted unit tests (ConfigLoader/BinDirectory/ComposerConfig): 46 tests, 0 failures
- Full `composer test`: 4 flaky ProcessTest failures reproduce identically on a clean local master worktree (known local env issue: macOS/PHP 8.5/Symfony 8.1, marker-window tests; master CI is green)