### PR TITLE
docs: note COMPOSER_PROCESS_TIMEOUT workaround for slow test runs

### DIFF
--- a/docs/helpers/faq.md
+++ b/docs/helpers/faq.md
@@ -103,6 +103,11 @@ runs PHPUnit, then stops the daemon. Phpunit itself is run with
 `php -d phar.readonly=0`. If tests were interrupted, stop the daemon
 manually as above.
 
+Composer runs `test` scripts with a 300 s process timeout; on slow hosts
+(notably grpc/macOS, see the grpc section above) PHPUnit can be killed
+mid-run. Raise it with `COMPOSER_PROCESS_TIMEOUT=1800 composer test` or
+set `config.process-timeout` in `composer.json`.
+
 ### CI enforces an 80% line-coverage floor
 
 Defined once in `composer.json` (`coverage:check` →


### PR DESCRIPTION
## Description

Follow-up to #675's findings: on slow hosts (notably grpc/macOS, #651) Composer's 300s process-timeout can kill `composer test` mid-run, which then leaves PHPUnit aborted and the daemon running.

## Changes

- `docs/helpers/faq.md`: `How the test suite works` section now documents `COMPOSER_PROCESS_TIMEOUT=1800 composer test` (or `config.process-timeout`).

## Changelog

Docs only — no changelog entry.

## Code Review

- [x] Docs-only change, verified by read-only subagent (finding was real + untracked)