### PR TITLE
feat: bound trusted-hosts caching in SymfonyController (closes #560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SymfonyController` no longer calls `Request::setTrustedHosts()` on every
+  request when `trusted_hosts` is configured. It now maintains a per-worker,
+  bounded (64-entry) validated-host cache and re-applies the patterns only on a
+  cache miss, so Symfony's internal `Request::$trustedHosts` memo benefits from
+  cross-request reuse in a long-lived worker while staying bounded. Without the
+  bound, a wildcard trusted-host pattern would let a remote client grow that
+  static list by one entry per distinct matching host for the worker's lifetime
+  (unbounded memory plus quadratic `in_array` lookup cost) — the very call this
+  optimisation removes was the only thing resetting it
+  ([#560](https://github.com/crazy-goat/workerman-bundle/issues/560))
+
 - `InotifyMonitorWatcher` no longer discards `IN_IGNORED` bookkeeping (or directory-create
   events) while a reload is pending: the guard previously dropped the whole event batch
   after `inotify_read()`, so `pathByWd` / `watchedPaths` kept entries for directories the

--- a/docs/helpers/decisions.md
+++ b/docs/helpers/decisions.md
@@ -34,6 +34,22 @@ exactly, and activity is whole-second granular.
 `StaticFilesMiddleware` caps the negative realpath cache so long-lived
 workers do not grow it unboundedly when files are missing (#570, #607).
 
+### Trusted-host patterns are applied once and re-applied only on cache miss (#560)
+
+`SymfonyController` maintains a per-worker, bounded (64-entry) validated-host
+cache. `Request::setTrustedHosts()` is called only on a cache miss (a host not
+seen — or evicted — by this worker), not on every request. The reset inside
+`setTrustedHosts()` is what bounds Symfony's internal `Request::$trustedHosts`
+list: with a wildcard trusted-host pattern that list would otherwise grow by one
+entry per distinct matching host for the worker's lifetime (unbounded memory +
+quadratic `in_array` lookup). The previous per-request call was wasteful but was
+the only thing resetting that list — fixing the waste without a bound would have
+been strictly worse. `getTrustedHosts()` returns the *patterns*, not the
+validated-host cache, so the regression test reads `Request::$trustedHosts` via
+reflection. When a trusted proxy forwards `X-Forwarded-Host`, the cache is
+skipped (reset every request) because the cache key (direct Host header) would
+not match the value `getHost()` validates.
+
 ## Security policy
 
 The following hardening measures were consolidated through the security

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -19,10 +19,34 @@ use Workerman\Protocols\Http\Response;
 
 final class SymfonyController
 {
+    /**
+     * Maximum number of distinct validated hosts cached per worker.
+     *
+     * Symfony's {@see SymfonyRequest::getHost()} appends every newly-seen
+     * matching host to a static list (Request::$trustedHosts) and scans it
+     * linearly on every lookup. That list is only ever cleared by
+     * {@see SymfonyRequest::setTrustedHosts()}, so with a wildcard trusted
+     * host pattern a remote client can grow it without bound — one retained
+     * string per distinct matching host, for the worker's lifetime, plus
+     * quadratic lookup cost. This constant — not client input — bounds the
+     * bundle-side cache and, through the reset-on-miss strategy below,
+     * Symfony's internal list as well (issue #560).
+     */
+    private const MAX_VALIDATED_HOSTS = 64;
+
     private ?SymfonyRequest $symfonyRequest = null;
     private ?SymfonyResponse $symfonyResponse = null;
     private ?ResetInterface $servicesResetter = null;
     private bool $servicesResetterInitialized = false;
+
+    /**
+     * Validated hosts cached per worker, bounded by {@see MAX_VALIDATED_HOSTS}.
+     * Only hosts that passed {@see SymfonyRequest::getHost()} are stored; a
+     * cache hit skips the {@see SymfonyRequest::setTrustedHosts()} reset.
+     *
+     * @var array<string, true>
+     */
+    private array $validatedHosts = [];
 
     /**
      * @param string[] $trustedHosts List of regex patterns for trusted hostnames
@@ -38,19 +62,40 @@ final class SymfonyController
     /**
      * Process the request through Symfony kernel and return Workerman response.
      * Note: kernel->terminate() is NOT called here - use terminateIfNeeded() after sending response.
-     * On first invocation with trusted_hosts configured, applies Symfony's global trusted host patterns.
+     *
+     * When trusted_hosts is configured, Symfony's global trusted host patterns
+     * are applied on the first request and re-applied only when a host is not
+     * in the per-worker validated-host cache (a cache miss). Re-applying via
+     * setTrustedHosts() resets Symfony's internal Request::$trustedHosts memo,
+     * so the memo cache benefits from cross-request reuse while staying bounded
+     * by {@see MAX_VALIDATED_HOSTS} — see the constraint in issue #560.
      */
     public function __invoke(Request $request, TcpConnection $connection): Response
     {
-        if ($this->trustedHosts !== []) {
-            SymfonyRequest::setTrustedHosts($this->trustedHosts);
-        }
-
         $this->symfonyRequest = RequestConverter::toSymfonyRequest($request);
 
-        // Early validation: reject non-matching Host headers before kernel boot
-        // This prevents the kernel from processing requests with spoofed Host headers
+        // Early validation: reject non-matching Host headers before kernel boot.
+        // This prevents the kernel from processing requests with spoofed Host
+        // headers. The patterns are re-applied on a cache miss so the reset
+        // inside setTrustedHosts() still bounds Symfony's validated-host list.
+        //
+        // setTrustedHosts() writes global static state; each server has its own
+        // controller instance, so a per-instance cache is correct for the
+        // single-server case. If a process ever runs several servers with
+        // different trusted_hosts, the last writer wins globally (pre-existing
+        // limitation of Symfony's static API, not worsened here).
         if ($this->trustedHosts !== []) {
+            $host = $this->extractHostForCache($this->symfonyRequest);
+            // When a trusted proxy forwards X-Forwarded-Host, getHost()
+            // validates a different value than the direct Host header used as
+            // the cache key, so skip the cache and reset on every request
+            // (still bounded, just without the cross-request memo benefit).
+            $cacheable = !$this->symfonyRequest->isFromTrustedProxy();
+
+            if (!$cacheable || !isset($this->validatedHosts[$host])) {
+                SymfonyRequest::setTrustedHosts($this->trustedHosts);
+            }
+
             try {
                 $this->symfonyRequest->getHost();
             } catch (SuspiciousOperationException) {
@@ -58,6 +103,15 @@ final class SymfonyController
                 $this->symfonyRequest = null;
 
                 return new Response(400);
+            }
+
+            // Cache only hosts that passed validation; invalid hosts must not
+            // populate the cache (they would never yield a useful hit).
+            if ($cacheable && !isset($this->validatedHosts[$host])) {
+                $this->validatedHosts[$host] = true;
+                if (\count($this->validatedHosts) > self::MAX_VALIDATED_HOSTS) {
+                    \array_shift($this->validatedHosts);
+                }
             }
         }
 
@@ -143,5 +197,27 @@ final class SymfonyController
                 ['exception' => $e->getMessage(), 'file' => $e->getFile(), 'line' => $e->getLine()],
             );
         }
+    }
+
+    /**
+     * Extract the normalized host used as the validated-host cache key.
+     *
+     * Mirrors the host resolution of {@see SymfonyRequest::getHost()} for the
+     * non-trusted-proxy path (Host header → SERVER_NAME → SERVER_ADDR), so the
+     * cache key matches the value getHost() validates. When a trusted proxy is
+     * in use, getHost() reads X-Forwarded-Host instead; the caller skips the
+     * cache in that case (see {@see __invoke}).
+     */
+    private function extractHostForCache(SymfonyRequest $request): string
+    {
+        $host = (string) $request->headers->get('HOST');
+        if ($host === '') {
+            $host = (string) $request->server->get('SERVER_NAME', '');
+        }
+        if ($host === '') {
+            $host = (string) $request->server->get('SERVER_ADDR', '');
+        }
+
+        return \strtolower((string) \preg_replace('/:\d+$/', '', \trim($host)));
     }
 }

--- a/src/Middleware/SymfonyController.php
+++ b/src/Middleware/SymfonyController.php
@@ -86,10 +86,11 @@ final class SymfonyController
         // limitation of Symfony's static API, not worsened here).
         if ($this->trustedHosts !== []) {
             $host = $this->extractHostForCache($this->symfonyRequest);
-            // When a trusted proxy forwards X-Forwarded-Host, getHost()
-            // validates a different value than the direct Host header used as
-            // the cache key, so skip the cache and reset on every request
-            // (still bounded, just without the cross-request memo benefit).
+            // When the request comes from a trusted proxy, getHost() may
+            // validate X-Forwarded-Host instead of the direct Host header
+            // used as the cache key, so skip the cache and reset on every
+            // request (still bounded, just without the cross-request memo
+            // benefit).
             $cacheable = !$this->symfonyRequest->isFromTrustedProxy();
 
             if (!$cacheable || !isset($this->validatedHosts[$host])) {
@@ -210,14 +211,8 @@ final class SymfonyController
      */
     private function extractHostForCache(SymfonyRequest $request): string
     {
-        $host = (string) $request->headers->get('HOST');
-        if ($host === '') {
-            $host = (string) $request->server->get('SERVER_NAME', '');
-        }
-        if ($host === '') {
-            $host = (string) $request->server->get('SERVER_ADDR', '');
-        }
+        $host = $request->headers->get('HOST') ?: $request->server->get('SERVER_NAME') ?: $request->server->get('SERVER_ADDR', '');
 
-        return \strtolower((string) \preg_replace('/:\d+$/', '', \trim($host)));
+        return \strtolower((string) \preg_replace('/:\d+$/', '', \trim((string) $host)));
     }
 }

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -1655,9 +1655,61 @@ final class SymfonyControllerTest extends TestCase
         $this->assertSame('example.com', $kernel->receivedRequest?->getHost());
     }
 
-    private function requestWithHost(string $host): Request
+    public function testTrustedProxySkipsCacheAndResetsEveryRequest(): void
     {
-        return new Request("GET /test HTTP/1.1\r\nHost: {$host}\r\n\r\n");
+        // When the request comes from a trusted proxy, getHost() validates
+        // the value of X-Forwarded-Host rather than the direct Host header
+        // used as the cache key. The controller must therefore skip the
+        // validated-host cache and keep calling setTrustedHosts() on every
+        // request — that reset is what keeps Symfony's internal list bounded
+        // (issue #560 constraint).
+        $kernel = new TestRequestTrackingKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^.+\.example\.com$'],
+        );
+
+        SymfonyRequest::setTrustedProxies(['127.0.0.1'], SymfonyRequest::HEADER_X_FORWARDED_HOST);
+        try {
+            // First request: host resolves from X-Forwarded-Host, not Host.
+            $response = $controller(
+                $this->requestWithHost('direct.example.com', 'x1.example.com'),
+                $this->connection,
+            );
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertSame('x1.example.com', $kernel->receivedRequest?->getHost());
+
+            // Second request with a different X-Forwarded-Host: the cache must
+            // be skipped again, so Symfony's internal list stays at one entry
+            // (reset on every request) instead of accumulating.
+            $response = $controller(
+                $this->requestWithHost('direct.example.com', 'x2.example.com'),
+                $this->connection,
+            );
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertSame('x2.example.com', $kernel->receivedRequest->getHost());
+        } finally {
+            SymfonyRequest::setTrustedProxies([], 0);
+        }
+
+        $this->assertSame(
+            1,
+            $this->trustedHostsCacheCount(),
+            'trusted-proxy path must reset the validated-host list on every request',
+        );
+        $this->assertSame([], $this->validatedHostsCache($controller), 'bundle cache must stay empty behind a trusted proxy');
+    }
+
+    private function requestWithHost(string $host, ?string $forwardedHost = null): Request
+    {
+        $buffer = "GET /test HTTP/1.1\r\nHost: {$host}\r\n";
+        if ($forwardedHost !== null) {
+            $buffer .= "X-Forwarded-Host: {$forwardedHost}\r\n";
+        }
+
+        return new Request($buffer . "\r\n");
     }
 
     /**

--- a/tests/SymfonyControllerTest.php
+++ b/tests/SymfonyControllerTest.php
@@ -1487,4 +1487,204 @@ final class SymfonyControllerTest extends TestCase
         // A second lifecycle call must be a no-op after the early return cleanup.
         $controller->terminateIfNeeded();
     }
+
+    public function testSetTrustedHostsIsNotCalledOnCacheHit(): void
+    {
+        // setTrustedHosts() must be skipped on a validated-host cache hit.
+        // The H1, H2, H1 sequence proves it: on the third request (H1, a cache
+        // hit) the reset is skipped, so Symfony's internal Request::$trustedHosts
+        // still holds H2 from request 2; getHost() does not find H1 in it,
+        // re-validates via the pattern, and appends H1 → 2 entries. With the
+        // old per-request reset, request 3 would wipe the list and re-add only
+        // H1 → 1 entry. Two entries prove the reset was skipped.
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^.+\\.test\\.local$'],
+        );
+
+        $this->assertSame(200, $controller($this->requestWithHost('h1.test.local'), $this->connection)->getStatusCode());
+        $this->assertSame(200, $controller($this->requestWithHost('h2.test.local'), $this->connection)->getStatusCode());
+        $this->assertSame(200, $controller($this->requestWithHost('h1.test.local'), $this->connection)->getStatusCode());
+
+        $this->assertSame(2, $this->trustedHostsCacheCount(), 'reset must be skipped on a cache hit');
+    }
+
+    public function testValidatedHostListStaysBoundedForManyDistinctHosts(): void
+    {
+        // Regression test for the unbounded memory leak this fix could
+        // introduce (issue #560): with a wildcard pattern, drive 10 000
+        // requests carrying distinct matching hosts. The naive fix (stop
+        // resetting without a bound) would let Symfony's internal
+        // Request::$trustedHosts grow to 10 000 entries. The bounded cache
+        // keeps it small — each cache miss resets it via setTrustedHosts().
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^.+\\.test\\.local$'],
+        );
+
+        $memoryBefore = \memory_get_usage();
+        for ($i = 1; $i <= 10000; ++$i) {
+            $controller($this->requestWithHost("h{$i}.test.local"), $this->connection);
+        }
+        $cacheCount = $this->trustedHostsCacheCount();
+        $memoryAfter = \memory_get_usage();
+
+        $this->assertLessThan(
+            128,
+            $cacheCount,
+            'Symfony Request::$trustedHosts must stay bounded, not grow towards 10000',
+        );
+        // Memory must not grow linearly with the number of distinct hosts.
+        // The bounded cache retains at most 64 host strings (~3 KB); the
+        // generous 1 MB ceiling catches an unbounded leak while tolerating
+        // PHP allocator noise.
+        $this->assertLessThan(
+            1024 * 1024,
+            $memoryAfter - $memoryBefore,
+            'Memory growth must be sublinear in the number of distinct hosts',
+        );
+    }
+
+    public function testHostResolutionStaysBoundedAfterManyDistinctHosts(): void
+    {
+        // Host resolution (the in_array fast path in Request::getHost()) must
+        // stay O(bound), not O(distinct hosts seen). After 10 000 distinct
+        // hosts, a repeat cached-host lookup must be as fast as after a
+        // handful — because Request::$trustedHosts is bounded by the cache.
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^.+\\.test\\.local$'],
+        );
+
+        // Warm the cache with a known host, then flood with 10 000 distinct hosts.
+        $controller($this->requestWithHost('cached.test.local'), $this->connection);
+        for ($i = 1; $i <= 10000; ++$i) {
+            $controller($this->requestWithHost("h{$i}.test.local"), $this->connection);
+        }
+
+        // The validated-host list is bounded, so a repeat request is O(bound).
+        $this->assertLessThan(128, $this->trustedHostsCacheCount());
+
+        $start = \hrtime(true);
+        for ($i = 0; $i < 1000; ++$i) {
+            $controller($this->requestWithHost('cached.test.local'), $this->connection);
+        }
+        $elapsedNs = \hrtime(true) - $start;
+
+        // 1000 repeat requests must complete in well under a second. With an
+        // unbounded 10 000-entry in_array scan the cost would be quadratic;
+        // the bounded cache keeps it flat.
+        $this->assertLessThan(
+            1_000_000_000,
+            $elapsedNs,
+            'Repeat-host resolution must stay bounded after 10 000 distinct hosts',
+        );
+    }
+
+    public function testEvictedHostIsStillValidatedOnLaterRequest(): void
+    {
+        // A host that was validated, then evicted from the bounded cache, must
+        // still be validated correctly on a later request (cache miss →
+        // setTrustedHosts reset → pattern re-match).
+        $kernel = new TestRequestTrackingKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^.+\\.test\\.local$'],
+        );
+
+        // Fill the cache (MAX_VALIDATED_HOSTS = 64) with distinct hosts.
+        for ($i = 1; $i <= 64; ++$i) {
+            $controller($this->requestWithHost("h{$i}.test.local"), $this->connection);
+        }
+        // The 65th distinct host evicts the oldest (h1) from the cache.
+        $controller($this->requestWithHost('h65.test.local'), $this->connection);
+
+        // h1 is now evicted — verify via the controller's private cache.
+        $this->assertNotContains('h1.test.local', $this->validatedHostsCache($controller));
+
+        // Re-request the evicted host: it is a cache miss, so setTrustedHosts()
+        // resets and getHost() re-validates via the pattern — must still pass.
+        $response = $controller($this->requestWithHost('h1.test.local'), $this->connection);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('h1.test.local', $kernel->receivedRequest?->getHost());
+    }
+
+    public function testTrustedHostsUnconfiguredDoesNotAccumulate(): void
+    {
+        // With trusted_hosts unconfigured, the controller must never call
+        // setTrustedHosts(), so neither patterns nor the validated-host cache
+        // accumulate — unchanged from before the fix.
+        $kernel = new TestNonTerminableKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController($kernel, $this->createResponseConverter());
+
+        for ($i = 1; $i <= 100; ++$i) {
+            $controller($this->requestWithHost("h{$i}.example.com"), $this->connection);
+        }
+
+        $this->assertSame([], SymfonyRequest::getTrustedHosts(), 'no patterns must be set');
+        $this->assertSame(0, $this->trustedHostsCacheCount(), 'validated-host cache must stay empty');
+    }
+
+    public function testTrustedHostsAcceptThenRejectThenAcceptAcrossRequests(): void
+    {
+        // Host rejection/acceptance must be unchanged across multiple sequential
+        // requests on the same controller instance: matching → 200, non-matching
+        // → 400, matching again → 200.
+        $kernel = new TestRequestTrackingKernel(new SymfonyResponse('OK'));
+        $controller = new SymfonyController(
+            $kernel,
+            $this->createResponseConverter(),
+            null,
+            ['^example\\.com$'],
+        );
+
+        $this->assertSame(200, $controller($this->requestWithHost('example.com'), $this->connection)->getStatusCode());
+        $this->assertSame(400, $controller($this->requestWithHost('attacker.com'), $this->connection)->getStatusCode());
+        $this->assertSame(200, $controller($this->requestWithHost('example.com'), $this->connection)->getStatusCode());
+        $this->assertSame('example.com', $kernel->receivedRequest?->getHost());
+    }
+
+    private function requestWithHost(string $host): Request
+    {
+        return new Request("GET /test HTTP/1.1\r\nHost: {$host}\r\n\r\n");
+    }
+
+    /**
+     * Read the size of Symfony's internal validated-host cache (Request::$trustedHosts).
+     *
+     * This protected static list is the one that grows without bound with the
+     * naive fix; getTrustedHosts() returns the patterns, not this cache, so
+     * reflection is the only way to observe it.
+     */
+    private function trustedHostsCacheCount(): int
+    {
+        $property = (new \ReflectionClass(SymfonyRequest::class))->getProperty('trustedHosts');
+        $value = $property->getValue();
+        \assert(\is_array($value));
+
+        return \count($value);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function validatedHostsCache(SymfonyController $controller): array
+    {
+        $property = (new \ReflectionClass(SymfonyController::class))->getProperty('validatedHosts');
+        $value = $property->getValue($controller);
+        \assert(\is_array($value));
+
+        return $value;
+    }
 }


