### PR TITLE
fix(test): require fresh event-marker entries in ProcessTest (closes #645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ProcessTest` event-marker assertions no longer fail spuriously when the daemon stalls or restarts: the start- and error-marker files are reset before each test and the helper now waits for a **freshly appended** entry (15 s budget) instead of returning on the first non-empty file, so stale entries from previous runs or a >4 s daemon gap can no longer satisfy the recency check ([#645](https://github.com/crazy-goat/workerman-bundle/issues/645))
+
 - Bound the dropped-underscore-header diagnostics in `RequestConverter` to 64 distinct names per worker process: the log-once-per-worker bookkeeping was an unbounded static map keyed by client-supplied header names, so a single unauthenticated peer could drive unbounded memory growth and sustained log-write amplification. Once the cap is reached, one suppression notice is logged and recording stops ([#638](https://github.com/crazy-goat/workerman-bundle/issues/638))
 
 - `StaticFilesMiddleware` no longer 404s every file in a subdirectory when `static_files.allowed_extensions` is configured: the allowlist and the residue-extension checks are file-only rules and are now applied exclusively to the last path component, while every component still gets the dotfile, leak-extension and blocked-name checks ([#637](https://github.com/crazy-goat/workerman-bundle/issues/637))

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -16,7 +16,11 @@ final class ProcessTest extends KernelTestCase
         $this->varDir = dirname(__DIR__) . '/var';
 
         // Clean up marker files from prior runs so leftover state cannot
-        // cause false failures (Issue #348 review warning #3).
+        // cause false failures (Issue #348 review warning #3). Reset BOTH
+        // markers: a stale entry in either could otherwise satisfy the
+        // fresh-entry waits below when the daemon stalls mid-run or a prior
+        // run was killed before its shutdown cleanup ran (Issue #645).
+        @unlink($this->varDir . '/' . ProcessMarkerPaths::START_MARKER);
         @unlink($this->varDir . '/' . ProcessMarkerPaths::ERROR_MARKER);
     }
 
@@ -48,12 +52,16 @@ final class ProcessTest extends KernelTestCase
      */
     public function testProcessStartEventIsDispatched(): void
     {
-        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::START_MARKER);
-        $this->assertNotEmpty($entries, 'Process start marker is not found');
+        $freshAfter = time() - 1;
+        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::START_MARKER, $freshAfter);
+        $this->assertNotEmpty($entries, 'No fresh ProcessStartEvent marker entry appeared within 15s');
 
         $latest = $this->findLatestEntryForProcess($entries, 'Test process');
         $this->assertNotNull($latest, 'No ProcessStartEvent entry found for "Test process"');
 
+        // Backstop recency check only: the fresh-entry wait above is the
+        // actual fix for #645. The issue suggested widening this window, but
+        // that is no longer needed and must not be done.
         $this->assertGreaterThan(
             time() - 4,
             $latest['timestamp'],
@@ -92,12 +100,16 @@ final class ProcessTest extends KernelTestCase
      */
     public function testProcessErrorEventIsDispatchedOnThrowable(): void
     {
-        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::ERROR_MARKER);
-        $this->assertNotEmpty($entries, 'Process error marker is not found — error event was not dispatched');
+        $freshAfter = time() - 1;
+        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::ERROR_MARKER, $freshAfter);
+        $this->assertNotEmpty($entries, 'No fresh ProcessErrorEvent marker entry appeared within 15s');
 
         $latest = $this->findLatestEntryForProcess($entries, 'Test error process');
         $this->assertNotNull($latest, 'No ProcessErrorEvent entry found for "Test error process"');
 
+        // Backstop recency check only: the fresh-entry wait above is the
+        // actual fix for #645. The issue suggested widening this window, but
+        // that is no longer needed and must not be done.
         $this->assertGreaterThan(
             time() - 4,
             $latest['timestamp'],
@@ -271,20 +283,33 @@ final class ProcessTest extends KernelTestCase
     }
 
     /**
-     * Wait for a marker file to appear and return its parsed entries.
+     * Wait for a marker file to gain a freshly appended entry and return all
+     * of its parsed entries.
+     *
+     * A merely non-empty file is not enough: entries left over from previous
+     * runs or written before a daemon stall could otherwise satisfy the
+     * caller (Issue #645). Polls at a 200ms interval until at least one
+     * parsed entry has a timestamp >= $freshAfter, or a generous ~15s
+     * deadline passes to tolerate slow macOS daemon respawns (see #534).
+     * Returns [] on timeout.
      *
      * @return list<array{timestamp: int, process: string, message?: string}>
      */
-    private function waitForMarkerEntries(string $relativePath): array
+    private function waitForMarkerEntries(string $relativePath, int $freshAfter): array
     {
         $i = 0;
         do {
             $content = @file_get_contents($this->varDir . '/' . $relativePath);
             if ($content !== false && $content !== '') {
-                return $this->parseMarkerEntries($content);
+                $entries = $this->parseMarkerEntries($content);
+                foreach ($entries as $entry) {
+                    if ($entry['timestamp'] >= $freshAfter) {
+                        return $entries;
+                    }
+                }
             }
             usleep(200000);
-        } while (++$i < 10);
+        } while (++$i < 75);
         return [];
     }
 

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -53,7 +53,7 @@ final class ProcessTest extends KernelTestCase
     public function testProcessStartEventIsDispatched(): void
     {
         $freshAfter = time() - 1;
-        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::START_MARKER, $freshAfter);
+        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::START_MARKER, 'Test process', $freshAfter);
         $this->assertNotEmpty($entries, 'No fresh ProcessStartEvent marker entry appeared within 15s');
 
         $latest = $this->findLatestEntryForProcess($entries, 'Test process');
@@ -101,7 +101,7 @@ final class ProcessTest extends KernelTestCase
     public function testProcessErrorEventIsDispatchedOnThrowable(): void
     {
         $freshAfter = time() - 1;
-        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::ERROR_MARKER, $freshAfter);
+        $entries = $this->waitForMarkerEntries(ProcessMarkerPaths::ERROR_MARKER, 'Test error process', $freshAfter);
         $this->assertNotEmpty($entries, 'No fresh ProcessErrorEvent marker entry appeared within 15s');
 
         $latest = $this->findLatestEntryForProcess($entries, 'Test error process');
@@ -283,19 +283,21 @@ final class ProcessTest extends KernelTestCase
     }
 
     /**
-     * Wait for a marker file to gain a freshly appended entry and return all
-     * of its parsed entries.
+     * Wait for a marker file to gain a freshly appended entry for the given
+     * process and return all of its parsed entries.
      *
      * A merely non-empty file is not enough: entries left over from previous
      * runs or written before a daemon stall could otherwise satisfy the
-     * caller (Issue #645). Polls at a 200ms interval until at least one
-     * parsed entry has a timestamp >= $freshAfter, or a generous ~15s
-     * deadline passes to tolerate slow macOS daemon respawns (see #534).
-     * Returns [] on timeout.
+     * caller (Issue #645). Freshness is scoped to the expected process name:
+     * the marker is shared by every supervised process, so an unrelated
+     * process restarting must not satisfy a wait. Polls at a 200ms interval
+     * until at least one parsed entry for $processName has a timestamp
+     * >= $freshAfter, or a generous ~15s deadline passes to tolerate slow
+     * macOS daemon respawns (see #534). Returns [] on timeout.
      *
      * @return list<array{timestamp: int, process: string, message?: string}>
      */
