### PR TITLE
docs: document fail-closed master identification upgrade impact (closes #640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `start -d` deployments never had a fingerprint
   ([#584](https://github.com/crazy-goat/workerman-bundle/issues/584))
 
+- Document the operator impact of the hardened master identification
+  (previous entry): upgrading while a server started by a pre-0.25
+  version is still running can make `stop` / `reload` / `status` report
+  "Workerman is not running" (no fingerprint sidecar exists yet — and on
+  non-Linux hosts there is no command-line fallback at all), and the same
+  report can appear in the short window after `start -d` until the master
+  writes its pid file and fingerprint. `UPGRADE.md` gains an "Upgrading
+  to 0.25" section and `docs/security.md` an "Operator impact" block
+  with the recovery steps
+  ([#640](https://github.com/crazy-goat/workerman-bundle/issues/640))
+
 - Fix unbounded memory growth in `StaticFilesMiddleware`'s realpath cache.
   The symlink-rejection path inserted into the shared worker cache without
   enforcing `CACHE_MAX_SIZE`, and negative entries only expired on a repeat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document the operator impact of the hardened master identification
   (previous entry): upgrading while a server started by a pre-0.25
   version is still running can make `stop` / `reload` / `status` report
-  "Workerman is not running" (no fingerprint sidecar exists yet — and on
+  "Workerman is not running." (no fingerprint sidecar exists yet — and on
   non-Linux hosts there is no command-line fallback at all), and the same
   report can appear in the short window after `start -d` until the master
   writes its pid file and fingerprint. `UPGRADE.md` gains an "Upgrading

--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ for the full threat model.
 > containerised layout trips it: the cache is warmed at image build time
 > (as `root`), the server runs as a non-root user.
 
+> **Note:** 0.25.0 also hardens master-process identification for
+> `stop` / `reload` / `status`: with a server started by an older version
+> still running, those commands may report "Workerman is not running".
+> Stop the server before upgrading — see
+> [Upgrading to 0.25](UPGRADE.md#upgrading-to-025).
+
 The error message names both UIDs and suggests the fix:
 
 ```

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ for the full threat model.
 
 > **Note:** 0.25.0 also hardens master-process identification for
 > `stop` / `reload` / `status`: with a server started by an older version
-> still running, those commands may report "Workerman is not running.".
+> still running, those commands may report "Workerman is not running."
 > Stop the server before upgrading — see
 > [Upgrading to 0.25](UPGRADE.md#upgrading-to-025).
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ for the full threat model.
 
 > **Note:** 0.25.0 also hardens master-process identification for
 > `stop` / `reload` / `status`: with a server started by an older version
-> still running, those commands may report "Workerman is not running".
+> still running, those commands may report "Workerman is not running.".
 > Stop the server before upgrading — see
 > [Upgrading to 0.25](UPGRADE.md#upgrading-to-025).
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -24,7 +24,7 @@ limited:
   `cli_set_process_title()` does not rewrite the argv visible there.
 - On **non-Linux hosts (macOS, BSD)** there is no command-line fallback
   at all: without a fingerprint file, `stop`, `reload` and `status`
-  always report `Workerman is not running`, even while the server is up.
+  always report `Workerman is not running.`, even while the server is up.
 
 Consequence: upgrading the bundle while a server started by an older
 version is still running can silently turn the control commands into
@@ -39,7 +39,7 @@ no-ops.
    from then on.
 
 **If you already upgraded with a running master** and the commands report
-`Workerman is not running`: recover by terminating the old master by
+`Workerman is not running.`: recover by terminating the old master by
 hand. Read the PID from the pid file, verify with
 `ps -p <pid> -o pid,comm,args` that it is the process you started, and
 `kill` it (never use a bare `pkill -f WorkerMan` — it would kill
@@ -53,7 +53,7 @@ control plane.
 — and with it the fingerprint sidecar — is written by the master process
 itself a moment later (`MasterWorker::saveMasterPid()`, issue #584). A
 `status`, `stop` or `reload` in that short window reports
-`Workerman is not running`; wait for the pid file (and its
+`Workerman is not running.`; wait for the pid file (and its
 `.fingerprint` sidecar) to appear, then retry.
 
 ### Config cache and runtime user

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,67 @@ This document lists breaking changes between releases and describes how to migra
 
 ---
 
+## Upgrading to 0.25
+
+### Master identification now fails closed — stop before upgrading
+
+Since 0.25.0 the bundle verifies the identity of the Workerman master
+process before sending `stop` / `reload` / `status` signals: a PID that
+cannot be verified is refused instead of being signalled (issue #584,
+[hardening details](docs/security.md#master-process-fingerprint-pid-file-hardening)).
+Verification needs the `.fingerprint` sidecar that the new version writes
+next to the pid file on every start. Servers started by older versions
+have no such sidecar, and the fallback that replaces it is strictly
+limited:
+
+- On **Linux** the fallback matches the exact process title Workerman
+  assigns to its master (`WorkerMan: master process ...`). It usually
+  works, but fails closed when `/proc/$pid/cmdline` is unreadable
+  (hidepid, master owned by another user) or on PHP >= 8.5 builds whose
+  `cli_set_process_title()` does not rewrite the argv visible there.
+- On **non-Linux hosts (macOS, BSD)** there is no command-line fallback
+  at all: without a fingerprint file, `stop`, `reload` and `status`
+  always report `Workerman is not running`, even while the server is up.
+
+Consequence: upgrading the bundle while a server started by an older
+version is still running can silently turn the control commands into
+no-ops.
+
+**Recommended upgrade path**
+
+1. Stop the server **before** deploying the new code (with the old code
+   the old identification still works).
+2. Deploy and start the new version — the fingerprint sidecar is written
+   automatically (foreground and daemon mode), and control commands work
+   from then on.
+
+**If you already upgraded with a running master** and the commands report
+`Workerman is not running`: recover by terminating the old master by
+hand. Read the PID from the pid file, verify with
+`ps -p <pid> -o pid,comm,args` that it is the process you started, and
+`kill` it (never use a bare `pkill -f WorkerMan` — it would kill
+unrelated Workerman applications on the host). Remove any leftover pid
+file, then start the new version once. A single start restores the
+control plane.
+
+### `start -d` returns before the master has written its pid file
+
+`start -d` returns as soon as the double fork completes, but the pid file
+— and with it the fingerprint sidecar — is written by the master process
+itself a moment later (`MasterWorker::saveMasterPid()`, issue #584). A
+`status`, `stop` or `reload` in that short window reports
+`Workerman is not running`; wait for the pid file (and its
+`.fingerprint` sidecar) to appear, then retry.
+
+### Config cache and runtime user
+
+The other upgrade-relevant 0.25.0 change: the configuration cache file
+must be owned by the process that loads it (a cache warmed up by a
+different user is refused at boot). See
+[Config cache and runtime user](README.md#config-cache-and-runtime-user).
+
+---
+
 ## Upgrading to 0.17
 
 ### `Utils::reboot()` deprecated in favour of `Utils::reload()`

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -113,6 +113,24 @@ Installed by `php bin/install-git-hook.php` (post-install/post-update).
 Every push runs php-cs-fixer (dry-run), phpstan and rector (dry-run).
 To skip in an emergency: `git push --no-verify`.
 
+## Control plane / master identification
+
+### `stop`/`reload`/`status` report "Workerman is not running" after a 0.25.0 upgrade
+
+Master identification fails closed since 0.25.0 (issue #584): without the
+`.fingerprint` sidecar next to the pid file, control commands refuse to
+signal. This bites in three situations: (1) the server was started by an
+older version and the code was upgraded without stopping it first — stop
+*before* upgrading; (2) macOS/BSD, where the cmdline fallback does not
+exist — the fingerprint (written on every 0.25.0+ start) is the only
+identity check, so a single restart restores the control plane; (3) the
+instant after `start -d` returns, before the master writes pid file and
+fingerprint — wait for both files to appear, then retry. Recovery when
+the old master cannot be verified: read the PID from the pid file, verify
+with `ps -p <pid> -o pid,comm,args`, kill it by hand (never a bare
+`pkill -f WorkerMan`), remove any stale pid file, and start once. Full
+guidance: UPGRADE.md "Upgrading to 0.25" (issue #640).
+
 ## GitHub CLI
 
 ### `gh issue list` returns at most 30 issues by default

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -115,7 +115,7 @@ To skip in an emergency: `git push --no-verify`.
 
 ## Control plane / master identification
 
-### `stop`/`reload`/`status` report "Workerman is not running" after a 0.25.0 upgrade
+### `stop`/`reload`/`status` report "Workerman is not running." after a 0.25.0 upgrade
 
 Master identification fails closed since 0.25.0 (issue #584): without the
 `.fingerprint` sidecar next to the pid file, control commands refuse to

--- a/docs/security.md
+++ b/docs/security.md
@@ -583,6 +583,35 @@ If the fingerprint file does not exist (e.g. after upgrading from a version that
 
 Verification is **fail-closed**: when the cmdline cannot be read (a process owned by another user under `hidepid`, a non-Linux host without `/proc`), `isMasterRunning()` logs a warning and returns `false` — the caller refuses to signal. Earlier revisions returned `true` in this situation (fail-open in the direction of sending a signal); that behaviour is gone (issue #584).
 
+### Operator impact
+
+The fail-closed behaviour is invisible in normal operation — the
+fingerprint is written on every start — but three situations trip it:
+
+- **Upgrading with a running master.** Versions before 0.25.0 never wrote
+  a fingerprint sidecar. If the code is upgraded while a master started
+  by an older version is still running, `stop`, `reload` and `status`
+  can only use the cmdline fallback — which fails closed with PHP >= 8.5
+  argv behaviour or an unreadable `/proc`, and on non-Linux hosts always
+  fails closed. Stop the server **before** upgrading; if you already upgraded,
+  terminate the old master by hand and start the new version once — see
+  [UPGRADE.md](UPGRADE.md#upgrading-to-025).
+- **Non-Linux hosts.** The cmdline fallback is Linux-only, so without a
+  fingerprint file every control command reports "Workerman is not
+  running" even when the server is up. On macOS/BSD the fingerprint is
+  the only verification channel (PID + UID; the start-time check is
+  Linux-only): do not delete `<pid_file>.fingerprint` by hand on a
+  working deployment, and run the console as the same user that started
+  the server. Non-`/proc` liveness checks (e.g. `ps -o comm=`) are
+  deliberately **not** implemented: they cannot match the process title
+  cross-user, and a looser match would re-open the identity-verification
+  hole of issue #584.
+- **Daemon-start window.** `start -d` returns before the master has
+  written its pid file; the fingerprint appears only when the master
+  reaches `MasterWorker::saveMasterPid()` a moment later. A `stop`,
+  `reload` or `status` in that window reports "Workerman is not running"
+  — wait for `<pid_file>.fingerprint` to appear, then retry.
+
 ### When this matters
 
 - **Multi-user hosts**: Shared CI runners, containers with multiple service accounts, or any environment where an attacker could spawn a process whose command line contains "WorkerMan" (or any plain PHP process — earlier revisions accepted any cmdline containing "php").

--- a/docs/security.md
+++ b/docs/security.md
@@ -598,7 +598,7 @@ fingerprint is written on every start — but three situations trip it:
   [UPGRADE.md](../UPGRADE.md#upgrading-to-025).
 - **Non-Linux hosts.** The cmdline fallback is Linux-only, so without a
   fingerprint file every control command reports "Workerman is not
-  running" even when the server is up. On macOS/BSD the fingerprint is
+  running." even when the server is up. On macOS/BSD the fingerprint is
   the only verification channel (PID + UID; the start-time check is
   Linux-only): do not delete `<pid_file>.fingerprint` by hand on a
   working deployment, and run the console as the same user that started

--- a/docs/security.md
+++ b/docs/security.md
@@ -595,7 +595,7 @@ fingerprint is written on every start — but three situations trip it:
   argv behaviour or an unreadable `/proc`, and on non-Linux hosts always
   fails closed. Stop the server **before** upgrading; if you already upgraded,
   terminate the old master by hand and start the new version once — see
-  [UPGRADE.md](UPGRADE.md#upgrading-to-025).
+  [UPGRADE.md](../UPGRADE.md#upgrading-to-025).
 - **Non-Linux hosts.** The cmdline fallback is Linux-only, so without a
   fingerprint file every control command reports "Workerman is not
   running" even when the server is up. On macOS/BSD the fingerprint is
@@ -609,7 +609,7 @@ fingerprint is written on every start — but three situations trip it:
 - **Daemon-start window.** `start -d` returns before the master has
   written its pid file; the fingerprint appears only when the master
   reaches `MasterWorker::saveMasterPid()` a moment later. A `stop`,
-  `reload` or `status` in that window reports "Workerman is not running"
+  `reload` or `status` in that window reports "Workerman is not running."
   — wait for `<pid_file>.fingerprint` to appear, then retry.
 
 ### When this matters


### PR DESCRIPTION
## Description

Closes #640

Documents the operator impact of the fail-closed master identification introduced in PR #608 (issue #584): `stop` / `reload` / `status` can report "Workerman is not running" in three situations a 0.25.0 upgrader will hit — upgrading with a master already running, non-Linux hosts (no `/proc` cmdline fallback), and the short window right after `start -d` before the fingerprint sidecar appears.

Docs-only change, no PHP code touched.

## Changes

- **UPGRADE.md**: new `## Upgrading to 0.25` section — "Master identification now fails closed — stop before upgrading" (all three cases, recommended upgrade path, hand-kill recovery with `ps -p <pid> -o pid,comm,args` verification), the `start -d` race window, and a cross-link to the config-cache note.
- **docs/security.md**: new `### Operator impact` subsection under "Fallback Behaviour" — the three fail-closed situations, the non-Linux PID+UID-only verification channel, and the explicit decision that non-`/proc` checks (e.g. `ps -o comm=`) are deliberately **not** implemented (would re-open #584).
- **README.md**: one blockquote cross-referencing UPGRADE.md in the existing 0.25.0 upgrade-note area.
- **CHANGELOG.md**: entry under `[Unreleased]` → `### Security`, directly after the #584 hardening entry, referencing (#640).
- **docs/helpers/faq.md**: knowledge-base entry per KB rules (one topic, links to UPGRADE.md).

All guidance was fact-checked against the source (`ProcessInspector`, `ServerManager`, `MasterWorker`, vendored Workerman v5.2.2: title is set in `init()` before `daemonize()`, so the upgrade case is conditional, not absolute — the docs say so).

## Changelog

`### Security` entry under [Unreleased]: "Document the fail-closed master identification impact for upgraders, non-Linux hosts and the daemon-start window (#640)".

## Code Review

- [x] Passed subagent code review (2 review rounds + final confirmation, all findings fixed)
- [x] All review comments addressed

## Validation

- `composer lint` (php-cs-fixer, phpstan, rector) — passes, run by the pre-push hook on every push
- `composer test` — 1733 tests, 13807 assertions, 0 failures