### PR DESCRIPTION
## Description

Closes #560

`SymfonyController` called `Request::setTrustedHosts()` on every request when `trusted_hosts` was configured. That call wipes Symfony's internal `Request::$trustedHosts` memo — but (per the issue's constraint) that per-request reset was the *only* thing keeping the list bounded. With a wildcard trusted-host pattern, a remote client could grow it by one retained string per distinct matching host for the worker's lifetime, plus quadratic `in_array()` lookup cost.

The fix (Option 1 from the issue): a per-worker, bounded (64-entry) validated-host cache. `setTrustedHosts()` is now called only on a cache miss, so the reset still happens on a miss and bounds Symfony's internal list, while cache hits keep the memoization benefit in a long-lived worker.

## Changes

- `src/Middleware/SymfonyController.php`: `MAX_VALIDATED_HOSTS = 64` constant, `$validatedHosts` bounded FIFO cache, miss-only `setTrustedHosts()` call, `extractHostForCache()` helper mirroring `getHost()`'s host resolution; cache skipped behind a trusted proxy (X-Forwarded-Host path)
- `tests/SymfonyControllerTest.php`: 7 new tests — cache-hit skip, 10 000-distinct-host bounded growth (reflection on `Request::$trustedHosts`), repeat-host timing bound, eviction re-validation, unconfigured path, accept/reject/accept, trusted-proxy cache-skip path
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`
- `docs/helpers/decisions.md`: knowledge-base entry documenting the reset-on-miss strategy

## Changelog

`SymfonyController` no longer calls `Request::setTrustedHosts()` on every request when `trusted_hosts` is configured — it keeps a bounded (64-entry) validated-host cache and re-applies patterns only on a cache miss, keeping Symfony's internal list bounded in long-lived workers ([#560](https://github.com/crazy-goat/workerman-bundle/issues/560))

## Validation

- `composer lint` (php-cs-fixer, PHPStan level 8, rector): green
- `composer test`: 1746 tests, 13830 assertions, OK (29 pre-existing skips)
- Local unit run: 36 SymfonyControllerTest tests, 113 assertions, OK
- Coverage gate: not verifiable locally (no PCOV/Xdebug) — CI will check the 80% floor

## Code Review

- [x] Passed subagent code review (2 passes — 1 minor + 2 nits found and fixed)
- [x] All review comments addressed