-    private function waitForMarkerEntries(string $relativePath, int $freshAfter): array
+    private function waitForMarkerEntries(string $relativePath, string $processName, int $freshAfter): array
     {
         $i = 0;
         do {
@@ -303,7 +305,7 @@ final class ProcessTest extends KernelTestCase
             if ($content !== false && $content !== '') {
                 $entries = $this->parseMarkerEntries($content);
                 foreach ($entries as $entry) {
-                    if ($entry['timestamp'] >= $freshAfter) {
+                    if ($entry['process'] === $processName && $entry['timestamp'] >= $freshAfter) {
                         return $entries;
                     }
                 }
@@ -316,12 +318,23 @@ final class ProcessTest extends KernelTestCase
     /**
      * Parse append-only marker file content into structured entries.
      *
+     * The final line is only parsed when it is newline-terminated: the file
+     * is read concurrently with the daemon's FILE_APPEND writes, so a
+     * partially written trailing line (no process field yet, truncated
+     * message) must not be treated as a valid entry (Issue #645 review).
+     *
      * @return list<array{timestamp: int, process: string, message?: string}>
      */
     private function parseMarkerEntries(string $content): array
     {
         $entries = [];
-        foreach (explode("\n", $content) as $line) {
+        $lines = explode("\n", $content);
+        if (end($lines) !== '') {
+            // Trailing line was not terminated by a newline: still being
+            // written, ignore it.
+            array_pop($lines);
+        }
+        foreach ($lines as $line) {
             if ($line === '') {
                 continue;
             }


### PR DESCRIPTION
## Description

Closes #645

`tests/ProcessTest.php` event-marker assertions compared an append-only marker's timestamp against `time() - 4` from the test process. The wait helper returned as soon as the marker file was **non-empty**, so a stale entry — leftover from a previous run (marker unlink only runs on clean daemon shutdown), or written before a daemon stall/restart gap over 4 s — legitimately failed the recency assertion ("1786268332 is greater than 1786268343").

## Changes

- `setUp()` now resets **both** marker files (`START_MARKER` and `ERROR_MARKER`) before every test, so state from earlier tests or killed runs can never satisfy a wait.
- `waitForMarkerEntries()` now waits for a **freshly appended entry for the asserted process** (timestamp ≥ `time() - 1` captured at call time) with a generous ~15 s / 200 ms poll budget instead of returning on the first non-empty file. Freshness is scoped per process: the start marker is shared by every supervised process, so an unrelated process restarting must not satisfy a wait.
- `parseMarkerEntries()` ignores an unterminated trailing line, which can be observed while the daemon appends concurrently (`FILE_APPEND`), so a partially written record can never count as fresh.
- The `assertGreaterThan(time() - 4, ...)` recency checks are kept as a backstop: whenever a fresh entry is found they are guaranteed satisfiable, so they can no longer false-fail.
- The untouched SIGTERM-restart test keeps working with a missing marker (baseline 0).

## Changelog

`ProcessTest` event-marker assertions no longer fail spuriously when the daemon stalls or restarts: markers are reset per test and the wait helper requires a freshly appended entry for the asserted process (15 s budget) instead of returning on the first non-empty file.

## Code Review

- [x] Passed subagent code review (2 rounds; second round: "Code looks good, no issues to fix")
- [x] All review comments addressed (freshness scoped to asserted process; partial trailing lines ignored)
- [x] `composer lint` clean (php-cs-fixer, phpstan, rector)

## Testing notes

Full local suite: 1725 tests, only the 4 pre-existing `ProcessTest` failures caused by a local-environment macOS grpc shutdown hang (workers cannot restart; identical failures on the clean base tree — not caused by this change). Linux CI matrix is authoritative.