### PR TITLE
feat(phar): add zip destination containment check to SfxDownloader (closes #587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SfxDownloader` now implements the zip-slip **destination-containment** check that `docs/security.md` already documented: entries are extracted one at a time, and each entry's resolved target must stay inside the destination directory. The deepest already-existing ancestor of each target is resolved with `realpath()` and checked against the resolved destination, so an entry such as `sub/evil.bin` cannot escape through a pre-existing symlink (`sub` → outside directory) planted inside the destination tree — an escape the name-level rules alone cannot see. Every extracted entry now passes both the name rules and the containment check, closing the gap where `listEntryNames()` validated one entry set while `extractTo()` extracted another; the docs additionally record that `ZipArchive::extractTo()` materialises symlink entries as regular files rather than creating links ([#587](https://github.com/crazy-goat/workerman-bundle/issues/587))
+
 - `SymfonyController` no longer calls `Request::setTrustedHosts()` on every
   request when `trusted_hosts` is configured. It now maintains a per-worker,
   bounded (64-entry) validated-host cache and re-applies the patterns only on a

--- a/docs/security.md
+++ b/docs/security.md
@@ -329,7 +329,9 @@ The `SfxDownloader` downloads and extracts `phpmicro.sfx` from upstream HTTPS mi
 - **Backslashes**: Entry names containing backslashes (`\`) are rejected.
 - **Absolute paths**: Entry names starting with `/` or a Windows drive letter (`C:\`) are rejected.
 - **Path traversal**: Entry names containing `..` segments after normalization are rejected.
-- **Destination containment**: Each entry is checked to ensure it resolves to a path inside the destination directory.
+- **Destination containment**: Entries are extracted one at a time, and every extracted entry's resolved target must stay inside the destination directory. The deepest already-existing ancestor of each target is resolved with `realpath()` and checked against the resolved destination, so an entry such as `sub/evil.bin` cannot escape through a pre-existing symlink (`sub` → outside directory) planted inside the destination tree — an escape the name-level rules alone cannot see. Every entry that is extracted passes both the name rules and the containment check.
+
+Note that `ZipArchive::extractTo()` materialises symlink entries as regular files rather than creating links, so an archive cannot plant a symlink at extraction time; the containment check guards the destination's pre-existing state instead.
 
 If any entry fails validation, the build aborts with a `\RuntimeException`.
 

--- a/src/Phar/SfxDownloader.php
+++ b/src/Phar/SfxDownloader.php
@@ -336,8 +336,11 @@ final readonly class SfxDownloader
      *
      * Stages:
      *  1. Open the zip archive with integrity checks.
-     *  2. List all entry names (validating each against zip-slip).
-     *  3. Extract all entries to the destination directory.
+     *  2. List all entry names (validating each against zip-slip) — a failing
+     *     entry aborts before anything is extracted (all-or-nothing).
+     *  3. Extract all entries to the destination directory, one at a time:
+     *     each entry is re-validated by name and its resolved target must
+     *     stay inside the destination directory (containment backstop).
      *  4. Locate the SFX entry:
      *     a. Try the entry whose basename matches the zip filename (minus .zip).
      *     b. Fall back to the first regular file entry from the archive.
@@ -402,14 +405,94 @@ final readonly class SfxDownloader
     }
 
     /**
-     * Extract all zip entries to the destination directory.
+     * Extract all zip entries to the destination directory, one entry at a time.
      *
-     * @throws \RuntimeException if extraction fails
+     * Every entry is checked immediately before it is extracted: the name
+     * rules from {@see validateEntryName()} are applied to exactly the
+     * entries that get extracted, and the resolved target must stay inside
+     * the destination directory (containment backstop). Note that
+     * ZipArchive::extractTo() materialises symlink entries as regular files
+     * rather than creating links — the containment check guards the
+     * destination's pre-existing state, which name rules alone cannot see.
+     *
+     * @throws \RuntimeException if the destination cannot be resolved, an
+     *                           entry fails validation, escapes the destination,
+     *                           or extraction fails
      */
     private function extractToDirectory(\ZipArchive $zip, string $zipPath, string $destinationDir): void
     {
-        if (!$zip->extractTo($destinationDir)) {
-            throw new \RuntimeException(sprintf('Failed to extract zip archive "%s" to "%s".', $zipPath, $destinationDir));
+        $resolvedDestination = realpath($destinationDir);
+        if ($resolvedDestination === false) {
+            throw new \RuntimeException(sprintf('Unable to resolve destination directory "%s".', $destinationDir));
+        }
+        $destinationBase = rtrim($resolvedDestination, '/\\');
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if (!is_string($name) || $name === '') {
+                throw new \RuntimeException(sprintf(
+                    'Zip archive "%s" contains an entry with an unreadable name (index %d); refusing to extract it.',
+                    $zipPath,
+                    $i,
+                ));
+            }
+
+            // Name-level zip-slip rules stay the first line of defence; they
+            // run here against exactly the entry being extracted.
+            $this->validateEntryName($name);
+
+            $this->assertEntryContainedIn($destinationBase, $name, $zipPath);
+
+            if (!$zip->extractTo($destinationDir, $name)) {
+                throw new \RuntimeException(sprintf(
+                    'Failed to extract entry "%s" from zip archive "%s".',
+                    $name,
+                    $zipPath,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Assert that an entry's target resolves inside the destination directory.
+     *
+     * The entry name has already passed {@see validateEntryName()}, so a
+     * lexical escape ("..", absolute path, drive letter, backslash) is not
+     * possible; this check is the containment backstop for escapes that
+     * lexical rules cannot see — most importantly a pre-existing symlink
+     * inside the destination tree (entry "sub/evil.bin" where "sub" is a
+     * symlink to a directory outside the destination). The deepest
+     * already-existing ancestor of the target is resolved with realpath()
+     * and must itself be inside the destination; the destination directory
+     * exists at this point, so the ancestor walk always terminates.
+     *
+     * @throws \RuntimeException if the entry resolves outside the destination
+     */
+    private function assertEntryContainedIn(string $destinationBase, string $entryName, string $zipPath): void
+    {
+        $target = $destinationBase . DIRECTORY_SEPARATOR . rtrim($entryName, '/');
+        $ancestor = $target;
+
+        do {
+            $resolved = realpath($ancestor);
+            if ($resolved !== false) {
+                $ancestor = $resolved;
+                break;
+            }
+            $parent = dirname($ancestor);
+            if ($parent === $ancestor) {
+                break;
+            }
+            $ancestor = $parent;
+        } while (true);
+
+        if (!str_starts_with($ancestor . DIRECTORY_SEPARATOR, $destinationBase . DIRECTORY_SEPARATOR)) {
+            throw new \RuntimeException(sprintf(
+                'Zip entry "%s" in archive "%s" resolves outside the destination directory "%s" and is rejected.',
+                $entryName,
+                $zipPath,
+                $destinationBase,
+            ));
         }
     }
 

--- a/tests/Phar/SfxDownloaderTest.php
+++ b/tests/Phar/SfxDownloaderTest.php
@@ -23,6 +23,9 @@ final class SfxDownloaderTest extends TestCase
 
     private string $tempDir;
 
+    /** @var list<string> Directories created outside $this->tempDir that tearDown() must remove */
+    private array $cleanupDirs = [];
+
     public static function setUpBeforeClass(): void
     {
         self::$serverPort = self::allocatePort();
@@ -51,6 +54,10 @@ final class SfxDownloaderTest extends TestCase
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->tempDir);
+        foreach ($this->cleanupDirs as $dir) {
+            $this->rmdirRecursive($dir);
+        }
+        $this->cleanupDirs = [];
     }
 
     private function rmdirRecursive(string $dir): void
@@ -67,13 +74,89 @@ final class SfxDownloaderTest extends TestCase
                 continue;
             }
             $path = $dir . '/' . $item;
-            if (is_dir($path)) {
+            if (is_link($path)) {
+                // Never follow a symlink into its target: the tree may
+                // contain links planted by the tests to outside directories.
+                unlink($path);
+            } elseif (is_dir($path)) {
                 $this->rmdirRecursive($path);
             } else {
                 unlink($path);
             }
         }
         rmdir($dir);
+    }
+
+    /**
+     * Create a zip archive containing a single symlink entry.
+     *
+     * ZipArchive has no API to mark an entry as a symlink, so the archive is
+     * assembled by hand: one STORED entry whose Unix external attributes
+     * carry the symlink mode (S_IFLNK | 0777) and whose content is the link
+     * target path.
+     */
+    private function createZipWithSymlinkEntry(string $zipPath, string $linkName, string $linkTarget): void
+    {
+        $name = $linkName;
+        $content = $linkTarget;
+        $crc = hexdec(hash('crc32b', $content));
+        $size = strlen($content);
+
+        // One STORED entry: local file header followed by the raw content at
+        // offset 0; the central directory points back to that header.
+        $localHeader = pack(
+            'VvvvvvVVVvv',
+            0x04034b50, // local file header signature
+            20,         // version needed to extract
+            0x0800,     // general purpose bit flags (UTF-8)
+            0,          // compression method: stored
+            0,          // last mod time
+            0,          // last mod date
+            $crc,
+            $size,      // compressed size
+            $size,      // uncompressed size
+            strlen($name),
+            0,          // extra field length
+        ) . $name;
+
+        // version made by: 0x031E (Unix, 3.0); symlink mode (S_IFLNK | 0777)
+        // lives in the upper 16 bits of the external attributes.
+        $externalAttrs = (0120000 | 0777) << 16;
+
+        $centralDirectory = pack(
+            'VvvvvvvVVVvvvvvVV',
+            0x02014b50,   // central directory signature
+            0x031E,       // version made by (Unix, 3.0)
+            20,           // version needed to extract
+            0x0800,       // general purpose bit flags (UTF-8)
+            0,            // compression method: stored
+            0,            // last mod time
+            0,            // last mod date
+            $crc,
+            $size,
+            $size,
+            strlen($name),
+            0,            // extra field length
+            0,            // file comment length
+            0,            // disk number start
+            0,            // internal attributes
+            $externalAttrs,
+            0,            // local header offset
+        ) . $name;
+
+        $endOfCentralDirectory = pack(
+            'VvvvvVVv',
+            0x06054b50,   // end of central directory signature
+            0,            // disk number
+            0,            // disk with central directory
+            1,            // entries on this disk
+            1,            // total entries
+            strlen($centralDirectory),
+            strlen($localHeader) + strlen($content), // central directory offset
+            0,            // comment length
+        );
+
+        file_put_contents($zipPath, $localHeader . $content . $centralDirectory . $endOfCentralDirectory);
     }
 
     /**
@@ -204,6 +287,61 @@ final class SfxDownloaderTest extends TestCase
             'https://example.invalid/phpmicro.sfx.zip',
             $this->tempDir,
         );
+    }
+
+    /**
+     * An entry that would resolve outside the destination directory via a
+     * pre-existing symlink inside the destination tree must be rejected: the
+     * name rules alone cannot see it (no "..", no absolute path), so the
+     * destination-containment backstop has to catch it.
+     *
+     * @requires extension zip
+     */
+    public function testExtractZipRejectsEntryEscapingViaSymlinkedSubdirectory(): void
+    {
+        $outside = sys_get_temp_dir() . '/sfx-outside-' . uniqid();
+        mkdir($outside, 0755, true);
+        $this->cleanupDirs[] = $outside;
+
+        if (!@symlink($outside, $this->tempDir . '/sub')) {
+            self::markTestSkipped('symlink() is not available on this platform.');
+        }
+
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithEntry($zipPath, [
+            'sub/evil.bin' => 'escaped-content',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('resolves outside the destination directory');
+
+        (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+    }
+
+    /**
+     * A crafted archive containing a symlink entry must not produce a symlink
+     * on disk: ZipArchive::extractTo() materialises link entries as regular
+     * files containing the link target, which the current extraction design
+     * depends on.
+     *
+     * @requires extension zip
+     */
+    public function testExtractZipDoesNotCreateSymlinkFromSymlinkEntry(): void
+    {
+        $zipPath = $this->tempDir . '/phpmicro.sfx.zip';
+        $this->createZipWithSymlinkEntry($zipPath, 'phpmicro.sfx', '../../outside/passwd');
+
+        $result = (new SfxDownloader())->fetch(
+            'https://example.invalid/phpmicro.sfx.zip',
+            $this->tempDir,
+        );
+
+        self::assertFileExists($result);
+        self::assertFalse(is_link($result), 'A symlink entry must not produce a symlink on disk.');
+        self::assertSame('../../outside/passwd', file_get_contents($result));
     }
 
     /**


### PR DESCRIPTION
## Description

Closes #587

docs/security.md claimed a zip **destination-containment** check that SfxDownloader did not implement. This PR implements it (the issue's recommended Option A) and makes the docs accurate.

## Changes

- `extractToDirectory()` now extracts entries **one at a time** through exactly the names that were validated — closing the validate-one-set / extract-another mismatch between `listEntryNames()` and the bulk `extractTo()`.
- New containment backstop: each entry's deepest already-existing ancestor is resolved with `realpath()` and must stay inside the resolved destination directory (the `StaticFilesMiddleware::getPublicPathFile()` idiom). This catches escapes the name rules alone cannot see — e.g. an entry `sub/evil.bin` where `sub` is a **pre-existing symlink** inside the destination tree pointing outside.
- `validateEntryName()` (backslashes, absolute paths, drive letters, `..`) stays the first line of defence; all-or-nothing validation before extraction is preserved.
- `docs/security.md` now describes the check accurately and records that `ZipArchive::extractTo()` materialises symlink entries as regular files (load-bearing for the design).
- Tests: crafted-archive rejection of a symlink-driven escape; a hand-built zip carrying a real symlink entry asserting no symlink lands on disk; all existing zip-slip rejection tests still pass.

## Changelog

`SfxDownloader` now implements the documented destination-containment zip-slip check (per-entry extraction + `realpath`-based containment backstop, closing the validate/extract set mismatch) (#587).

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed

## Validation

- `composer lint` (php-cs-fixer, phpstan, rector): OK
- `composer test`: 1748 tests, 13835 assertions, OK (29 pre-existing skips)