### PR TITLE
docs: add release workflow guide

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -247,10 +247,16 @@ done on `master` — they are made on the release branch `v0.25.0`:
 ```bash
 git checkout v0.25.0 && git pull origin v0.25.0
 git checkout -b fix/<ticket>-<description>   # branch off the release branch
-# ... fix + changelog entry under a new "## [0.25.1] - YYYY-MM-DD" heading ...
+# ... fix + changelog entry under [Unreleased] (same pattern as the main flow) ...
 git push -u origin fix/<ticket>-<description>
 gh pr create --base v0.25.0 --head fix/<ticket>-<description> --title "fix: ..."
 ```
+
+Follow the same changelog pattern as the main flow: first add the entry
+under `[Unreleased]` (which the release-branch changelog inherits), then
+promote it to a new `## [0.25.1] - YYYY-MM-DD` heading — placed between
+`[Unreleased]` and `[0.25.0]`, Keep a Changelog's reverse-chronological
+order — when cutting the patch.
 
 Merge the PR into `v0.25.0` (CI runs on the PR as usual), then tag the
 patch from the release branch:
@@ -261,9 +267,12 @@ git tag -a v0.25.1 -m "Release 0.25.1"
 git push origin v0.25.1     # release.yaml fires: draft release → fix notes → publish
 ```
 
-The fix also needs to reach `master` (and newer release branches) — via
-`git cherry-pick` in a follow-up PR, or directly if the same fix targets
-the next release line.
+The fix also needs to reach `master` (and newer release branches) via a
+`git cherry-pick` in a follow-up PR. The cherry-picked commit carries the
+`[0.25.1]` changelog heading, which does **not** belong on `master` (its
+changelog tracks the next release line): keep master's entry under
+`[Unreleased]` instead — resolve the `CHANGELOG.md` conflict accordingly
+when the pick lands.
 
 ---
 


### PR DESCRIPTION
## What

New [`docs/release-workflow.md`](docs/release-workflow.md), documenting the release cycle that follows the `bin/pick-issue.php` release gate (exit code 3):

1. **Changelog PR** — `[Unreleased]` → `[0.X.Y] - YYYY-MM-DD` + restore fresh `[Unreleased]`, with a **completeness check** (runner verifies every milestone issue is referenced in the release section), CI, merge
2. **Release branch `vX.Y.Z` + annotated tag** — all dev goes to master, so the release branch is the base for follow-up fixes and patch releases of older lines; tag verified against `origin/master`
3. **Release notes** — `release.yaml` publishes a **draft**; overwrite the auto-generated "What's Changed" with the changelog section (matching the existing release style, verified against v0.24.1/v0.23.0), guarded extraction, then publish
4. **Close milestone** + re-run `pick-issue.php`
5. **Patch-release flow**: hotfix PRs target the `vX.Y.Z` branch; patch tags (`v0.25.1`) are cut from it, then cherry-picked to master

## Why

This is the flow used to cut 0.25.0 (PR #658, tag v0.25.0, release notes, milestone close) plus the findings of an agent review:

- **HIGH** — releases were published with auto-generated notes *before* the curated changelog was pasted; notifications fired with the wrong body (BC-break warning reached nobody). Now fixed by `draft: true` (companion PR #660) + explicit publish step
- **MEDIUM** — no `[Unreleased]` restoration step (0.25.0 cut left the changelog without a target section; restore included in PR #660)
- **MEDIUM** — no changelog completeness check; verified clean for 0.25.0 (all 24 milestone issues covered; #639/#641 are release-process meta-issues, #141/#217/#558 are cross-references)
- **LOW** — brittle sed extraction, manual milestone lookup, no tag↔master check — each now has a guard/one-liner

## Checklist

- [x] docs/release-workflow.md + index + workflow.md cross-link
- [x] Completeness check verified clean for 0.25.0 (agent-verified: tag annotated, points to origin/master, release body == changelog section)
