### PR TITLE
chore: release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.25.0] - 2026-08-10
 
 ### Added
 


### PR DESCRIPTION
## What

Cut the **0.25.0** release: promote the `## [Unreleased]` section of `CHANGELOG.md` to a dated release entry (`2026-08-10`).

## Why

Per the release gate in [`docs/workflow.md`](docs/workflow.md): milestone **0.25.0** has no open issues left (all 24 closed), so the workflow stops until a release is cut. The changelog content was already finalized via #641 (0.25.0 release notes).

## What's in 0.25.0

- **BC breaks**: `ResponseConverterStrategyInterface::convert()` gained a 4th `$protocolVersion` param + widened `$headers` shape (#556, #579); config-cache ownership is now enforced at boot (#586, #639); fail-closed master identification (#640)
- **Security**: 9 hardening fixes — header control-char filter (#581), cookie URL-decoding (#583), master-process identification (#584), HTTPS downgrade (#585), config-cache dir guard (#586), StaticFiles denylist/allowlist (#582, #580), duplicate Content-Length (#579), X-Forwarded_For collision (#578), underscore-header memory cap (#638)
- **Memory/performance**: connection-timer sweeper (#555, #571), services_resetter on exception paths (#572), MemoryRebootStrategy gc reading (#561), no manual chunking (#556), static-files realpath cache bound (#570)
- **Tests/CI/tooling**: flaky ProcessTest fix (#645), coverage gate 80% (#589), `bin/pick-issue.php` (#633)
- **Docs**: README config reference completion incl. TLS (#590)

## Checklist

- [x] Changelog entry dated
- [ ] Tag `v0.25.0` + `gh release create` after merge (per workflow.md)
- [ ] Close milestone 0.25.0 after release
