### PR TITLE
chore: add bin/gh-branch helper for issue branch creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New developer helper `bin/gh-branch`: creates or switches to the
+  `<type>/issue-<N>-<slug>` branch for a GitHub issue in one command — the
+  type (`fix`/`feat`/`docs`/…) is inferred from the issue's `[Type]` title
+  prefix or labels, the branch is created from the fresh remote default
+  branch, and the branch name is printed to stdout so it can be captured
+  (`branch=$(bin/gh-branch 491)`). Optional `--push`, `--dry-run` and
+  `--force` flags. Wired into `docs/workflow.md` (step 2) so that neither
+  humans nor LLMs have to invent branch names.
+
 ### Fixed
 
 - `SfxDownloader::fetch()` no longer leaves a failed-checksum artifact on disk: when SHA-256 verification of a downloaded artifact fails, the artifact is unlinked before the exception is rethrown, so the next `fetch()` re-downloads instead of re-verifying the same bad bytes forever. The same cleanup now applies to zip-extraction failures (corrupt archive, malicious entry, extraction error) — `extractZip()` failures unlink the archive and rethrow the original exception, and the checksum path mentions the removal when it succeeded so a retry is obviously safe ([#642](https://github.com/crazy-goat/workerman-bundle/issues/642))

--- a/bin/README.md
+++ b/bin/README.md
@@ -38,11 +38,12 @@ is below a threshold. Used by `composer coverage:check`.
 
 Creates or switches to the `<type>/issue-<N>-<slug>` branch for a GitHub issue,
 so the branch name never needs to be invented by hand or by an LLM (see
-`docs/workflow.md`, step 2). The type is inferred from issue labels
+`docs/workflow.md`, step 2). The type is inferred from a `[Type]` title prefix
+(`[Bug]`→`fix`, `[Feat]`→`feat`, `[Tests]`→`test`, …), then from issue labels
 (`bug`/`security`→`fix`, `enhancement`→`feat`, `documentation`→`docs`, …),
-then from a `[Type]` title prefix, and defaults to `fix`; an explicit type
-argument always wins. The branch is created from the **fresh** default remote
-branch (never from a stale local `master`).
+and defaults to `fix`; an explicit type argument always wins. The branch is
+created from the **fresh** default remote branch (never from a stale local
+`master`).
 
 **Usage:**
 ```bash

--- a/bin/README.md
+++ b/bin/README.md
@@ -34,6 +34,36 @@ git push --no-verify
 Parses a PHPUnit Clover XML file and exits non-zero when total line coverage
 is below a threshold. Used by `composer coverage:check`.
 
+### `gh-branch`
+
+Creates or switches to the `<type>/issue-<N>-<slug>` branch for a GitHub issue,
+so the branch name never needs to be invented by hand or by an LLM (see
+`docs/workflow.md`, step 2). The type is inferred from issue labels
+(`bug`/`security`→`fix`, `enhancement`→`feat`, `documentation`→`docs`, …),
+then from a `[Type]` title prefix, and defaults to `fix`; an explicit type
+argument always wins. The branch is created from the **fresh** default remote
+branch (never from a stale local `master`).
+
+**Usage:**
+```bash
+bin/gh-branch 491                 # create/switch to the issue branch
+bin/gh-branch 491 feat            # force type override
+bin/gh-branch 491 --push          # create + push with upstream
+bin/gh-branch 491 --dry-run       # print branch name only (no git mutation)
+bin/gh-branch 491 --force         # create despite dirty tree / non-default branch
+```
+
+Creation is refused on a dirty working tree or when not on the default
+branch — `--force` overrides (uncommitted changes are carried to the new
+branch, exactly as with `git switch -c`).
+
+Prints the branch name to stdout, so it can be captured
+(`branch=$(bin/gh-branch 491)`). All messages go to stderr.
+
+Requires the `gh` CLI (authenticated); GitHub-issue repos only — nothing
+Jira/decodo related. Exit codes: 0 = ok, 1 = environment/issue/dirty-tree
+error, 2 = usage error.
+
 ### `pick-issue.php`
 
 Ranks the open issues of the lowest open milestone and prints the top

--- a/bin/gh-branch
+++ b/bin/gh-branch
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# gh-branch — create or switch to <type>/issue-<N>-<slug> branch from a GitHub issue.
+# For GitHub-issue repos only (nothing Jira/decodo related). See docs/workflow.md step 2.
+#
+# Type is inferred from a [Type]-prefixed title, then from issue labels
+# (bug/security -> fix, enhancement -> feat, documentation -> docs, ...), and
+# defaults to fix. An explicit type argument always wins.
+#
+# Prints the branch name to stdout (last line) so it can be captured:
+#     branch=$(bin/gh-branch 491)
+
+set -euo pipefail
+
+TYPES="fix feat docs perf refactor chore test build ci"
+
+usage() {
+  cat <<EOF
+usage: gh-branch <ISSUE-NUMBER> [TYPE] [--push] [--dry-run]
+
+Create or switch to <TYPE>/issue-<N>-<slug>, based on the default remote branch.
+
+  TYPE        optional; inferred from labels, then [Type] title prefix; default fix
+              allowed: $TYPES
+  --push      also push with upstream
+  --dry-run   print the branch name without touching git
+  --force     create even with a dirty tree or when not on the default branch
+
+Prints the branch name to stdout, all messages to stderr.
+EOF
+}
+
+die() {
+  echo "gh-branch: $*" >&2
+  exit 1
+}
+
+# --- parse arguments ---
+NUMBER=""
+TYPE=""
+TYPE_ARG_SET=""
+PUSH=0
+DRY=0
+FORCE=0
+
+for arg in "$@"; do
+  a="${arg#\#}"
+  if [[ "$a" =~ ^[0-9]+$ ]]; then
+    NUMBER="$a"
+  elif [[ " $TYPES " == *" $arg "* ]]; then
+    TYPE="$arg"
+    TYPE_ARG_SET=1
+  elif [[ "$arg" == "--push" ]]; then
+    PUSH=1
+  elif [[ "$arg" == "--dry-run" ]]; then
+    DRY=1
+  elif [[ "$arg" == "--force" ]]; then
+    FORCE=1
+  elif [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+    usage
+    exit 0
+  else
+    die "unknown argument: $arg"$'\n'"$(usage)"
+  fi
+done
+
+[[ -n "$NUMBER" ]] || die "missing issue number"$'\n'"$(usage)"
+
+# --- environment checks ---
+command -v gh >/dev/null 2>&1 || die "'gh' CLI not found (brew install gh, then gh auth login)"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
+gh repo view >/dev/null 2>&1 || die "not a GitHub repository (or gh not authenticated — check 'gh auth status')"
+
+# --- fetch issue ---
+title=$(gh issue view "$NUMBER" --json title -q .title) \
+  || die "cannot fetch issue #$NUMBER — wrong number?"
+state=$(gh issue view "$NUMBER" --json state -q .state)
+labels=$(gh issue view "$NUMBER" --json labels -q '[.labels[].name] | join(",")')
+
+[[ "$state" != "OPEN" ]] && echo "gh-branch: warning: issue #$NUMBER is $state (not OPEN)" >&2
+
+# --- infer type: explicit arg > title prefix > labels > fix ---
+SOURCE="default"
+if [[ -z "$TYPE" ]]; then
+  case "$title" in
+    "[Bug]"*|"[Security]"*)        TYPE=fix ;;
+    "[Feat]"*|"[Feature]"*)        TYPE=feat ;;
+    "[Doc]"*|"[Docs]"*)            TYPE=docs ;;
+    "[Perf]"*|"[Performance]"*)    TYPE=perf ;;
+    "[Refactor]"*)                 TYPE=refactor ;;
+    "[Chore]"*)                    TYPE=chore ;;
+    "[Test]"*|"[Tests]"*)          TYPE=test ;;
+  esac
+  [[ -n "$TYPE" ]] && SOURCE="title prefix"
+fi
+if [[ -z "$TYPE" ]]; then
+  case ",$labels," in
+    *,bug,*)                  TYPE=fix ;;
+    *,security,*)             TYPE=fix ;;
+    *,enhancement,*)          TYPE=feat ;;
+    *,documentation,*)        TYPE=docs ;;
+    *,technical-debt,*|*,code-quality,*) TYPE=refactor ;;
+    *,performance,*)          TYPE=perf ;;
+    *,php82,*)                TYPE=chore ;;
+  esac
+  [[ -n "$TYPE" ]] && SOURCE="labels"
+fi
+TYPE="${TYPE:-fix}"
+[[ -n "$TYPE_ARG_SET" ]] && SOURCE="explicit"
+
+# --- slugify title: strip [Type] prefix, lowercase, keep [a-z0-9-], max 40 ---
+slug=$(printf '%s' "$title" \
+  | sed -E 's/^\[[^]]*\][[:space:]]*//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+  | cut -c1-40 \
+  | sed -E 's/-+$//')
+
+branch="$TYPE/issue-$NUMBER"
+[[ -n "$slug" ]] && branch="$branch-$slug"
+
+if (( ${#branch} > 100 )); then
+  die "branch name too long (${#branch} chars): $branch"
+fi
+
+echo "gh-branch: issue #$NUMBER ($state): $title" >&2
+echo "gh-branch: branch: $branch (type from ${SOURCE:-default})" >&2
+
+if [[ "$DRY" == 1 ]]; then
+  printf '%s\n' "$branch"
+  exit 0
+fi
+
+# --- switch to existing / create from fresh origin default ---
+current=$(git symbolic-ref --short -q HEAD 2>/dev/null || true)
+if [[ "$current" == "$branch" ]]; then
+  echo "gh-branch: already on $branch" >&2
+elif git show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "gh-branch: switching to existing local branch" >&2
+  git switch "$branch"
+elif git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  echo "gh-branch: fetching existing remote branch" >&2
+  git fetch origin "$branch"
+  git switch "$branch"
+else
+  if [[ -n "$(git status --porcelain)" ]] && [[ "$FORCE" != 1 ]]; then
+    die "working tree is dirty — commit or stash first (or use --force)"
+  fi
+  default=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+  if [[ -n "$current" && "$current" != "$default" ]] && [[ "$FORCE" != 1 ]]; then
+    die "on branch '$current', not on the default branch '$default' — switch first (or use --force)"
+  fi
+  echo "gh-branch: creating $branch from origin/$default" >&2
+  git fetch origin "$default"
+  git switch -c "$branch" "origin/$default"
+fi
+
+if [[ "$PUSH" == 1 ]]; then
+  git push -u origin "$branch"
+  echo "gh-branch: pushed with upstream" >&2
+fi
+
+printf '%s\n' "$branch"

--- a/bin/gh-branch
+++ b/bin/gh-branch
@@ -16,7 +16,7 @@ TYPES="fix feat docs perf refactor chore test build ci"
 
 usage() {
   cat <<EOF
-usage: gh-branch <ISSUE-NUMBER> [TYPE] [--push] [--dry-run]
+usage: gh-branch <ISSUE-NUMBER> [TYPE] [--push] [--dry-run] [--force]
 
 Create or switch to <TYPE>/issue-<N>-<slug>, based on the default remote branch.
 
@@ -33,6 +33,12 @@ EOF
 die() {
   echo "gh-branch: $*" >&2
   exit 1
+}
+
+die_usage() {
+  echo "gh-branch: $*" >&2
+  usage >&2
+  exit 2
 }
 
 # --- parse arguments ---
@@ -60,22 +66,25 @@ for arg in "$@"; do
     usage
     exit 0
   else
-    die "unknown argument: $arg"$'\n'"$(usage)"
+    die_usage "unknown argument: $arg"
   fi
 done
 
-[[ -n "$NUMBER" ]] || die "missing issue number"$'\n'"$(usage)"
+[[ -n "$NUMBER" ]] || die_usage "missing issue number"
 
 # --- environment checks ---
 command -v gh >/dev/null 2>&1 || die "'gh' CLI not found (brew install gh, then gh auth login)"
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
 gh repo view >/dev/null 2>&1 || die "not a GitHub repository (or gh not authenticated — check 'gh auth status')"
 
-# --- fetch issue ---
-title=$(gh issue view "$NUMBER" --json title -q .title) \
-  || die "cannot fetch issue #$NUMBER — wrong number?"
-state=$(gh issue view "$NUMBER" --json state -q .state)
-labels=$(gh issue view "$NUMBER" --json labels -q '[.labels[].name] | join(",")')
+# --- fetch issue (single call; @tsv escapes tabs/newlines in values) ---
+IFS=$'\t' read -r title state labels < <(
+  gh issue view "$NUMBER" --json title,state,labels -q '[.title, .state, ([.labels[].name] | join(","))] | @tsv'
+) || die "cannot fetch issue #$NUMBER — wrong number?"
+
+if [[ "$DRY" == 1 && "$PUSH" == 1 ]]; then
+  echo "gh-branch: warning: --push ignored with --dry-run" >&2
+fi
 
 [[ "$state" != "OPEN" ]] && echo "gh-branch: warning: issue #$NUMBER is $state (not OPEN)" >&2
 

--- a/bin/gh-branch
+++ b/bin/gh-branch
@@ -20,7 +20,7 @@ usage: gh-branch <ISSUE-NUMBER> [TYPE] [--push] [--dry-run] [--force]
 
 Create or switch to <TYPE>/issue-<N>-<slug>, based on the default remote branch.
 
-  TYPE        optional; inferred from labels, then [Type] title prefix; default fix
+  TYPE        optional; inferred from [Type] title prefix, then labels; default fix
               allowed: $TYPES
   --push      also push with upstream
   --dry-run   print the branch name without touching git

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,8 +14,8 @@ comments, related code). Delegate it to a subagent with its own context.
 ```bash
 # The subagent receives a task like:
 # "List the top 5 most impactful open issues in crazy-goat/workerman-bundle.
-#  For each, return: number, title, labels, one-paragraph rationale,
-#  and a recommended branch name (feat/issue-<N>-<kebab> or fix/issue-<N>-<kebab>).
+#  For each, return: number, title, labels, one-paragraph rationale.
+#  Do NOT propose branch names — bin/gh-branch derives them in step 2.
 #  Prioritize: enhancement, code-quality, good-first-issue,
 #  stability/data-correctness/performance, blockers, user-facing (README/API docs)."
 ```
@@ -86,17 +86,29 @@ a higher milestone.
 
 ## 2. Create a Fresh Feature Branch
 
-```bash
-# Make sure you're on master with the latest changes
-git checkout master
-git pull origin master
+Run the helper — the branch name is derived from the issue, nobody (human or
+LLM) has to invent it:
 
-# Create a feature branch
-git checkout -b feat/issue-<NUMBER>-<short-description>
+```bash
+bin/gh-branch <NUMBER>             # creates/switches to <type>/issue-<N>-<slug>
+bin/gh-branch <NUMBER> feat        # force type (fix|feat|docs|perf|refactor|chore|test|build|ci)
+bin/gh-branch <NUMBER> --push      # also push with upstream
+branch=$(bin/gh-branch <NUMBER>)   # capture the name (printed to stdout) for later steps
 ```
 
-**Branch naming convention:** `feat/issue-<NUMBER>-<kebab-case>`
-or `fix/issue-<NUMBER>-<kebab-case>` (e.g. `feat/issue-491-update-readme`)
+The `fix`/`feat`/… type is inferred from issue labels (`bug`/`security`→`fix`,
+`enhancement`→`feat`, `documentation`→`docs`, …), falling back to a
+`[Type]`-prefixed title, and finally to `fix`. The branch is created from the
+fresh remote default branch, so no manual fetch/pull is needed. If the branch
+already exists (locally or on origin) it switches to it instead; a dirty
+working tree or being on a non-default branch aborts **creation** — use
+`--force` to proceed anyway (uncommitted changes are then carried to the new
+branch, exactly as with `git switch -c`). Use `--dry-run` to see the name
+without touching git.
+
+**Branch naming convention:** `fix/issue-<NUMBER>-<kebab-case>`
+or `feat/issue-<NUMBER>-<kebab-case>` (e.g. `feat/issue-491-update-readme`) —
+the script produces exactly this shape.
 
 Existing examples in this repository:
 - `feature/295-servermanager-magic-timeout-constants`
@@ -469,9 +481,9 @@ extend `docs/troubleshooting.md` or ask the user before adding a new entry.
 #    php bin/pick-issue.php --milestone=0.7.0 --top=5 --json
 #    alternative: delegate full triage to a subagent ("List top 5 impactful\u2026")
 
-# 2. Feature branch
-git checkout master && git pull origin master
-git checkout -b feat/issue-<NUMBER>-<description>
+# 2. Feature branch — name derived by the helper (type from labels/prefix)
+bin/gh-branch <NUMBER>            # e.g. fix/issue-491-update-readme
+branch=$(bin/gh-branch <NUMBER>)  # capture name for the subagent task below
 
 # 3. Implementation (worker/coder subagent)
 #    subagent: "Implement issue #<NUMBER>..."

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -96,9 +96,10 @@ bin/gh-branch <NUMBER> --push      # also push with upstream
 branch=$(bin/gh-branch <NUMBER>)   # capture the name (printed to stdout) for later steps
 ```
 
-The `fix`/`feat`/… type is inferred from issue labels (`bug`/`security`→`fix`,
-`enhancement`→`feat`, `documentation`→`docs`, …), falling back to a
-`[Type]`-prefixed title, and finally to `fix`. The branch is created from the
+The `fix`/`feat`/… type is inferred from a `[Type]` title prefix
+(`[Bug]`→`fix`, `[Feat]`→`feat`, `[Tests]`→`test`, …), falling back to issue
+labels (`bug`/`security`→`fix`, `enhancement`→`feat`, `documentation`→`docs`,
+…), and finally to `fix`. The branch is created from the
 fresh remote default branch, so no manual fetch/pull is needed. If the branch
 already exists (locally or on origin) it switches to it instead; a dirty
 working tree or being on a non-default branch aborts **creation** — use


### PR DESCRIPTION
## Description

Adds `bin/gh-branch` — a small bash helper that creates/switches to the
`<type>/issue-<N>-<slug>` branch for a GitHub issue in one command, so
neither humans nor LLMs have to invent branch names. Pure GitHub-issue repos;
nothing Jira/decodo related (that stays with `decodo jira start-task`).

## Changes

- `bin/gh-branch`: type inferred from `[Type]` title prefix → labels → `fix`
  (explicit argument wins); slug sanitised to `[a-z0-9-]` (max 40 chars);
  branch created from the **fresh** remote default branch; switches to
  existing branch if present (local or remote); refuses on dirty tree or
  non-default branch unless `--force`; `--push` / `--dry-run` flags;
  branch name on stdout for scripting; exit codes 0/1/2
- `docs/workflow.md`: step 1 triage subagent no longer proposes branch
  names, step 2 uses the helper, quick reference updated
- `bin/README.md`: gh-branch documented
- `CHANGELOG.md`: entry under [Unreleased] → Added

## Changelog

Added: `bin/gh-branch` developer helper for automated issue branch creation
(type from title prefix/labels, fresh origin base, stdout name); wired into
`docs/workflow.md` step 2.

## Code Review

- [x] Passed subagent code review
- [x] All review comments addressed (2 rounds: blockers fixed, second round clean)

## Validation

Script verified end-to-end in throwaway repos (create/switch/force/dry-run,
dirty-tree guards, exit codes); `bash -n` passes; review round 2 confirmed no
regressions across 12 mocked scenarios. PHP lints/tests not run — no PHP
code touched by this change.