### PR TITLE
fix: InotifyMonitorWatcher IN_IGNORED cleanup + inotify_add_watch failure handling (closes #575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `InotifyMonitorWatcher` no longer discards `IN_IGNORED` bookkeeping (or directory-create
+  events) while a reload is pending: the guard previously dropped the whole event batch
+  after `inotify_read()`, so `pathByWd` / `watchedPaths` kept entries for directories the
+  kernel had stopped watching, and a stale `watchedPaths` entry silently suppressed
+  re-watching a recreated directory ([#575](https://github.com/crazy-goat/workerman-bundle/issues/575))
+- `InotifyMonitorWatcher` now checks the `inotify_add_watch()` return value: on failure it
+  writes to neither bookkeeping map and logs a warning naming the path and
+  `/proc/sys/fs/inotify/max_user_watches` (once per path), instead of corrupting
+  `pathByWd[0]` with a false descriptor and permanently marking the path as watched
+  ([#575](https://github.com/crazy-goat/workerman-bundle/issues/575))
+- `InotifyMonitorWatcher` now skips events carrying an unknown watch descriptor (no more
+  `null` concatenation into a bogus watch path) and watches directories moved into the
+  tree — including their pre-existing children — which previously arrived as
+  `IN_MOVED_TO|IN_ISDIR` and were missed entirely ([#575](https://github.com/crazy-goat/workerman-bundle/issues/575))
+
 ## [0.25.0] - 2026-08-10
 
 ### Added

--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -30,6 +30,15 @@ them instead of restating the pattern in issues or PRs.
 
 ## Test suite
 
+### Testing an `inotify_add_watch()` failure without exhausting watch limits
+
+To exercise `InotifyMonitorWatcher::watchDir()`'s failure branch, queue a
+`IN_CREATE|IN_ISDIR` event and delete the directory before the event is
+processed: `inotify_add_watch()` then fails deterministically with ENOENT.
+Do not try to exhaust `/proc/sys/fs/inotify/max_user_watches` — it is
+host-specific and slow. (Inotify events are queued synchronously at syscall
+time, so `mkdir` → `rmdir` → `invokeOnNotify` is race-free.)
+
 ### grpc extension on macOS: stop timeouts, zombie masters, no worker restarts
 
 If the `grpc` extension is loaded (Homebrew PHP), its shutdown handler

--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -78,6 +78,10 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
                 unset($this->pathByWd[$event['wd']]);
                 if ($path !== null) {
                     unset($this->watchedPaths[$path]);
+                    // A reported failure is only relevant while the path is
+                    // tracked; if the directory reappears and fails again, the
+                    // new failure must be reported, not silently suppressed.
+                    unset($this->loggedWatchFailures[$path]);
                 }
                 continue;
             }
@@ -155,7 +159,7 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
             return true;
         }
 
-        $wd = \inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
+        $wd = @\inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
 
         if ($wd === false) {
             if (!isset($this->loggedWatchFailures[$path])) {

--- a/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
+++ b/src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php
@@ -17,6 +17,8 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
     private array $pathByWd = [];
     /** @var array<string, true> */
     private array $watchedPaths = [];
+    /** @var array<string, true> Paths whose failed add_watch was already reported */
+    private array $loggedWatchFailures = [];
     private \Closure|null $reloadCallback = null;
 
     public function start(): void
@@ -57,10 +59,7 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
             foreach ($iterator as $file) {
                 /** @var \SplFileInfo $file */
                 if ($file->isDir()) {
-                    $path = $file->getPathname();
-                    if (!isset($this->watchedPaths[$path])) {
-                        $this->watchDir($path);
-                    }
+                    $this->watchDir($file->getPathname());
                 }
             }
         }
@@ -73,10 +72,6 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
     {
         $events = \inotify_read($inotifyFd) ?: [];
 
-        if ($this->reloadCallback instanceof \Closure) {
-            return;
-        }
-
         foreach ($events as $event) {
             if ($this->isFlagSet($event['mask'], IN_IGNORED)) {
                 $path = $this->pathByWd[$event['wd']] ?? null;
@@ -87,12 +82,24 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
                 continue;
             }
 
-            if ($this->isFlagSet($event['mask'], IN_CREATE | IN_ISDIR)) {
-                $this->watchDir($this->pathByWd[$event['wd']] . '/' . $event['name']);
+            if (
+                $this->isFlagSet($event['mask'], IN_CREATE | IN_ISDIR)
+                || $this->isFlagSet($event['mask'], IN_MOVED_TO | IN_ISDIR)
+            ) {
+                $parentPath = $this->pathByWd[$event['wd']] ?? null;
+                if ($parentPath !== null) {
+                    $this->watchDirTree($parentPath . '/' . $event['name']);
+                }
                 continue;
             }
 
             if (!$this->checkPattern($event['name'])) {
+                continue;
+            }
+
+            // Bookkeeping above always runs, even while a reload is pending;
+            // only the reload scheduling is skipped once one is already armed.
+            if ($this->reloadCallback instanceof \Closure) {
                 continue;
             }
 
@@ -102,16 +109,79 @@ final class InotifyMonitorWatcher extends FileMonitorWatcher
             };
 
             $this->worker::$globalEvent?->delay(self::RELOAD_DELAY, $this->reloadCallback);
-
-            return;
         }
     }
 
-    private function watchDir(string $path): void
+    /**
+     * Watch a directory and any subdirectories it already contains.
+     *
+     * A directory moved into the tree (or created and populated in one step)
+     * can arrive with children already present; those children never produce
+     * events because no watch existed when they were created, so their
+     * watches have to be established by walking the subtree.
+     */
+    private function watchDirTree(string $path): void
     {
+        if (!$this->watchDir($path)) {
+            return;
+        }
+
+        try {
+            $iterator = $this->createRecursiveIterator(
+                $path,
+                \FilesystemIterator::SKIP_DOTS,
+                \RecursiveIteratorIterator::SELF_FIRST,
+            );
+        } catch (\UnexpectedValueException) {
+            // Directory disappeared between the event and this walk.
+            return;
+        }
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            if ($file->isDir()) {
+                $this->watchDir($file->getPathname());
+            }
+        }
+    }
+
+    /**
+     * Add a watch for one directory. Idempotent per path; safe to call from
+     * every entry point (start, deferred walk, event processing).
+     */
+    private function watchDir(string $path): bool
+    {
+        if (isset($this->watchedPaths[$path])) {
+            return true;
+        }
+
         $wd = \inotify_add_watch($this->fd, $path, IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_TO);
+
+        if ($wd === false) {
+            if (!isset($this->loggedWatchFailures[$path])) {
+                $this->loggedWatchFailures[$path] = true;
+                Worker::log(sprintf(
+                    'InotifyMonitorWatcher: failed to watch "%s" (inotify_add_watch() returned false); '
+                    . 'check /proc/sys/fs/inotify/max_user_watches if many directories are unwatched',
+                    $path,
+                ));
+            }
+
+            return false;
+        }
+
+        // A watch surviving a move keeps its descriptor, so the descriptor may
+        // already be mapped to the old location of this directory: drop that
+        // stale path to keep both maps consistent.
+        $previousPath = $this->pathByWd[$wd] ?? null;
+        if ($previousPath !== null && $previousPath !== $path) {
+            unset($this->watchedPaths[$previousPath]);
+        }
+
         $this->pathByWd[$wd] = $path;
         $this->watchedPaths[$path] = true;
+
+        return true;
     }
 
     private function isFlagSet(int $check, int $flag): bool

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -540,6 +540,12 @@ final class InotifyMonitorWatcherTest extends TestCase
     {
         $tmpDir = $this->createTempDir();
 
+        // Created BEFORE the watcher starts, so the root watch never queues a
+        // known-wd IN_CREATE|IN_ISDIR for it: the only events referencing it
+        // are the ones from the unrecorded watch below.
+        $unrecordedDir = $tmpDir . '/unrecorded';
+        mkdir($unrecordedDir, 0700);
+
         $worker = $this->createMock(Worker::class);
         $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
         $this->setUpEventLoop();
@@ -552,8 +558,6 @@ final class InotifyMonitorWatcherTest extends TestCase
         // Register a watch directly on the watcher's descriptor, bypassing the
         // bookkeeping maps: its events then carry a descriptor onNotify() has
         // never seen.
-        $unrecordedDir = $tmpDir . '/unrecorded';
-        mkdir($unrecordedDir, 0700);
         \inotify_add_watch($fd, $unrecordedDir, self::IN_CREATE | self::IN_ISDIR);
 
         $pathByWdBefore = $this->getPrivateProperty($watcher, 'pathByWd');
@@ -653,6 +657,15 @@ final class InotifyMonitorWatcherTest extends TestCase
         $tmpDir = $this->createTempDir();
         $logFile = $tmpDir . '/workerman.log';
         $originalLogFile = Worker::$logFile;
+        $originalOutputStream = Worker::$outputStream;
+        // Worker::log() -> safeEcho() requires a writable stream; in a unit
+        // test no stream has been initialised, so give it one (same convention
+        // as MasterWorkerTest::testFingerprintRenameFailureIsLogged).
+        $testStream = \fopen('php://temp', 'w+');
+        if ($testStream === false) {
+            self::fail('Unable to open temp stream for test');
+        }
+        Worker::$outputStream = $testStream;
         Worker::$logFile = $logFile;
 
         try {
@@ -704,6 +717,7 @@ final class InotifyMonitorWatcherTest extends TestCase
             $this->assertSame(1, substr_count($log, 'ghost'), 'the warning must be logged at most once per path');
         } finally {
             Worker::$logFile = $originalLogFile;
+            Worker::$outputStream = $originalOutputStream;
         }
     }
 

--- a/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
+++ b/tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php
@@ -418,6 +418,295 @@ final class InotifyMonitorWatcherTest extends TestCase
         }
     }
 
+    /**
+     * @requires extension inotify
+     */
+    public function testInIgnoredCleanupRunsWhileReloadIsPending(): void
+    {
+        $tmpDir = $this->createTempDir();
+        mkdir($tmpDir . '/subdir', 0700);
+
+        $delayCount = 0;
+        $eventLoop = $this->createMock(EventInterface::class);
+        $eventLoop->method('onReadable')->willReturnCallback(function (): void {
+        });
+        $eventLoop->method('delay')->willReturnCallback(function () use (&$delayCount): int {
+            ++$delayCount;
+
+            return $delayCount;
+        });
+
+        Worker::$globalEvent = $eventLoop;
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+
+        $watcher->start();
+        $this->invokeDeferredWalk($watcher);
+
+        // Arm a pending reload with a matching file change.
+        file_put_contents($tmpDir . '/a.php', '<?php');
+        $this->waitForInotifyEvents();
+
+        $fd = $this->getPrivateProperty($watcher, 'fd');
+        $this->invokeOnNotify($watcher, $fd);
+
+        $this->assertNotNull(
+            $this->getPrivateProperty($watcher, 'reloadCallback'),
+            'precondition: a reload must be pending before the subdirectory is deleted',
+        );
+        $delaysBefore = $delayCount;
+
+        // Delete a watched subdirectory while the reload is still pending.
+        rmdir($tmpDir . '/subdir');
+        clearstatcache();
+        $this->waitForInotifyEvents();
+        $this->invokeOnNotify($watcher, $fd);
+
+        $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
+        $watchedPaths = $this->getPrivateProperty($watcher, 'watchedPaths');
+        $this->assertNotContains(
+            $tmpDir . '/subdir',
+            $pathByWd,
+            'IN_IGNORED cleanup must run while a reload is pending',
+        );
+        $this->assertArrayNotHasKey(
+            $tmpDir . '/subdir',
+            $watchedPaths,
+            'watchedPaths must be cleaned while a reload is pending',
+        );
+        $this->assertNotNull(
+            $this->getPrivateProperty($watcher, 'reloadCallback'),
+            'the pending reload must stay armed',
+        );
+        $this->assertSame($delaysBefore, $delayCount, 'no additional reload may be scheduled');
+        $this->assertMapsConsistent($watcher);
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testDeletedDirectoryIsWatchedAgainAfterRecreation(): void
+    {
+        $tmpDir = $this->createTempDir();
+        mkdir($tmpDir . '/subdir', 0700);
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+        $this->setUpEventLoop();
+
+        $watcher->start();
+        $this->invokeDeferredWalk($watcher);
+
+        rmdir($tmpDir . '/subdir');
+        clearstatcache();
+        $this->waitForInotifyEvents();
+
+        $fd = $this->getPrivateProperty($watcher, 'fd');
+        $this->invokeOnNotify($watcher, $fd);
+
+        $this->assertNotContains(
+            $tmpDir . '/subdir',
+            $this->getPrivateProperty($watcher, 'pathByWd'),
+            'deleted directory must be cleaned from pathByWd',
+        );
+        $this->assertArrayNotHasKey(
+            $tmpDir . '/subdir',
+            $this->getPrivateProperty($watcher, 'watchedPaths'),
+            'deleted directory must be cleaned from watchedPaths',
+        );
+
+        mkdir($tmpDir . '/subdir', 0700);
+        $this->waitForInotifyEvents();
+        $this->invokeOnNotify($watcher, $fd);
+
+        $this->assertContains(
+            $tmpDir . '/subdir',
+            $this->getPrivateProperty($watcher, 'pathByWd'),
+            'recreated directory must be watched again',
+        );
+        $this->assertArrayHasKey(
+            $tmpDir . '/subdir',
+            $this->getPrivateProperty($watcher, 'watchedPaths'),
+            'recreated directory must be recorded as watched',
+        );
+        $this->assertMapsConsistent($watcher);
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testEventWithUnknownWatchDescriptorIsSkipped(): void
+    {
+        $tmpDir = $this->createTempDir();
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+        $this->setUpEventLoop();
+
+        $watcher->start();
+
+        $fd = $this->getPrivateProperty($watcher, 'fd');
+        \assert(\is_resource($fd));
+
+        // Register a watch directly on the watcher's descriptor, bypassing the
+        // bookkeeping maps: its events then carry a descriptor onNotify() has
+        // never seen.
+        $unrecordedDir = $tmpDir . '/unrecorded';
+        mkdir($unrecordedDir, 0700);
+        \inotify_add_watch($fd, $unrecordedDir, self::IN_CREATE | self::IN_ISDIR);
+
+        $pathByWdBefore = $this->getPrivateProperty($watcher, 'pathByWd');
+        $watchedPathsBefore = $this->getPrivateProperty($watcher, 'watchedPaths');
+
+        mkdir($unrecordedDir . '/child', 0700);
+        $this->waitForInotifyEvents();
+        $this->invokeOnNotify($watcher, $fd);
+
+        $this->assertSame(
+            $pathByWdBefore,
+            $this->getPrivateProperty($watcher, 'pathByWd'),
+            'an event for an unknown watch descriptor must not register a watch',
+        );
+        $this->assertSame(
+            $watchedPathsBefore,
+            $this->getPrivateProperty($watcher, 'watchedPaths'),
+            'an event for an unknown watch descriptor must not touch watchedPaths',
+        );
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testMovedInDirectoryWithPreExistingChildrenIsWatched(): void
+    {
+        $tmpDir = $this->createTempDir();
+
+        $staging = sys_get_temp_dir() . '/inotify_staging_' . bin2hex(random_bytes(4));
+        mkdir($staging . '/nested', 0700, true);
+        file_put_contents($staging . '/nested/cache.php', '<?php');
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+        $this->setUpEventLoop();
+
+        $watcher->start();
+
+        // A directory moved into the tree arrives as IN_MOVED_TO|IN_ISDIR with
+        // its children already present (they were created outside any watch).
+        rename($staging, $tmpDir . '/moved');
+        $this->waitForInotifyEvents();
+
+        $fd = $this->getPrivateProperty($watcher, 'fd');
+        $this->invokeOnNotify($watcher, $fd);
+
+        $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
+        $watchedPaths = $this->getPrivateProperty($watcher, 'watchedPaths');
+        $this->assertContains($tmpDir . '/moved', $pathByWd, 'moved-in directory must be watched');
+        $this->assertContains(
+            $tmpDir . '/moved/nested',
+            $pathByWd,
+            'pre-existing child of a moved-in directory must be watched',
+        );
+        $this->assertArrayHasKey($tmpDir . '/moved', $watchedPaths);
+        $this->assertArrayHasKey($tmpDir . '/moved/nested', $watchedPaths);
+        $this->assertMapsConsistent($watcher);
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testMovingWatchedDirectoryKeepsMapsConsistent(): void
+    {
+        $tmpDir = $this->createTempDir();
+        mkdir($tmpDir . '/alpha', 0700);
+
+        $worker = $this->createMock(Worker::class);
+        $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+        $this->setUpEventLoop();
+
+        $watcher->start();
+        $this->invokeDeferredWalk($watcher);
+
+        // The watch follows the inode, so the kernel reports the same watch
+        // descriptor for the new location; the old path must not linger.
+        rename($tmpDir . '/alpha', $tmpDir . '/beta');
+        clearstatcache();
+        $this->waitForInotifyEvents();
+
+        $fd = $this->getPrivateProperty($watcher, 'fd');
+        $this->invokeOnNotify($watcher, $fd);
+
+        $this->assertContains($tmpDir . '/beta', $this->getPrivateProperty($watcher, 'pathByWd'));
+        $this->assertNotContains($tmpDir . '/alpha', $this->getPrivateProperty($watcher, 'pathByWd'));
+        $watchedPaths = $this->getPrivateProperty($watcher, 'watchedPaths');
+        $this->assertArrayHasKey($tmpDir . '/beta', $watchedPaths);
+        $this->assertArrayNotHasKey($tmpDir . '/alpha', $watchedPaths);
+        $this->assertMapsConsistent($watcher);
+    }
+
+    /**
+     * @requires extension inotify
+     */
+    public function testFailedAddWatchWritesNoMapsAndLogsWarningOnce(): void
+    {
+        $tmpDir = $this->createTempDir();
+        $logFile = $tmpDir . '/workerman.log';
+        $originalLogFile = Worker::$logFile;
+        Worker::$logFile = $logFile;
+
+        try {
+            $worker = $this->createMock(Worker::class);
+            $watcher = $this->createWatcherWithSourceDir($worker, $tmpDir, ['*.php']);
+            $this->setUpEventLoop();
+
+            $watcher->start();
+
+            $fd = $this->getPrivateProperty($watcher, 'fd');
+
+            // Create a directory and remove it again before the queued event is
+            // processed: the IN_CREATE|IN_ISDIR then hits a path that no longer
+            // exists, so inotify_add_watch() fails.
+            mkdir($tmpDir . '/ghost', 0700);
+            $this->waitForInotifyEvents();
+            rmdir($tmpDir . '/ghost');
+            clearstatcache();
+            $this->waitForInotifyEvents();
+
+            $this->invokeOnNotify($watcher, $fd);
+
+            $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
+            $this->assertSame(
+                [$tmpDir],
+                array_values($pathByWd),
+                'a failed add_watch must not pollute pathByWd',
+            );
+            $this->assertArrayNotHasKey(
+                $tmpDir . '/ghost',
+                $this->getPrivateProperty($watcher, 'watchedPaths'),
+                'a failed add_watch must not mark the path as watched',
+            );
+
+            $log = (string) file_get_contents($logFile);
+            $this->assertStringContainsString('ghost', $log, 'the warning must name the failed path');
+            $this->assertStringContainsString('max_user_watches', $log, 'the warning must point to the watch limit');
+
+            // Repeat the same failing cycle: the warning is emitted once per path.
+            mkdir($tmpDir . '/ghost', 0700);
+            $this->waitForInotifyEvents();
+            rmdir($tmpDir . '/ghost');
+            clearstatcache();
+            $this->waitForInotifyEvents();
+
+            $this->invokeOnNotify($watcher, $fd);
+
+            $log = (string) file_get_contents($logFile);
+            $this->assertSame(1, substr_count($log, 'ghost'), 'the warning must be logged at most once per path');
+        } finally {
+            Worker::$logFile = $originalLogFile;
+        }
+    }
+
     // ---- Helper methods ----
 
     private function setUpEventLoop(): void
@@ -503,6 +792,23 @@ final class InotifyMonitorWatcherTest extends TestCase
         $regexProp->setValue($instance, $compilePatterns->invoke($instance, $filePattern));
 
         return $instance;
+    }
+
+    private function assertMapsConsistent(InotifyMonitorWatcher $watcher): void
+    {
+        $pathByWd = $this->getPrivateProperty($watcher, 'pathByWd');
+        $watchedPaths = $this->getPrivateProperty($watcher, 'watchedPaths');
+
+        $this->assertCount(
+            count($pathByWd),
+            $watchedPaths,
+            'pathByWd and watchedPaths must have equal sizes',
+        );
+
+        foreach ($pathByWd as $wd => $path) {
+            $this->assertIsInt($wd, 'watch descriptors must be integers');
+            $this->assertArrayHasKey($path, $watchedPaths, sprintf('path "%s" must be recorded as watched', $path));
+        }
     }
 
     private function removeDirectory(string $dir): void


### PR DESCRIPTION
## Description

Closes #575

`InotifyMonitorWatcher` (dev-time file-monitor worker) had four defects:

1. **IN_IGNORED bookkeeping discarded while a reload is pending** — `onNotify()` consumed the event batch via `inotify_read()` and then returned early, so `IN_IGNORED` cleanup (the only place `pathByWd`/`watchedPaths` entries are removed) never ran during the 0.33 s reload window. Stale `watchedPaths` entries then suppressed re-watching in `deferredWalk()` — a memory bookkeeping bug turning into missed reloads.
2. **Unchecked `inotify_add_watch()`** — on failure (`false`, e.g. `max_user_watches` exhaustion) it wrote `pathByWd[false]` (integer key 0, colliding with a real descriptor) and permanently marked the path as watched. Now: no map writes, one warning per path naming the path and the watch-limit cause.
3. **Unknown-`wd` events** — `pathByWd[$event['wd']] . '/' ...` concatenated `null` (deprecation + wrong-path watch). Now skipped.
4. **Moved-in directories missed** — `IN_MOVED_TO|IN_ISDIR` arrives despite the mask; the branch only tested `IN_CREATE|IN_ISDIR`. Now `watchDirTree()` watches the moved-in subtree including pre-existing children.

Plus: a review follow-up suppressed the raw PHP `E_WARNING` from `inotify_add_watch()` (`@`, checked return kept — codebase convention) and clears the per-path failure log on `IN_IGNORED` so a reappearing directory's new failure is reported again. Lazy-startup behavior from #324 is preserved (top-level dirs synchronous, deep walk deferred).

## Changes

- `src/Reboot/FileMonitorWatcher/InotifyMonitorWatcher.php` — reload-pending guard moved from `onNotify()` pre-loop `return` to the reload-scheduling branch; guarded `watchDir()` (returns `bool`), failure logging once per path; unknown-wd skip; `IN_MOVED_TO|IN_ISDIR` via `watchDirTree()`; unified `watchedPaths` guard; stale-path cleanup on wd reuse; `IN_IGNORED` also clears `loggedWatchFailures`.
- `tests/Reboot/FileMonitorWatcher/InotifyMonitorWatcherTest.php` — 6 new `@requires extension inotify` integration tests (real kernel events): IN_IGNORED cleanup during pending reload + no double-schedule, delete→recreate re-watch, failed add_watch → no map writes + once-per-path warning, unknown-wd skip, moved-in dir with pre-existing children, watched-dir move map consistency; new `assertMapsConsistent()` helper asserts the acceptance-criteria invariant.
- `CHANGELOG.md` — `[Unreleased] → Fixed` entries referencing #575.
- `docs/helpers/faq.md` — KB entry: deterministic technique for testing the add_watch failure branch (mkdir → rmdir → invoke, ENOENT).

## Validation

- `composer lint` (php-cs-fixer, PHPStan L8, rector): clean.
- `composer test` (full suite, real Workerman daemon): 1739 tests, 0 failures, 29 skipped (inotify/grpc-gated); `tests/Reboot/FileMonitorWatcher/`: 41 tests OK.
- ⚠️ `ext-inotify` is not installed on the dev host (macOS) — the 6 new tests skip locally and run for real on CI (Linux). Their behavior relies on documented kernel-event semantics (synchronous event queuing at syscall time, wd reuse per inode, IN_IGNORED on rmdir), verified by code reading; CI is the runtime verification.
- Coverage gate (80%, CI PHP 8.2 leg) not runnable locally (no PCOV/Xdebug); new lines are covered by the extension-gated tests on CI.

## Changelog

Three `Fixed` bullets under `[Unreleased]` covering the IN_IGNORED cleanup, add_watch failure handling, and unknown-wd/moved-in-dir fixes (see diff).

## Code Review

- [x] Passed subagent code review (2 rounds — round 2: "Code looks good, no issues to fix")
- [x] All review comments addressed

## Out-of-scope finding (pre-existing, not fixed here)

`IN_MOVED_FROM` is missing from the watch mask — moved-out trees keep their kernel watch until eventual deletion. Low impact (dev facility), tracked for a future issue candidate.